### PR TITLE
⚡ Bolt: Fix SpannableString leak in HackerNewsItem

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-24 - [Performance Leak in SpannableString]
+**Learning:** `SpannableString` retains spans added via `setSpan`. If a method adds a span (like `ForegroundColorSpan`) every time it's called (e.g., in a RecyclerView `onBindViewHolder`), and the `SpannableString` instance is cached/reused, the number of spans will grow indefinitely, causing a memory leak and rendering performance degradation.
+**Action:** When caching `SpannableString`s that are modified dynamically, always remove existing spans of the same type before adding a new one, or check if the span already exists.

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/data/HackerNewsItem.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/data/HackerNewsItem.java
@@ -286,6 +286,11 @@ class HackerNewsItem implements Item {
         if (displayedAuthor.length() == 0) {
             return displayedAuthor;
         }
+        // Remove existing ForegroundColorSpan to prevent accumulation
+        Object[] spans = displayedAuthor.getSpans(0, displayedAuthor.length(), ForegroundColorSpan.class);
+        for (Object span : spans) {
+            displayedAuthor.removeSpan(span);
+        }
         displayedAuthor.setSpan(new ForegroundColorSpan(color != 0 ? color : defaultColor),
                 AUTHOR_SEPARATOR.length(), displayedAuthor.length(),
                 Spanned.SPAN_INCLUSIVE_EXCLUSIVE);

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/data/HackerNewsItem.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/data/HackerNewsItem.java
@@ -21,10 +21,6 @@ import android.content.Intent;
 import android.graphics.Typeface;
 import android.net.Uri;
 import android.os.Parcel;
-import androidx.annotation.Keep;
-import androidx.annotation.NonNull;
-import androidx.annotation.VisibleForTesting;
-import androidx.core.content.ContextCompat;
 import android.text.Spannable;
 import android.text.SpannableString;
 import android.text.SpannableStringBuilder;
@@ -36,553 +32,570 @@ import android.text.style.ForegroundColorSpan;
 import android.text.style.StrikethroughSpan;
 import android.text.style.StyleSpan;
 import android.view.View;
-
+import androidx.annotation.Keep;
+import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
+import androidx.core.content.ContextCompat;
 import io.github.sheepdestroyer.materialisheep.AppUtils;
 import io.github.sheepdestroyer.materialisheep.Navigable;
 import io.github.sheepdestroyer.materialisheep.R;
 import io.github.sheepdestroyer.materialisheep.annotation.Synthetic;
 
-/**
- * A data model for a Hacker News item.
- */
+/** A data model for a Hacker News item. */
 class HackerNewsItem implements Item {
-    private static final String AUTHOR_SEPARATOR = " - ";
+  private static final String AUTHOR_SEPARATOR = " - ";
 
-    // The item's unique id. Required.
-    @Keep private long id;
-    // true if the item is deleted.
-    @Keep private boolean deleted;
-    // The type of item. One of "job", "story", "comment", "poll", or "pollopt".
-    @Keep private String type;
-    // The username of the item's author.
-    @Keep private String by;
-    // Creation date of the item, in Unix Time.
-    @Keep private long time;
-    // The comment, Ask HN, or poll text. HTML.
-    @Keep private String text;
-    // true if the item is dead.
-    @Keep private boolean dead;
-    // The item's parent. For comments, either another comment or the relevant story. For pollopts, the relevant poll.
-    @Keep private long parent;
-    // The ids of the item's comments, in ranked display order.
-    @Keep private long[] kids;
-    // The URL of the story.
-    @Keep private String url;
-    // The story's score, or the votes for a pollopt.
-    @Keep private int score;
-    // The title of the story or poll.
-    @Keep private String title;
-    // A list of related pollopts, in display order.
-    @SuppressWarnings("unused")
-    @Keep private long[] parts;
-    // In the case of stories or polls, the total comment count.
-    @Keep private int descendants = -1;
+  // The item's unique id. Required.
+  @Keep private long id;
+  // true if the item is deleted.
+  @Keep private boolean deleted;
+  // The type of item. One of "job", "story", "comment", "poll", or "pollopt".
+  @Keep private String type;
+  // The username of the item's author.
+  @Keep private String by;
+  // Creation date of the item, in Unix Time.
+  @Keep private long time;
+  // The comment, Ask HN, or poll text. HTML.
+  @Keep private String text;
+  // true if the item is dead.
+  @Keep private boolean dead;
+  // The item's parent. For comments, either another comment or the relevant story. For pollopts,
+  // the relevant poll.
+  @Keep private long parent;
+  // The ids of the item's comments, in ranked display order.
+  @Keep private long[] kids;
+  // The URL of the story.
+  @Keep private String url;
+  // The story's score, or the votes for a pollopt.
+  @Keep private int score;
+  // The title of the story or poll.
+  @Keep private String title;
 
-    // view state
-    private boolean favorite;
-    private boolean viewed;
-    private int localRevision = -1;
-    @VisibleForTesting int level = 0;
-    private boolean collapsed;
-    private boolean contentExpanded;
-    int rank;
-    private int lastKidCount = -1;
-    private boolean hasNewDescendants = false;
-    private boolean voted;
-    private boolean pendingVoted;
-    private long next, previous;
+  // A list of related pollopts, in display order.
+  @SuppressWarnings("unused")
+  @Keep
+  private long[] parts;
 
-    // non parcelable fields
-    private HackerNewsItem[] kidItems;
-    private HackerNewsItem parentItem;
-    private Spannable displayedTime;
-    private Spannable displayedAuthor;
-    private CharSequence displayedText;
-    private int defaultColor;
+  // In the case of stories or polls, the total comment count.
+  @Keep private int descendants = -1;
 
-    /**
-     * A {@link Creator} that creates {@link HackerNewsItem} instances from a {@link Parcel}.
-     */
-    public static final Creator<HackerNewsItem> CREATOR = new Creator<HackerNewsItem>() {
+  // view state
+  private boolean favorite;
+  private boolean viewed;
+  private int localRevision = -1;
+  @VisibleForTesting int level = 0;
+  private boolean collapsed;
+  private boolean contentExpanded;
+  int rank;
+  private int lastKidCount = -1;
+  private boolean hasNewDescendants = false;
+  private boolean voted;
+  private boolean pendingVoted;
+  private long next, previous;
+
+  // non parcelable fields
+  private HackerNewsItem[] kidItems;
+  private HackerNewsItem parentItem;
+  private Spannable displayedTime;
+  private Spannable displayedAuthor;
+  private CharSequence displayedText;
+  private int defaultColor;
+
+  /** A {@link Creator} that creates {@link HackerNewsItem} instances from a {@link Parcel}. */
+  public static final Creator<HackerNewsItem> CREATOR =
+      new Creator<HackerNewsItem>() {
         @Override
         public HackerNewsItem createFromParcel(Parcel source) {
-            return new HackerNewsItem(source);
+          return new HackerNewsItem(source);
         }
 
         @Override
         public HackerNewsItem[] newArray(int size) {
-            return new HackerNewsItem[size];
+          return new HackerNewsItem[size];
         }
-    };
+      };
 
-    HackerNewsItem(long id) {
-        this.id = id;
-    }
+  HackerNewsItem(long id) {
+    this.id = id;
+  }
 
-    private HackerNewsItem(long id, int level) {
-        this(id);
-        this.level = level;
-    }
+  private HackerNewsItem(long id, int level) {
+    this(id);
+    this.level = level;
+  }
 
-    @Synthetic
-    HackerNewsItem(Parcel source) {
-        id = source.readLong();
-        title = source.readString();
-        time = source.readLong();
-        by = source.readString();
-        kids = source.createLongArray();
-        url = source.readString();
-        text = source.readString();
-        type = source.readString();
-        favorite = source.readInt() != 0;
-        descendants = source.readInt();
-        score = source.readInt();
-        favorite = source.readInt() == 1;
-        viewed = source.readInt() == 1;
-        localRevision = source.readInt();
-        level = source.readInt();
-        dead = source.readInt() == 1;
-        deleted = source.readInt() == 1;
-        collapsed = source.readInt() == 1;
-        contentExpanded = source.readInt() == 1;
-        rank = source.readInt();
-        lastKidCount = source.readInt();
-        hasNewDescendants = source.readInt() == 1;
-        parent = source.readLong();
-        voted = source.readInt() == 1;
-        pendingVoted = source.readInt() == 1;
-        next = source.readLong();
-        previous = source.readLong();
-    }
+  @Synthetic
+  HackerNewsItem(Parcel source) {
+    id = source.readLong();
+    title = source.readString();
+    time = source.readLong();
+    by = source.readString();
+    kids = source.createLongArray();
+    url = source.readString();
+    text = source.readString();
+    type = source.readString();
+    favorite = source.readInt() != 0;
+    descendants = source.readInt();
+    score = source.readInt();
+    favorite = source.readInt() == 1;
+    viewed = source.readInt() == 1;
+    localRevision = source.readInt();
+    level = source.readInt();
+    dead = source.readInt() == 1;
+    deleted = source.readInt() == 1;
+    collapsed = source.readInt() == 1;
+    contentExpanded = source.readInt() == 1;
+    rank = source.readInt();
+    lastKidCount = source.readInt();
+    hasNewDescendants = source.readInt() == 1;
+    parent = source.readLong();
+    voted = source.readInt() == 1;
+    pendingVoted = source.readInt() == 1;
+    next = source.readLong();
+    previous = source.readLong();
+  }
 
-    @Override
-    public void populate(Item info) {
-        title = info.getTitle();
-        time = info.getTime();
-        by = info.getBy();
-        kids = info.getKids();
-        url = info.getRawUrl();
-        text = info.getText();
-        displayedText = info.getDisplayedText(); // pre-load, but not part of Parcelable
-        type = info.getRawType();
-        descendants = info.getDescendants();
-        hasNewDescendants = lastKidCount >= 0 && descendants > lastKidCount;
-        lastKidCount = descendants;
-        parent = Long.parseLong(info.getParent());
-        deleted = info.isDeleted();
-        dead = info.isDead();
-        score = info.getScore();
-        viewed = info.isViewed();
-        favorite = info.isFavorite();
-        localRevision = 1;
-    }
+  @Override
+  public void populate(Item info) {
+    title = info.getTitle();
+    time = info.getTime();
+    by = info.getBy();
+    kids = info.getKids();
+    url = info.getRawUrl();
+    text = info.getText();
+    displayedText = info.getDisplayedText(); // pre-load, but not part of Parcelable
+    type = info.getRawType();
+    descendants = info.getDescendants();
+    hasNewDescendants = lastKidCount >= 0 && descendants > lastKidCount;
+    lastKidCount = descendants;
+    parent = Long.parseLong(info.getParent());
+    deleted = info.isDeleted();
+    dead = info.isDead();
+    score = info.getScore();
+    viewed = info.isViewed();
+    favorite = info.isFavorite();
+    localRevision = 1;
+  }
 
-    @Override
-    public String getRawType() {
-        return type;
-    }
+  @Override
+  public String getRawType() {
+    return type;
+  }
 
-    @Override
-    public String getRawUrl() {
-        return url;
-    }
+  @Override
+  public String getRawUrl() {
+    return url;
+  }
 
-    @Override
-    public long[] getKids() {
-        return kids;
-    }
+  @Override
+  public long[] getKids() {
+    return kids;
+  }
 
-    @Override
-    public String getBy() {
-        return by;
-    }
+  @Override
+  public String getBy() {
+    return by;
+  }
 
-    @Override
-    public long getTime() {
-        return time;
-    }
+  @Override
+  public long getTime() {
+    return time;
+  }
 
-    @Override
-    public int describeContents() {
-        return 0;
-    }
+  @Override
+  public int describeContents() {
+    return 0;
+  }
 
-    @Override
-    public void writeToParcel(Parcel dest, int flags) {
-        dest.writeLong(id);
-        dest.writeString(title);
-        dest.writeLong(time);
-        dest.writeString(by);
-        dest.writeLongArray(kids);
-        dest.writeString(url);
-        dest.writeString(text);
-        dest.writeString(type);
-        dest.writeInt(favorite ? 1 : 0);
-        dest.writeInt(descendants);
-        dest.writeInt(score);
-        dest.writeInt(favorite ? 1 : 0);
-        dest.writeInt(viewed ? 1 : 0);
-        dest.writeInt(localRevision);
-        dest.writeInt(level);
-        dest.writeInt(dead ? 1 : 0);
-        dest.writeInt(deleted ? 1 : 0);
-        dest.writeInt(collapsed ? 1 : 0);
-        dest.writeInt(contentExpanded ? 1 : 0);
-        dest.writeInt(rank);
-        dest.writeInt(lastKidCount);
-        dest.writeInt(hasNewDescendants ? 1 : 0);
-        dest.writeLong(parent);
-        dest.writeInt(voted ? 1 : 0);
-        dest.writeInt(pendingVoted ? 1 : 0);
-        dest.writeLong(next);
-        dest.writeLong(previous);
-    }
+  @Override
+  public void writeToParcel(Parcel dest, int flags) {
+    dest.writeLong(id);
+    dest.writeString(title);
+    dest.writeLong(time);
+    dest.writeString(by);
+    dest.writeLongArray(kids);
+    dest.writeString(url);
+    dest.writeString(text);
+    dest.writeString(type);
+    dest.writeInt(favorite ? 1 : 0);
+    dest.writeInt(descendants);
+    dest.writeInt(score);
+    dest.writeInt(favorite ? 1 : 0);
+    dest.writeInt(viewed ? 1 : 0);
+    dest.writeInt(localRevision);
+    dest.writeInt(level);
+    dest.writeInt(dead ? 1 : 0);
+    dest.writeInt(deleted ? 1 : 0);
+    dest.writeInt(collapsed ? 1 : 0);
+    dest.writeInt(contentExpanded ? 1 : 0);
+    dest.writeInt(rank);
+    dest.writeInt(lastKidCount);
+    dest.writeInt(hasNewDescendants ? 1 : 0);
+    dest.writeLong(parent);
+    dest.writeInt(voted ? 1 : 0);
+    dest.writeInt(pendingVoted ? 1 : 0);
+    dest.writeLong(next);
+    dest.writeLong(previous);
+  }
 
-    @Override
-    public String getId() {
-        return String.valueOf(id);
-    }
+  @Override
+  public String getId() {
+    return String.valueOf(id);
+  }
 
-    @Override
-    public long getLongId() {
-        return id;
-    }
+  @Override
+  public long getLongId() {
+    return id;
+  }
 
-    @Override
-    public String getTitle() {
+  @Override
+  public String getTitle() {
+    return title;
+  }
+
+  @Override
+  public String getDisplayedTitle() {
+    switch (getType()) {
+      case COMMENT_TYPE:
+        return text;
+      case JOB_TYPE:
+      case STORY_TYPE:
+      case POLL_TYPE: // TODO poll need to display options
+      default:
         return title;
     }
+  }
 
-    @Override
-    public String getDisplayedTitle() {
-        switch (getType()) {
-            case COMMENT_TYPE:
-                return text;
-            case JOB_TYPE:
-            case STORY_TYPE:
-            case POLL_TYPE: // TODO poll need to display options
-            default:
-                return title;
-        }
+  @NonNull
+  @Override
+  public String getType() {
+    return !TextUtils.isEmpty(type) ? type : STORY_TYPE;
+  }
+
+  @Override
+  public Spannable getDisplayedAuthor(Context context, boolean linkify, int color) {
+    if (displayedAuthor == null) {
+      if (TextUtils.isEmpty(by)) {
+        displayedAuthor = new SpannableString("");
+      } else {
+        defaultColor =
+            ContextCompat.getColor(
+                context,
+                AppUtils.getThemedResId(
+                    context,
+                    linkify ? android.R.attr.textColorLink : android.R.attr.textColorSecondary));
+        displayedAuthor = createAuthorSpannable(linkify);
+      }
+    }
+    if (displayedAuthor.length() == 0) {
+      return displayedAuthor;
+    }
+    // Remove existing ForegroundColorSpan to prevent accumulation
+    Object[] spans =
+        displayedAuthor.getSpans(0, displayedAuthor.length(), ForegroundColorSpan.class);
+    for (Object span : spans) {
+      displayedAuthor.removeSpan(span);
+    }
+    displayedAuthor.setSpan(
+        new ForegroundColorSpan(color != 0 ? color : defaultColor),
+        AUTHOR_SEPARATOR.length(),
+        displayedAuthor.length(),
+        Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
+    return displayedAuthor;
+  }
+
+  @Override
+  public Spannable getDisplayedTime(Context context) {
+    if (displayedTime == null) {
+      SpannableStringBuilder builder =
+          new SpannableStringBuilder(dead ? context.getString(R.string.dead_prefix) + " " : "");
+      SpannableString timeSpannable =
+          new SpannableString(AppUtils.getAbbreviatedTimeSpan(time * 1000));
+      if (deleted) {
+        timeSpannable.setSpan(
+            new StrikethroughSpan(), 0, timeSpannable.length(), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
+      }
+      builder.append(timeSpannable);
+      displayedTime = builder;
+    }
+    return displayedTime;
+  }
+
+  @Override
+  public int getKidCount() {
+    if (descendants > 0) {
+      return descendants;
     }
 
-    @NonNull
-    @Override
-    public String getType() {
-        return !TextUtils.isEmpty(type) ? type : STORY_TYPE;
+    return kids != null ? kids.length : 0;
+  }
+
+  @Override
+  public int getLastKidCount() {
+    return lastKidCount;
+  }
+
+  @Override
+  public void setLastKidCount(int lastKidCount) {
+    this.lastKidCount = lastKidCount;
+  }
+
+  @Override
+  public boolean hasNewKids() {
+    return hasNewDescendants;
+  }
+
+  @Override
+  public String getUrl() {
+    switch (getType()) {
+      case JOB_TYPE:
+      case POLL_TYPE:
+      case COMMENT_TYPE:
+        return getItemUrl(getId());
+      default:
+        return TextUtils.isEmpty(url) ? getItemUrl(getId()) : url;
     }
+  }
 
-    @Override
-    public Spannable getDisplayedAuthor(Context context, boolean linkify, int color) {
-        if (displayedAuthor == null) {
-            if (TextUtils.isEmpty(by)) {
-                displayedAuthor = new SpannableString("");
-            } else {
-                defaultColor = ContextCompat.getColor(context, AppUtils.getThemedResId(context,
-                        linkify ? android.R.attr.textColorLink : android.R.attr.textColorSecondary));
-                displayedAuthor = createAuthorSpannable(linkify);
-            }
-        }
-        if (displayedAuthor.length() == 0) {
-            return displayedAuthor;
-        }
-        // Remove existing ForegroundColorSpan to prevent accumulation
-        Object[] spans = displayedAuthor.getSpans(0, displayedAuthor.length(), ForegroundColorSpan.class);
-        for (Object span : spans) {
-            displayedAuthor.removeSpan(span);
-        }
-        displayedAuthor.setSpan(new ForegroundColorSpan(color != 0 ? color : defaultColor),
-                AUTHOR_SEPARATOR.length(), displayedAuthor.length(),
-                Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
-        return displayedAuthor;
+  @NonNull
+  private SpannableString createAuthorSpannable(boolean authorLink) {
+    SpannableString bySpannable = new SpannableString(AUTHOR_SEPARATOR + by);
+    if (!authorLink) {
+      return bySpannable;
     }
+    bySpannable.setSpan(
+        new StyleSpan(Typeface.BOLD),
+        AUTHOR_SEPARATOR.length(),
+        bySpannable.length(),
+        Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
+    ClickableSpan clickableSpan =
+        new ClickableSpan() {
+          @Override
+          public void onClick(View view) {
+            view.getContext()
+                .startActivity(
+                    new Intent(Intent.ACTION_VIEW).setData(AppUtils.createUserUri(getBy())));
+          }
 
-    @Override
-    public Spannable getDisplayedTime(Context context) {
-        if (displayedTime == null) {
-            SpannableStringBuilder builder = new SpannableStringBuilder(dead ?
-                    context.getString(R.string.dead_prefix) + " " : "");
-            SpannableString timeSpannable = new SpannableString(
-                    AppUtils.getAbbreviatedTimeSpan(time * 1000));
-            if (deleted) {
-                timeSpannable.setSpan(new StrikethroughSpan(), 0, timeSpannable.length(),
-                        Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
-            }
-            builder.append(timeSpannable);
-            displayedTime = builder;
-        }
-        return displayedTime;
-    }
-
-    @Override
-    public int getKidCount() {
-        if (descendants > 0) {
-            return descendants;
-        }
-
-        return kids != null ? kids.length : 0;
-    }
-
-    @Override
-    public int getLastKidCount() {
-        return lastKidCount;
-    }
-
-    @Override
-    public void setLastKidCount(int lastKidCount) {
-        this.lastKidCount = lastKidCount;
-    }
-
-    @Override
-    public boolean hasNewKids() {
-        return hasNewDescendants;
-    }
-
-    @Override
-    public String getUrl() {
-        switch (getType()) {
-            case JOB_TYPE:
-            case POLL_TYPE:
-            case COMMENT_TYPE:
-                return getItemUrl(getId());
-            default:
-                return TextUtils.isEmpty(url) ? getItemUrl(getId()) : url;
-        }
-    }
-
-    @NonNull
-    private SpannableString createAuthorSpannable(boolean authorLink) {
-        SpannableString bySpannable = new SpannableString(AUTHOR_SEPARATOR + by);
-        if (!authorLink) {
-            return bySpannable;
-        }
-        bySpannable.setSpan(new StyleSpan(Typeface.BOLD),
-                AUTHOR_SEPARATOR.length(), bySpannable.length(),
-                Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
-        ClickableSpan clickableSpan = new ClickableSpan() {
-            @Override
-            public void onClick(View view) {
-                view.getContext().startActivity(new Intent(Intent.ACTION_VIEW)
-                        .setData(AppUtils.createUserUri(getBy())));
-            }
-
-            @Override
-            public void updateDrawState(TextPaint ds) {
-                super.updateDrawState(ds);
-                ds.setUnderlineText(false);
-            }
+          @Override
+          public void updateDrawState(TextPaint ds) {
+            super.updateDrawState(ds);
+            ds.setUnderlineText(false);
+          }
         };
-        bySpannable.setSpan(clickableSpan,
-                AUTHOR_SEPARATOR.length(), bySpannable.length(),
-                Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
-        return bySpannable;
+    bySpannable.setSpan(
+        clickableSpan,
+        AUTHOR_SEPARATOR.length(),
+        bySpannable.length(),
+        Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
+    return bySpannable;
+  }
+
+  private String getItemUrl(String itemId) {
+    return String.format(HackerNewsClient.WEB_ITEM_PATH, itemId);
+  }
+
+  @Override
+  public String getSource() {
+    return TextUtils.isEmpty(getUrl()) ? null : Uri.parse(getUrl()).getHost();
+  }
+
+  @Override
+  public HackerNewsItem[] getKidItems() {
+    if (kids == null || kids.length == 0) {
+      return new HackerNewsItem[0];
     }
 
-    private String getItemUrl(String itemId) {
-        return String.format(HackerNewsClient.WEB_ITEM_PATH, itemId);
-    }
-
-    @Override
-    public String getSource() {
-        return TextUtils.isEmpty(getUrl()) ? null : Uri.parse(getUrl()).getHost();
-    }
-
-    @Override
-    public HackerNewsItem[] getKidItems() {
-        if (kids == null || kids.length == 0) {
-            return new HackerNewsItem[0];
+    if (kidItems == null) {
+      kidItems = new HackerNewsItem[kids.length];
+      for (int i = 0; i < kids.length; i++) {
+        HackerNewsItem item = new HackerNewsItem(kids[i], level + 1);
+        item.rank = i + 1;
+        if (i > 0) {
+          item.previous = kids[i - 1];
         }
-
-        if (kidItems == null) {
-            kidItems = new HackerNewsItem[kids.length];
-            for (int i = 0; i < kids.length; i++) {
-                HackerNewsItem item = new HackerNewsItem(kids[i], level + 1);
-                item.rank = i + 1;
-                if (i > 0) {
-                    item.previous = kids[i - 1];
-                }
-                if (i < kids.length - 1) {
-                    item.next = kids[i + 1];
-                }
-                kidItems[i] = item;
-            }
+        if (i < kids.length - 1) {
+          item.next = kids[i + 1];
         }
-
-        return kidItems;
+        kidItems[i] = item;
+      }
     }
 
-    @Override
-    public String getText() {
-        return text;
-    }
+    return kidItems;
+  }
 
-    @Override
-    public CharSequence getDisplayedText() {
-        if (displayedText == null) {
-            displayedText = AppUtils.fromHtml(text);
-        }
-        return displayedText;
-    }
+  @Override
+  public String getText() {
+    return text;
+  }
 
-    @Override
-    public boolean isStoryType() {
-        switch (getType()) {
-            case STORY_TYPE:
-            case POLL_TYPE:
-            case JOB_TYPE:
-                return true;
-            case COMMENT_TYPE:
-            default:
-                return false;
-        }
+  @Override
+  public CharSequence getDisplayedText() {
+    if (displayedText == null) {
+      displayedText = AppUtils.fromHtml(text);
     }
+    return displayedText;
+  }
 
-    @Override
-    public boolean isFavorite() {
-        return favorite;
+  @Override
+  public boolean isStoryType() {
+    switch (getType()) {
+      case STORY_TYPE:
+      case POLL_TYPE:
+      case JOB_TYPE:
+        return true;
+      case COMMENT_TYPE:
+      default:
+        return false;
     }
+  }
 
-    @Override
-    public void setFavorite(boolean favorite) {
-        this.favorite = favorite;
-    }
+  @Override
+  public boolean isFavorite() {
+    return favorite;
+  }
 
-    @Override
-    public int getLocalRevision() {
-        return localRevision;
-    }
+  @Override
+  public void setFavorite(boolean favorite) {
+    this.favorite = favorite;
+  }
 
-    @Override
-    public void setLocalRevision(int localRevision) {
-        this.localRevision = localRevision;
-    }
+  @Override
+  public int getLocalRevision() {
+    return localRevision;
+  }
 
-    @Override
-    public int getDescendants() {
-        return descendants;
-    }
+  @Override
+  public void setLocalRevision(int localRevision) {
+    this.localRevision = localRevision;
+  }
 
-    @Override
-    public boolean isViewed() {
-        return viewed;
-    }
+  @Override
+  public int getDescendants() {
+    return descendants;
+  }
 
-    @Override
-    public void setIsViewed(boolean isViewed) {
-        viewed = isViewed;
-    }
+  @Override
+  public boolean isViewed() {
+    return viewed;
+  }
 
-    @Override
-    public int getLevel() {
-        return level;
-    }
+  @Override
+  public void setIsViewed(boolean isViewed) {
+    viewed = isViewed;
+  }
 
-    @Override
-    public String getParent() {
-        return String.valueOf(parent);
-    }
+  @Override
+  public int getLevel() {
+    return level;
+  }
 
-    @Override
-    public Item getParentItem() {
-        if (parent == 0) {
-            return null;
-        }
-        if (parentItem == null) {
-            parentItem = new HackerNewsItem(parent);
-        }
-        return parentItem;
-    }
+  @Override
+  public String getParent() {
+    return String.valueOf(parent);
+  }
 
-    @Override
-    public boolean isDeleted() {
-        return deleted;
+  @Override
+  public Item getParentItem() {
+    if (parent == 0) {
+      return null;
     }
+    if (parentItem == null) {
+      parentItem = new HackerNewsItem(parent);
+    }
+    return parentItem;
+  }
 
-    @Override
-    public boolean isDead() {
-        return dead;
-    }
+  @Override
+  public boolean isDeleted() {
+    return deleted;
+  }
 
-    @Override
-    public int getScore() {
-        return score;
-    }
+  @Override
+  public boolean isDead() {
+    return dead;
+  }
 
-    @Override
-    public void incrementScore() {
-        score++;
-        voted = true;
-        pendingVoted = true;
-    }
+  @Override
+  public int getScore() {
+    return score;
+  }
 
-    @Override
-    public boolean isVoted() {
-        return voted;
-    }
+  @Override
+  public void incrementScore() {
+    score++;
+    voted = true;
+    pendingVoted = true;
+  }
 
-    @Override
-    public boolean isPendingVoted() {
-        return pendingVoted;
-    }
+  @Override
+  public boolean isVoted() {
+    return voted;
+  }
 
-    @Override
-    public void clearPendingVoted() {
-        pendingVoted = false;
-    }
+  @Override
+  public boolean isPendingVoted() {
+    return pendingVoted;
+  }
 
-    @Override
-    public boolean isCollapsed() {
-        return collapsed;
-    }
+  @Override
+  public void clearPendingVoted() {
+    pendingVoted = false;
+  }
 
-    @Override
-    public void setCollapsed(boolean collapsed) {
-        this.collapsed = collapsed;
-    }
+  @Override
+  public boolean isCollapsed() {
+    return collapsed;
+  }
 
-    @Override
-    public int getRank() {
-        return rank;
-    }
+  @Override
+  public void setCollapsed(boolean collapsed) {
+    this.collapsed = collapsed;
+  }
 
-    @Override
-    public boolean isContentExpanded() {
-        return contentExpanded;
-    }
+  @Override
+  public int getRank() {
+    return rank;
+  }
 
-    @Override
-    public void setContentExpanded(boolean expanded) {
-        contentExpanded = expanded;
-    }
+  @Override
+  public boolean isContentExpanded() {
+    return contentExpanded;
+  }
 
-    @Override
-    public long getNeighbour(int direction) {
-        switch (direction) {
-            case Navigable.DIRECTION_UP:
-                return previous;
-            case Navigable.DIRECTION_DOWN:
-                return next;
-            case Navigable.DIRECTION_LEFT:
-                return level > 1 ? parent : 0L;
-            case Navigable.DIRECTION_RIGHT:
-                return kids != null && kids.length > 0 ? kids[0] : 0L;
-            default:
-                return 0L;
-        }
-    }
+  @Override
+  public void setContentExpanded(boolean expanded) {
+    contentExpanded = expanded;
+  }
 
-    @Override
-    public int hashCode() {
-        return (int) id;
+  @Override
+  public long getNeighbour(int direction) {
+    switch (direction) {
+      case Navigable.DIRECTION_UP:
+        return previous;
+      case Navigable.DIRECTION_DOWN:
+        return next;
+      case Navigable.DIRECTION_LEFT:
+        return level > 1 ? parent : 0L;
+      case Navigable.DIRECTION_RIGHT:
+        return kids != null && kids.length > 0 ? kids[0] : 0L;
+      default:
+        return 0L;
     }
+  }
 
-    @Override
-    public boolean equals(Object o) {
-        return o instanceof HackerNewsItem && id == ((HackerNewsItem) o).id;
-    }
+  @Override
+  public int hashCode() {
+    return (int) id;
+  }
 
-    void preload() {
-        getDisplayedText(); // pre-load HTML
-        getKidItems(); // pre-construct kids
-    }
+  @Override
+  public boolean equals(Object o) {
+    return o instanceof HackerNewsItem && id == ((HackerNewsItem) o).id;
+  }
+
+  void preload() {
+    getDisplayedText(); // pre-load HTML
+    getKidItems(); // pre-construct kids
+  }
 }

--- a/app/src/test/java/io/github/sheepdestroyer/materialisheep/data/HackerNewsItemTest.java
+++ b/app/src/test/java/io/github/sheepdestroyer/materialisheep/data/HackerNewsItemTest.java
@@ -1,0 +1,106 @@
+package io.github.sheepdestroyer.materialisheep.data;
+
+import android.content.Context;
+import android.os.Parcel;
+import android.text.Spannable;
+import android.text.style.ForegroundColorSpan;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(RobolectricTestRunner.class)
+public class HackerNewsItemTest {
+
+    @Test
+    public void testGetDisplayedAuthor_DoesNotAccumulateSpans() {
+        // Arrange
+        HackerNewsItem item = new HackerNewsItem(12345);
+        TestItem source = new TestItem(12345) {
+             @Override
+             public String getBy() {
+                 return "author";
+             }
+        };
+        item.populate(source);
+        Context context = RuntimeEnvironment.application;
+
+        // Act & Assert
+        // First call
+        Spannable firstResult = item.getDisplayedAuthor(context, false, 0);
+        int spansAfterFirstCall = firstResult.getSpans(0, firstResult.length(), ForegroundColorSpan.class).length;
+        assertEquals("Should have 1 ForegroundColorSpan initially", 1, spansAfterFirstCall);
+
+        // Second call
+        Spannable secondResult = item.getDisplayedAuthor(context, false, 0);
+        int spansAfterSecondCall = secondResult.getSpans(0, secondResult.length(), ForegroundColorSpan.class).length;
+        assertEquals("Should still have 1 ForegroundColorSpan after second call", 1, spansAfterSecondCall);
+
+        // Multiple calls
+        for (int i = 0; i < 100; i++) {
+             item.getDisplayedAuthor(context, false, 0);
+        }
+        Spannable finalResult = item.getDisplayedAuthor(context, false, 0);
+        int spansAfterManyCalls = finalResult.getSpans(0, finalResult.length(), ForegroundColorSpan.class).length;
+        assertEquals("Should still have 1 ForegroundColorSpan after many calls", 1, spansAfterManyCalls);
+    }
+
+    // Minimal Item implementation for populating HackerNewsItem
+    static class TestItem implements Item {
+        private final long id;
+        TestItem(long id) { this.id = id; }
+
+        @Override public String getBy() { return "author"; }
+        @Override public String getTitle() { return "title"; }
+        @Override public long getTime() { return 0; }
+        @Override public long[] getKids() { return new long[0]; }
+        @Override public String getRawUrl() { return "http://example.com"; }
+        @Override public String getText() { return "text"; }
+        @Override public android.text.Spannable getDisplayedAuthor(android.content.Context context, boolean linkify, int color) { return null; }
+        @Override public CharSequence getDisplayedText() { return null; }
+        @Override public String getRawType() { return "story"; }
+        @Override public int getDescendants() { return 0; }
+        @Override public String getParent() { return "0"; }
+        @Override public boolean isDeleted() { return false; }
+        @Override public boolean isDead() { return false; }
+        @Override public int getScore() { return 0; }
+        @Override public boolean isViewed() { return false; }
+        @Override public boolean isFavorite() { return false; }
+
+        @Override public String getId() { return String.valueOf(id); }
+        @Override public long getLongId() { return id; }
+        @Override public String getUrl() { return "http://example.com"; }
+        @Override public String getDisplayedTitle() { return "title"; }
+        @Override public String getType() { return "story"; }
+        @Override public android.text.Spannable getDisplayedTime(android.content.Context context) { return null; }
+        @Override public int getKidCount() { return 0; }
+        @Override public int getLastKidCount() { return 0; }
+        @Override public void setLastKidCount(int lastKidCount) {}
+        @Override public boolean hasNewKids() { return false; }
+        @Override public String getSource() { return "example.com"; }
+        @Override public Item[] getKidItems() { return new Item[0]; }
+        @Override public boolean isStoryType() { return true; }
+        @Override public void setFavorite(boolean favorite) {}
+        @Override public int getLocalRevision() { return 0; }
+        @Override public void setLocalRevision(int localRevision) {}
+        @Override public void setIsViewed(boolean isViewed) {}
+        @Override public int getLevel() { return 0; }
+        @Override public Item getParentItem() { return null; }
+        @Override public void incrementScore() {}
+        @Override public boolean isVoted() { return false; }
+        @Override public boolean isPendingVoted() { return false; }
+        @Override public void clearPendingVoted() {}
+        @Override public boolean isCollapsed() { return false; }
+        @Override public void setCollapsed(boolean collapsed) {}
+        @Override public int getRank() { return 0; }
+        @Override public boolean isContentExpanded() { return false; }
+        @Override public void setContentExpanded(boolean expanded) {}
+        @Override public long getNeighbour(int direction) { return 0; }
+        @Override public int describeContents() { return 0; }
+        @Override public void writeToParcel(Parcel dest, int flags) {}
+        @Override public void populate(Item info) {}
+    }
+}

--- a/app/src/test/java/io/github/sheepdestroyer/materialisheep/data/HackerNewsItemTest.java
+++ b/app/src/test/java/io/github/sheepdestroyer/materialisheep/data/HackerNewsItemTest.java
@@ -1,106 +1,285 @@
 package io.github.sheepdestroyer.materialisheep.data;
 
+import static org.junit.Assert.assertEquals;
+
 import android.content.Context;
 import android.os.Parcel;
 import android.text.Spannable;
 import android.text.style.ForegroundColorSpan;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 
-import static org.junit.Assert.assertEquals;
-
 @RunWith(RobolectricTestRunner.class)
 public class HackerNewsItemTest {
 
-    @Test
-    public void testGetDisplayedAuthor_DoesNotAccumulateSpans() {
-        // Arrange
-        HackerNewsItem item = new HackerNewsItem(12345);
-        TestItem source = new TestItem(12345) {
-             @Override
-             public String getBy() {
-                 return "author";
-             }
+  @Test
+  public void testGetDisplayedAuthor_DoesNotAccumulateSpans() {
+    // Arrange
+    HackerNewsItem item = new HackerNewsItem(12345);
+    TestItem source =
+        new TestItem(12345) {
+          @Override
+          public String getBy() {
+            return "author";
+          }
         };
-        item.populate(source);
-        Context context = RuntimeEnvironment.application;
+    item.populate(source);
+    Context context = RuntimeEnvironment.application;
 
-        // Act & Assert
-        // First call
-        Spannable firstResult = item.getDisplayedAuthor(context, false, 0);
-        int spansAfterFirstCall = firstResult.getSpans(0, firstResult.length(), ForegroundColorSpan.class).length;
-        assertEquals("Should have 1 ForegroundColorSpan initially", 1, spansAfterFirstCall);
+    // Act & Assert
+    // First call
+    Spannable firstResult = item.getDisplayedAuthor(context, false, 0);
+    int spansAfterFirstCall =
+        firstResult.getSpans(0, firstResult.length(), ForegroundColorSpan.class).length;
+    assertEquals("Should have 1 ForegroundColorSpan initially", 1, spansAfterFirstCall);
 
-        // Second call
-        Spannable secondResult = item.getDisplayedAuthor(context, false, 0);
-        int spansAfterSecondCall = secondResult.getSpans(0, secondResult.length(), ForegroundColorSpan.class).length;
-        assertEquals("Should still have 1 ForegroundColorSpan after second call", 1, spansAfterSecondCall);
+    // Second call
+    Spannable secondResult = item.getDisplayedAuthor(context, false, 0);
+    int spansAfterSecondCall =
+        secondResult.getSpans(0, secondResult.length(), ForegroundColorSpan.class).length;
+    assertEquals(
+        "Should still have 1 ForegroundColorSpan after second call", 1, spansAfterSecondCall);
 
-        // Multiple calls
-        for (int i = 0; i < 100; i++) {
-             item.getDisplayedAuthor(context, false, 0);
-        }
-        Spannable finalResult = item.getDisplayedAuthor(context, false, 0);
-        int spansAfterManyCalls = finalResult.getSpans(0, finalResult.length(), ForegroundColorSpan.class).length;
-        assertEquals("Should still have 1 ForegroundColorSpan after many calls", 1, spansAfterManyCalls);
+    // Multiple calls
+    for (int i = 0; i < 100; i++) {
+      item.getDisplayedAuthor(context, false, 0);
+    }
+    Spannable finalResult = item.getDisplayedAuthor(context, false, 0);
+    int spansAfterManyCalls =
+        finalResult.getSpans(0, finalResult.length(), ForegroundColorSpan.class).length;
+    assertEquals(
+        "Should still have 1 ForegroundColorSpan after many calls", 1, spansAfterManyCalls);
+  }
+
+  // Minimal Item implementation for populating HackerNewsItem
+  static class TestItem implements Item {
+    private final long id;
+
+    TestItem(long id) {
+      this.id = id;
     }
 
-    // Minimal Item implementation for populating HackerNewsItem
-    static class TestItem implements Item {
-        private final long id;
-        TestItem(long id) { this.id = id; }
-
-        @Override public String getBy() { return "author"; }
-        @Override public String getTitle() { return "title"; }
-        @Override public long getTime() { return 0; }
-        @Override public long[] getKids() { return new long[0]; }
-        @Override public String getRawUrl() { return "http://example.com"; }
-        @Override public String getText() { return "text"; }
-        @Override public android.text.Spannable getDisplayedAuthor(android.content.Context context, boolean linkify, int color) { return null; }
-        @Override public CharSequence getDisplayedText() { return null; }
-        @Override public String getRawType() { return "story"; }
-        @Override public int getDescendants() { return 0; }
-        @Override public String getParent() { return "0"; }
-        @Override public boolean isDeleted() { return false; }
-        @Override public boolean isDead() { return false; }
-        @Override public int getScore() { return 0; }
-        @Override public boolean isViewed() { return false; }
-        @Override public boolean isFavorite() { return false; }
-
-        @Override public String getId() { return String.valueOf(id); }
-        @Override public long getLongId() { return id; }
-        @Override public String getUrl() { return "http://example.com"; }
-        @Override public String getDisplayedTitle() { return "title"; }
-        @Override public String getType() { return "story"; }
-        @Override public android.text.Spannable getDisplayedTime(android.content.Context context) { return null; }
-        @Override public int getKidCount() { return 0; }
-        @Override public int getLastKidCount() { return 0; }
-        @Override public void setLastKidCount(int lastKidCount) {}
-        @Override public boolean hasNewKids() { return false; }
-        @Override public String getSource() { return "example.com"; }
-        @Override public Item[] getKidItems() { return new Item[0]; }
-        @Override public boolean isStoryType() { return true; }
-        @Override public void setFavorite(boolean favorite) {}
-        @Override public int getLocalRevision() { return 0; }
-        @Override public void setLocalRevision(int localRevision) {}
-        @Override public void setIsViewed(boolean isViewed) {}
-        @Override public int getLevel() { return 0; }
-        @Override public Item getParentItem() { return null; }
-        @Override public void incrementScore() {}
-        @Override public boolean isVoted() { return false; }
-        @Override public boolean isPendingVoted() { return false; }
-        @Override public void clearPendingVoted() {}
-        @Override public boolean isCollapsed() { return false; }
-        @Override public void setCollapsed(boolean collapsed) {}
-        @Override public int getRank() { return 0; }
-        @Override public boolean isContentExpanded() { return false; }
-        @Override public void setContentExpanded(boolean expanded) {}
-        @Override public long getNeighbour(int direction) { return 0; }
-        @Override public int describeContents() { return 0; }
-        @Override public void writeToParcel(Parcel dest, int flags) {}
-        @Override public void populate(Item info) {}
+    @Override
+    public String getBy() {
+      return "author";
     }
+
+    @Override
+    public String getTitle() {
+      return "title";
+    }
+
+    @Override
+    public long getTime() {
+      return 0;
+    }
+
+    @Override
+    public long[] getKids() {
+      return new long[0];
+    }
+
+    @Override
+    public String getRawUrl() {
+      return "http://example.com";
+    }
+
+    @Override
+    public String getText() {
+      return "text";
+    }
+
+    @Override
+    public android.text.Spannable getDisplayedAuthor(
+        android.content.Context context, boolean linkify, int color) {
+      return null;
+    }
+
+    @Override
+    public CharSequence getDisplayedText() {
+      return null;
+    }
+
+    @Override
+    public String getRawType() {
+      return "story";
+    }
+
+    @Override
+    public int getDescendants() {
+      return 0;
+    }
+
+    @Override
+    public String getParent() {
+      return "0";
+    }
+
+    @Override
+    public boolean isDeleted() {
+      return false;
+    }
+
+    @Override
+    public boolean isDead() {
+      return false;
+    }
+
+    @Override
+    public int getScore() {
+      return 0;
+    }
+
+    @Override
+    public boolean isViewed() {
+      return false;
+    }
+
+    @Override
+    public boolean isFavorite() {
+      return false;
+    }
+
+    @Override
+    public String getId() {
+      return String.valueOf(id);
+    }
+
+    @Override
+    public long getLongId() {
+      return id;
+    }
+
+    @Override
+    public String getUrl() {
+      return "http://example.com";
+    }
+
+    @Override
+    public String getDisplayedTitle() {
+      return "title";
+    }
+
+    @Override
+    public String getType() {
+      return "story";
+    }
+
+    @Override
+    public android.text.Spannable getDisplayedTime(android.content.Context context) {
+      return null;
+    }
+
+    @Override
+    public int getKidCount() {
+      return 0;
+    }
+
+    @Override
+    public int getLastKidCount() {
+      return 0;
+    }
+
+    @Override
+    public void setLastKidCount(int lastKidCount) {}
+
+    @Override
+    public boolean hasNewKids() {
+      return false;
+    }
+
+    @Override
+    public String getSource() {
+      return "example.com";
+    }
+
+    @Override
+    public Item[] getKidItems() {
+      return new Item[0];
+    }
+
+    @Override
+    public boolean isStoryType() {
+      return true;
+    }
+
+    @Override
+    public void setFavorite(boolean favorite) {}
+
+    @Override
+    public int getLocalRevision() {
+      return 0;
+    }
+
+    @Override
+    public void setLocalRevision(int localRevision) {}
+
+    @Override
+    public void setIsViewed(boolean isViewed) {}
+
+    @Override
+    public int getLevel() {
+      return 0;
+    }
+
+    @Override
+    public Item getParentItem() {
+      return null;
+    }
+
+    @Override
+    public void incrementScore() {}
+
+    @Override
+    public boolean isVoted() {
+      return false;
+    }
+
+    @Override
+    public boolean isPendingVoted() {
+      return false;
+    }
+
+    @Override
+    public void clearPendingVoted() {}
+
+    @Override
+    public boolean isCollapsed() {
+      return false;
+    }
+
+    @Override
+    public void setCollapsed(boolean collapsed) {}
+
+    @Override
+    public int getRank() {
+      return 0;
+    }
+
+    @Override
+    public boolean isContentExpanded() {
+      return false;
+    }
+
+    @Override
+    public void setContentExpanded(boolean expanded) {}
+
+    @Override
+    public long getNeighbour(int direction) {
+      return 0;
+    }
+
+    @Override
+    public int describeContents() {
+      return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {}
+
+    @Override
+    public void populate(Item info) {}
+  }
 }


### PR DESCRIPTION
💡 What: The optimization implemented
This change modifies `HackerNewsItem.getDisplayedAuthor` to remove any existing `ForegroundColorSpan`s from the cached `displayedAuthor` spannable string before adding a new one.

🎯 Why: The performance problem it solves
The `displayedAuthor` field is cached in `HackerNewsItem`. The `getDisplayedAuthor` method is called repeatedly by `StoryRecyclerViewAdapter` during scrolling (in `onBindViewHolder`). Each call was unconditionally adding a new `ForegroundColorSpan` to the spannable string. This caused the number of spans to grow linearly with the number of times the item was displayed/bound, leading to increased memory usage and slower text rendering/measurement (layout) over time.

📊 Impact: Expected performance improvement
Eliminates the unbounded growth of span objects attached to list items. This stabilizes memory usage for long lists and prevents text rendering performance from degrading as the user scrolls back and forth.

🔬 Measurement: How to verify the improvement
A new unit test `HackerNewsItemTest` has been added. It calls `getDisplayedAuthor` multiple times and asserts that the number of `ForegroundColorSpan`s remains constant (1), instead of increasing. Before the fix, this test failed. After the fix, it passes.

---
*PR created automatically by Jules for task [13315084923907386707](https://jules.google.com/task/13315084923907386707) started by @sheepdestroyer*

## Summary by Sourcery

Prevent accumulation of text color spans in cached HackerNews author display strings and add coverage to guard against regressions.

Bug Fixes:
- Clear existing ForegroundColorSpan instances from the cached displayedAuthor spannable before applying a new one to avoid span accumulation and performance degradation during list scrolling.

Documentation:
- Add a Bolt note documenting the SpannableString span retention behavior and the chosen mitigation when caching spannables.

Tests:
- Add Robolectric-based HackerNewsItemTest to verify that repeated getDisplayedAuthor calls keep the number of ForegroundColorSpan instances constant.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix memory leak in `HackerNewsItem` by removing existing `ForegroundColorSpan`s in `getDisplayedAuthor` to prevent span accumulation.
> 
>   - **Behavior**:
>     - Modify `getDisplayedAuthor` in `HackerNewsItem` to remove existing `ForegroundColorSpan`s before adding a new one.
>     - Prevents accumulation of spans, stabilizing memory usage and text rendering performance.
>   - **Testing**:
>     - Add `HackerNewsItemTest` to verify that `getDisplayedAuthor` does not accumulate spans.
>     - Test ensures only one `ForegroundColorSpan` is present after multiple calls.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sheepdestroyer%2Fmaterialisheep&utm_source=github&utm_medium=referral)<sup> for 3c5bdb6d15746926a1a102e5c89f01fede654049. You can [customize](https://app.ellipsis.dev/sheepdestroyer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented accumulation of color spans in author displays, eliminating a memory/performance regression during repeated updates.

* **Tests**
  * Added unit tests that verify span accumulation does not occur across repeated calls.

* **Documentation**
  * Added guidance about avoiding unbounded span growth when caching and reusing SpannableStrings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->