### PR TITLE
Revert "feat: implement Algolia ETag support"

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -9,11 +9,10 @@ All compilation blockers have been resolved. The project builds successfully.
 - Fixed `R` class generation by using `androidx.appcompat.R.attr`.
 - Fixed Kotlin and Java compilation errors.
 - Provisioned JDK 21.
-- **Migrate to RxJava 3**: Successfully migrated from EOL RxJava 1.3.8 to RxJava 3.1.8.
 
 ## Future Work
 
 ### Tech Debt & Modernization
-- **Implement Algolia ETag Support**:
-  - **Reason**: `TODO` found in codebase. Improves network efficiency.
-  - **Context**: Started in `feature/algolia-etag`.
+- **Migrate to RxJava 3**:
+  - **Reason**: Current codebase uses RxJava 1.3.8 (EOL). Reviewers strongly recommended upgrading to RxJava 3.
+  - **Context**: This was deferred from the Dagger 2 migration PR (#13) to avoid excessive scope creep and complexity, as RxJava 3 introduces significant breaking changes (e.g., `Flowable`, null-safety) that should be handled in isolation.

--- a/app/src/main/java/io/github/hidroh/materialistic/data/AlgoliaPopularClient.java
+++ b/app/src/main/java/io/github/hidroh/materialistic/data/AlgoliaPopularClient.java
@@ -66,30 +66,14 @@ public class AlgoliaPopularClient extends AlgoliaClient {
     public static final String PAST_MONTH = "past_month";
     public static final String PAST_YEAR = "past_year";
 
-    /**
-     * Searches for popular stories using Algolia's numeric filters.
-     *
-     * @param filter the {@link Range} filter to apply
-     * @return an {@link Observable} that emits the search results
-     */
     @Override
     protected Observable<AlgoliaHits> searchRx(@Range String filter) {
-        return mRestService.searchByMinTimestampRx(getNumericFilter(filter), null);
+        return mRestService.searchByMinTimestampRx(MIN_CREATED_AT + toTimestamp(filter) / 1000);
     }
 
-    /**
-     * Searches for popular stories using Algolia's numeric filters.
-     *
-     * @param filter the {@link Range} filter to apply
-     * @return a {@link Call} that can be used to execute the search
-     */
     @Override
     protected Call<AlgoliaHits> search(@Range String filter) {
-        return mRestService.searchByMinTimestamp(getNumericFilter(filter), null);
-    }
-
-    private String getNumericFilter(@Range String filter) {
-        return MIN_CREATED_AT + toTimestamp(filter) / 1000;
+        return mRestService.searchByMinTimestamp(MIN_CREATED_AT + toTimestamp(filter) / 1000);
     }
 
     private long toTimestamp(@Range String filter) {


### PR DESCRIPTION
### **User description**
Reverts sheepdestroyer/materialistic#25


___

### **PR Type**
Bug fix


___

### **Description**
- Removes ETag header support from Algolia API calls

- Simplifies RestService interface by removing nullable etag parameters

- Removes ETag-related imports and documentation

- Adds TODO comment for future ETag implementation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["AlgoliaClient RestService"] -->|Remove ETag header parameter| B["Simplified API methods"]
  C["AlgoliaPopularClient"] -->|Remove null etag argument| D["Direct numeric filter calls"]
  E["Imports & Documentation"] -->|Remove ETag references| F["Cleaner codebase"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AlgoliaClient.java</strong><dd><code>Remove ETag header support from Algolia client</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/src/main/java/io/github/hidroh/materialistic/data/AlgoliaClient.java

<ul><li>Removes <code>@Header</code> import and <code>@Nullable</code> annotation imports<br> <li> Removes <code>HEADER_IF_NONE_MATCH</code> constant and ETag-related documentation<br> <li> Simplifies all RestService method signatures by removing <code>@Header</code> etag <br>parameters<br> <li> Updates method calls to remove <code>null</code> etag arguments<br> <li> Adds TODO comment for future ETag header implementation</ul>


</details>


  </td>
  <td><a href="https://github.com/sheepdestroyer/materialistic/pull/26/files#diff-ef47d8dcb1c3740fa80b3a775bf6022ce0d0c4513efc8633901a25e57a6df984">+14/-82</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AlgoliaPopularClient.java</strong><dd><code>Simplify popular client search methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/src/main/java/io/github/hidroh/materialistic/data/AlgoliaPopularClient.java

<ul><li>Removes documentation for searchRx and search methods<br> <li> Removes <code>null</code> etag argument from RestService method calls<br> <li> Removes private <code>getNumericFilter()</code> helper method<br> <li> Inlines numeric filter calculation directly in method implementations</ul>


</details>


  </td>
  <td><a href="https://github.com/sheepdestroyer/materialistic/pull/26/files#diff-91e1a142275f5863cc7b2077017ac92e4fac2888e65a80a435b5543b550b6d8d">+2/-18</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TODO.md</strong><dd><code>Update TODO documentation with migration status</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

TODO.md

<ul><li>Removes completed RxJava 3 migration from completed work section<br> <li> Removes Algolia ETag support from future work section<br> <li> Moves RxJava 3 migration to future work with updated context and <br>rationale</ul>


</details>


  </td>
  <td><a href="https://github.com/sheepdestroyer/materialistic/pull/26/files#diff-5c6a1301c6b59b30a040d747d065e861d3dd98bde0e5a4356d92d594e9835986">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project roadmap with revised dependency upgrade strategies and removal of unsupported framework features.

* **Refactor**
  * Streamlined API request handling by removing ETag header support, reducing complexity.
  * Optimized internal filter computation and removed redundant helper code.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->