### PR TITLE
chore: untrack agent-tools from git

### DIFF
--- a/agent-tools
+++ b/agent-tools
@@ -1,1 +1,0 @@
-../agent-tools


### PR DESCRIPTION
Removes agent-tools from git tracking while preserving local files. This prevents local agent scratchpad files from accidentally being committed.

## Summary by Sourcery

Chores:
- Remove agent-tools from the repository so local scratchpad files are no longer tracked by git.