### PR TITLE
chore: untrack agent-tools from git

### DIFF
--- a/agent-tools
+++ b/agent-tools
@@ -1,1 +1,0 @@
-../agent-tools


### PR DESCRIPTION
Removes agent-tools from git tracking while preserving local files. This prevents local agent scratchpad files from accidentally being committed.

## Summary by Sourcery

Chores:
- Stop tracking the agent-tools directory so that local scratchpad files are no longer committed to version control.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes `agent-tools` from git tracking to prevent accidental commits of local scratchpad files.
> 
>   - **Version Control**:
>     - Removes `agent-tools` from git tracking to prevent accidental commits of local scratchpad files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sheepdestroyer%2Fmaterialistic&utm_source=github&utm_medium=referral)<sup> for 026ee066461d992f4d86d9b67e5a751081b34ebe. You can [customize](https://app.ellipsis.dev/sheepdestroyer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused agent-tools module reference from the codebase.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->