### PR TITLE
🛡️ Sentinel: [HIGH] Restrict WebView file access

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,9 @@
+# Sentinel's Security Journal 🛡️
+
+## 2025-10-27 - WebView File Access Vulnerability
+**Vulnerability:** `CacheableWebView` enabled `setAllowFileAccess(true)` globally for all loaded content, and `WebView` used `file:///` as a base URL for `loadDataWithBaseURL`. This combination potentially allowed malicious HTML content to access local files if it could bypass other restrictions.
+**Learning:** `setAllowFileAccess(true)` is often enabled for legitimate features (like offline caching) but must be scoped tightly. A global setting persists across page loads. Using `file:///` as a base URL grants broad file access permissions to the loaded content.
+**Prevention:**
+1. Default to `setAllowFileAccess(false)`.
+2. Only enable it strictly when loading a trusted local file (e.g., from cache), and ensure it's disabled otherwise.
+3. Use more restrictive base URLs like `file:///android_asset/` or `about:blank` when loading HTML content.

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/CacheableWebView.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/CacheableWebView.java
@@ -19,155 +19,151 @@ package io.github.sheepdestroyer.materialisheep.widget;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.net.Uri;
-
-import androidx.annotation.CallSuper;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
 import android.webkit.WebViewClient;
-
+import androidx.annotation.CallSuper;
+import io.github.sheepdestroyer.materialisheep.AppUtils;
 import java.io.File;
 import java.util.Map;
 
-import io.github.sheepdestroyer.materialisheep.AppUtils;
-
 public class CacheableWebView extends WebView {
-    private static final String CACHE_PREFIX = "webarchive-";
-    private static final String CACHE_EXTENSION = ".mht";
-    private ArchiveClient mArchiveClient = new ArchiveClient();
+  private static final String CACHE_PREFIX = "webarchive-";
+  private static final String CACHE_EXTENSION = ".mht";
+  private ArchiveClient mArchiveClient = new ArchiveClient();
 
-    public CacheableWebView(Context context) {
-        this(context, null);
+  public CacheableWebView(Context context) {
+    this(context, null);
+  }
+
+  public CacheableWebView(Context context, AttributeSet attrs) {
+    this(context, attrs, 0);
+  }
+
+  public CacheableWebView(Context context, AttributeSet attrs, int defStyleAttr) {
+    super(context, attrs, defStyleAttr);
+    init();
+  }
+
+  @Override
+  public void reloadUrl(String url) {
+    super.reloadUrl(getCacheableUrl(url));
+  }
+
+  @Override
+  public void loadUrl(String url) {
+    if (TextUtils.isEmpty(url)) {
+      return;
     }
+    mArchiveClient.lastProgress = 0;
+    super.loadUrl(getCacheableUrl(url));
+  }
 
-    public CacheableWebView(Context context, AttributeSet attrs) {
-        this(context, attrs, 0);
+  @Override
+  public void loadUrl(String url, Map<String, String> additionalHttpHeaders) {
+    if (TextUtils.isEmpty(url)) {
+      return;
     }
+    mArchiveClient.lastProgress = 0;
+    super.loadUrl(getCacheableUrl(url), additionalHttpHeaders);
+  }
 
-    public CacheableWebView(Context context, AttributeSet attrs, int defStyleAttr) {
-        super(context, attrs, defStyleAttr);
-        init();
+  @Override
+  public void setWebChromeClient(WebChromeClient client) {
+    if (!(client instanceof ArchiveClient)) {
+      throw new IllegalArgumentException(
+          "client should be an instance of " + ArchiveClient.class.getName());
     }
+    mArchiveClient = (ArchiveClient) client;
+    super.setWebChromeClient(mArchiveClient);
+  }
 
+  private void init() {
+    enableCache();
+    setLoadSettings();
+    setWebViewClient(new WebViewClient());
+    setWebChromeClient(mArchiveClient);
+  }
+
+  @SuppressWarnings("deprecation")
+  private void enableCache() {
+    WebSettings webSettings = getSettings();
+    webSettings.setAllowFileAccess(false);
+    webSettings.setAllowFileAccessFromFileURLs(false);
+    webSettings.setAllowUniversalAccessFromFileURLs(false);
+    setCacheModeInternal();
+  }
+
+  private void setCacheModeInternal() {
+    getSettings().setCacheMode(WebSettings.LOAD_CACHE_ELSE_NETWORK);
+  }
+
+  @SuppressLint("SetJavaScriptEnabled")
+  private void setLoadSettings() {
+    WebSettings webSettings = getSettings();
+    webSettings.setLoadWithOverviewMode(true);
+    webSettings.setUseWideViewPort(true);
+    webSettings.setJavaScriptEnabled(true);
+  }
+
+  private String getCacheableUrl(String url) {
+    // file access should be disabled by default, and only enabled if loading a file from cache
+    getSettings().setAllowFileAccess(false);
+    if (TextUtils.equals(url, BLANK) || TextUtils.equals(url, FILE)) {
+      mArchiveClient.cacheFileName = null;
+      return url;
+    }
+    mArchiveClient.cacheFileName = generateCacheFilename(url);
+    setCacheModeInternal();
+    File cacheFile = new File(mArchiveClient.cacheFileName);
+    if (cacheFile.exists() && !AppUtils.hasConnection(getContext())) {
+      getSettings().setCacheMode(WebSettings.LOAD_CACHE_ONLY);
+      getSettings().setAllowFileAccess(true);
+      return Uri.fromFile(cacheFile).toString();
+    }
+    return url;
+  }
+
+  private String generateCacheFilename(String url) {
+    String name;
+    try {
+      java.security.MessageDigest digest = java.security.MessageDigest.getInstance("SHA-256");
+      byte[] hash = digest.digest(url.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+      StringBuilder hexString = new StringBuilder();
+      for (byte b : hash) {
+        String hex = Integer.toHexString(0xff & b);
+        if (hex.length() == 1) {
+          hexString.append('0');
+        }
+        hexString.append(hex);
+      }
+      name = hexString.toString();
+    } catch (java.security.NoSuchAlgorithmException e) {
+      name = String.valueOf(url.hashCode());
+    }
+    return getContext().getApplicationContext().getCacheDir().getAbsolutePath()
+        + File.separator
+        + CACHE_PREFIX
+        + name
+        + CACHE_EXTENSION;
+  }
+
+  public static class ArchiveClient extends WebChromeClient {
+    int lastProgress = 0;
+    String cacheFileName = null;
+
+    @CallSuper
     @Override
-    public void reloadUrl(String url) {
-        super.reloadUrl(getCacheableUrl(url));
+    public void onProgressChanged(android.webkit.WebView view, int newProgress) {
+      if (view.getSettings().getCacheMode() == WebSettings.LOAD_CACHE_ONLY) {
+        return;
+      }
+      if (cacheFileName != null && lastProgress != 100 && newProgress == 100) {
+        lastProgress = newProgress;
+        view.saveWebArchive(cacheFileName);
+      }
     }
-
-    @Override
-    public void loadUrl(String url) {
-        if (TextUtils.isEmpty(url)) {
-            return;
-        }
-        mArchiveClient.lastProgress = 0;
-        super.loadUrl(getCacheableUrl(url));
-    }
-
-    @Override
-    public void loadUrl(String url, Map<String, String> additionalHttpHeaders) {
-        if (TextUtils.isEmpty(url)) {
-            return;
-        }
-        mArchiveClient.lastProgress = 0;
-        super.loadUrl(getCacheableUrl(url), additionalHttpHeaders);
-    }
-
-    @Override
-    public void setWebChromeClient(WebChromeClient client) {
-        if (!(client instanceof ArchiveClient)) {
-            throw new IllegalArgumentException("client should be an instance of " +
-                    ArchiveClient.class.getName());
-        }
-        mArchiveClient = (ArchiveClient) client;
-        super.setWebChromeClient(mArchiveClient);
-    }
-
-    private void init() {
-        enableCache();
-        setLoadSettings();
-        setWebViewClient(new WebViewClient());
-        setWebChromeClient(mArchiveClient);
-    }
-
-    @SuppressWarnings("deprecation")
-    private void enableCache() {
-        WebSettings webSettings = getSettings();
-        webSettings.setAllowFileAccess(false);
-        webSettings.setAllowFileAccessFromFileURLs(false);
-        webSettings.setAllowUniversalAccessFromFileURLs(false);
-        setCacheModeInternal();
-    }
-
-    private void setCacheModeInternal() {
-        getSettings().setCacheMode(WebSettings.LOAD_CACHE_ELSE_NETWORK);
-    }
-
-    @SuppressLint("SetJavaScriptEnabled")
-    private void setLoadSettings() {
-        WebSettings webSettings = getSettings();
-        webSettings.setLoadWithOverviewMode(true);
-        webSettings.setUseWideViewPort(true);
-        webSettings.setJavaScriptEnabled(true);
-    }
-
-    private String getCacheableUrl(String url) {
-        // file access should be disabled by default, and only enabled if loading a file from cache
-        getSettings().setAllowFileAccess(false);
-        if (TextUtils.equals(url, BLANK) || TextUtils.equals(url, FILE)) {
-            mArchiveClient.cacheFileName = null;
-            return url;
-        }
-        mArchiveClient.cacheFileName = generateCacheFilename(url);
-        setCacheModeInternal();
-        File cacheFile = new File(mArchiveClient.cacheFileName);
-        if (cacheFile.exists() && !AppUtils.hasConnection(getContext())) {
-            getSettings().setCacheMode(WebSettings.LOAD_CACHE_ONLY);
-            getSettings().setAllowFileAccess(true);
-            return Uri.fromFile(cacheFile).toString();
-        }
-        return url;
-    }
-
-    private String generateCacheFilename(String url) {
-        String name;
-        try {
-            java.security.MessageDigest digest = java.security.MessageDigest.getInstance("SHA-256");
-            byte[] hash = digest.digest(url.getBytes(java.nio.charset.StandardCharsets.UTF_8));
-            StringBuilder hexString = new StringBuilder();
-            for (byte b : hash) {
-                String hex = Integer.toHexString(0xff & b);
-                if (hex.length() == 1) {
-                    hexString.append('0');
-                }
-                hexString.append(hex);
-            }
-            name = hexString.toString();
-        } catch (java.security.NoSuchAlgorithmException e) {
-            name = String.valueOf(url.hashCode());
-        }
-        return getContext().getApplicationContext().getCacheDir().getAbsolutePath() +
-                File.separator +
-                CACHE_PREFIX +
-                name +
-                CACHE_EXTENSION;
-    }
-
-    public static class ArchiveClient extends WebChromeClient {
-        int lastProgress = 0;
-        String cacheFileName = null;
-
-        @CallSuper
-        @Override
-        public void onProgressChanged(android.webkit.WebView view, int newProgress) {
-            if (view.getSettings().getCacheMode() == WebSettings.LOAD_CACHE_ONLY) {
-                return;
-            }
-            if (cacheFileName != null && lastProgress != 100 && newProgress == 100) {
-                lastProgress = newProgress;
-                view.saveWebArchive(cacheFileName);
-            }
-        }
-
-    }
+  }
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/CacheableWebView.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/CacheableWebView.java
@@ -90,9 +90,12 @@ public class CacheableWebView extends WebView {
         setWebChromeClient(mArchiveClient);
     }
 
+    @SuppressWarnings("deprecation")
     private void enableCache() {
         WebSettings webSettings = getSettings();
-        webSettings.setAllowFileAccess(true);
+        webSettings.setAllowFileAccess(false);
+        webSettings.setAllowFileAccessFromFileURLs(false);
+        webSettings.setAllowUniversalAccessFromFileURLs(false);
         setCacheModeInternal();
     }
 
@@ -109,6 +112,8 @@ public class CacheableWebView extends WebView {
     }
 
     private String getCacheableUrl(String url) {
+        // file access should be disabled by default, and only enabled if loading a file from cache
+        getSettings().setAllowFileAccess(false);
         if (TextUtils.equals(url, BLANK) || TextUtils.equals(url, FILE)) {
             mArchiveClient.cacheFileName = null;
             return url;
@@ -118,6 +123,7 @@ public class CacheableWebView extends WebView {
         File cacheFile = new File(mArchiveClient.cacheFileName);
         if (cacheFile.exists() && !AppUtils.hasConnection(getContext())) {
             getSettings().setCacheMode(WebSettings.LOAD_CACHE_ONLY);
+            getSettings().setAllowFileAccess(true);
             return Uri.fromFile(cacheFile).toString();
         }
         return url;

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/WebView.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/WebView.java
@@ -31,7 +31,7 @@ import io.github.sheepdestroyer.materialisheep.annotation.Synthetic;
 
 public class WebView extends android.webkit.WebView {
     static final String BLANK = "about:blank";
-    static final String FILE = "file:///";
+    static final String FILE = "file:///android_asset/";
     private final HistoryWebViewClient mClient = new HistoryWebViewClient();
     @Synthetic
     String mPendingUrl, mPendingHtml;

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/WebView.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/WebView.java
@@ -16,116 +16,115 @@
 
 package io.github.sheepdestroyer.materialisheep.widget;
 
-import android.annotation.TargetApi;
 import android.content.Context;
 import android.graphics.Bitmap;
-import android.os.Build;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebViewClient;
-
 import io.github.sheepdestroyer.materialisheep.AppUtils;
 import io.github.sheepdestroyer.materialisheep.annotation.Synthetic;
 
 public class WebView extends android.webkit.WebView {
-    static final String BLANK = "about:blank";
-    static final String FILE = "file:///android_asset/";
-    private final HistoryWebViewClient mClient = new HistoryWebViewClient();
+  static final String BLANK = "about:blank";
+  static final String FILE = "file:///android_asset/";
+  private final HistoryWebViewClient mClient = new HistoryWebViewClient();
+  @Synthetic String mPendingUrl, mPendingHtml;
+
+  public WebView(Context context) {
+    this(context, null);
+  }
+
+  public WebView(Context context, AttributeSet attrs) {
+    this(context, attrs, 0);
+  }
+
+  public WebView(Context context, AttributeSet attrs, int defStyleAttr) {
+    super(context, attrs, defStyleAttr);
+    super.setWebViewClient(mClient);
+  }
+
+  @Override
+  public void setWebViewClient(WebViewClient client) {
+    mClient.wrap(client);
+  }
+
+  @Override
+  public boolean canGoBack() {
+    return TextUtils.isEmpty(mPendingUrl) && super.canGoBack();
+  }
+
+  public void reloadUrl(String url) {
+    if (getProgress() < 100) {
+      stopLoading(); // this will fire onPageFinished for current URL
+    }
+    mPendingUrl = url;
+    loadUrl(BLANK); // clear current web resources, load pending URL upon onPageFinished
+  }
+
+  public void reloadHtml(String html) {
+    mPendingHtml = html;
+    reloadUrl(FILE);
+  }
+
+  static class HistoryWebViewClient extends WebViewClient {
+    private WebViewClient mClient;
+
+    @Override
+    public void onPageStarted(android.webkit.WebView view, String url, Bitmap favicon) {
+      super.onPageStarted(view, url, favicon);
+      view.pageUp(true);
+      WebView webView = (WebView) view;
+      if (AppUtils.urlEquals(url, webView.mPendingUrl)) {
+        view.setVisibility(VISIBLE);
+      }
+      if (mClient != null) {
+        mClient.onPageStarted(view, url, favicon);
+      }
+    }
+
+    @Override
+    public void onPageFinished(android.webkit.WebView view, String url) {
+      super.onPageFinished(view, url);
+      WebView webView = (WebView) view;
+      if (TextUtils.equals(url, BLANK)) { // has pending reload, open corresponding URL
+        if (!TextUtils.isEmpty(webView.mPendingHtml)) {
+          view.loadDataWithBaseURL(
+              webView.mPendingUrl, webView.mPendingHtml, "text/html", "UTF-8", webView.mPendingUrl);
+        } else {
+          view.loadUrl(webView.mPendingUrl);
+        }
+      } else if (!TextUtils.isEmpty(webView.mPendingUrl)
+          && TextUtils.equals(url, webView.mPendingUrl)) { // reload done, clear history
+        webView.mPendingUrl = null;
+        webView.mPendingHtml = null;
+        view.clearHistory();
+      }
+      if (mClient != null) {
+        mClient.onPageFinished(view, url);
+      }
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public WebResourceResponse shouldInterceptRequest(android.webkit.WebView view, String url) {
+      return mClient != null
+          ? mClient.shouldInterceptRequest(view, url)
+          : super.shouldInterceptRequest(view, url);
+    }
+
+    @Override
+    public WebResourceResponse shouldInterceptRequest(
+        android.webkit.WebView view, WebResourceRequest request) {
+      return mClient != null
+          ? mClient.shouldInterceptRequest(view, request)
+          : super.shouldInterceptRequest(view, request);
+    }
+
     @Synthetic
-    String mPendingUrl, mPendingHtml;
-
-    public WebView(Context context) {
-        this(context, null);
+    void wrap(WebViewClient client) {
+      mClient = client;
     }
-
-    public WebView(Context context, AttributeSet attrs) {
-        this(context, attrs, 0);
-    }
-
-    public WebView(Context context, AttributeSet attrs, int defStyleAttr) {
-        super(context, attrs, defStyleAttr);
-        super.setWebViewClient(mClient);
-    }
-
-    @Override
-    public void setWebViewClient(WebViewClient client) {
-        mClient.wrap(client);
-    }
-
-    @Override
-    public boolean canGoBack() {
-        return TextUtils.isEmpty(mPendingUrl) && super.canGoBack();
-    }
-
-    public void reloadUrl(String url) {
-        if (getProgress() < 100) {
-            stopLoading(); // this will fire onPageFinished for current URL
-        }
-        mPendingUrl = url;
-        loadUrl(BLANK); // clear current web resources, load pending URL upon onPageFinished
-    }
-
-    public void reloadHtml(String html) {
-        mPendingHtml = html;
-        reloadUrl(FILE);
-    }
-
-    static class HistoryWebViewClient extends WebViewClient {
-        private WebViewClient mClient;
-
-        @Override
-        public void onPageStarted(android.webkit.WebView view, String url, Bitmap favicon) {
-            super.onPageStarted(view, url, favicon);
-            view.pageUp(true);
-            WebView webView = (WebView) view;
-            if (AppUtils.urlEquals(url, webView.mPendingUrl)) {
-                view.setVisibility(VISIBLE);
-            }
-            if (mClient != null) {
-                mClient.onPageStarted(view, url, favicon);
-            }
-        }
-
-        @Override
-        public void onPageFinished(android.webkit.WebView view, String url) {
-            super.onPageFinished(view, url);
-            WebView webView = (WebView) view;
-            if (TextUtils.equals(url, BLANK)) { // has pending reload, open corresponding URL
-                if (!TextUtils.isEmpty(webView.mPendingHtml)) {
-                    view.loadDataWithBaseURL(webView.mPendingUrl, webView.mPendingHtml,
-                            "text/html", "UTF-8", webView.mPendingUrl);
-                } else {
-                    view.loadUrl(webView.mPendingUrl);
-                }
-            } else if (!TextUtils.isEmpty(webView.mPendingUrl) &&
-                    TextUtils.equals(url, webView.mPendingUrl)) { // reload done, clear history
-                webView.mPendingUrl = null;
-                webView.mPendingHtml = null;
-                view.clearHistory();
-            }
-            if (mClient != null) {
-                mClient.onPageFinished(view, url);
-            }
-        }
-
-        @SuppressWarnings("deprecation")
-        @Override
-        public WebResourceResponse shouldInterceptRequest(android.webkit.WebView view, String url) {
-            return mClient != null ? mClient.shouldInterceptRequest(view, url)
-                    : super.shouldInterceptRequest(view, url);
-        }
-
-        @Override
-        public WebResourceResponse shouldInterceptRequest(android.webkit.WebView view, WebResourceRequest request) {
-            return mClient != null ? mClient.shouldInterceptRequest(view, request)
-                    : super.shouldInterceptRequest(view, request);
-        }
-
-        @Synthetic
-        void wrap(WebViewClient client) {
-            mClient = client;
-        }
-    }
+  }
 }

--- a/app/src/test/java/io/github/sheepdestroyer/materialisheep/widget/CacheableWebViewTest.java
+++ b/app/src/test/java/io/github/sheepdestroyer/materialisheep/widget/CacheableWebViewTest.java
@@ -1,11 +1,9 @@
 package io.github.sheepdestroyer.materialisheep.widget;
 
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 import android.app.Application;
 import androidx.test.core.app.ApplicationProvider;
-import io.github.sheepdestroyer.materialisheep.BuildConfig;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -15,18 +13,18 @@ import org.robolectric.annotation.Config;
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 34) // Robolectric supports up to 34 currently, checking if 36 works might fail
 public class CacheableWebViewTest {
-    private CacheableWebView webView;
+  private CacheableWebView webView;
 
-    @Before
-    public void setUp() {
-        Application application = ApplicationProvider.getApplicationContext();
-        webView = new CacheableWebView(application);
-    }
+  @Before
+  public void setUp() {
+    Application application = ApplicationProvider.getApplicationContext();
+    webView = new CacheableWebView(application);
+  }
 
-    @Test
-    public void testFileAccessDisabledByDefault() {
-        assertFalse(webView.getSettings().getAllowFileAccess());
-        assertFalse(webView.getSettings().getAllowFileAccessFromFileURLs());
-        assertFalse(webView.getSettings().getAllowUniversalAccessFromFileURLs());
-    }
+  @Test
+  public void testFileAccessDisabledByDefault() {
+    assertFalse(webView.getSettings().getAllowFileAccess());
+    assertFalse(webView.getSettings().getAllowFileAccessFromFileURLs());
+    assertFalse(webView.getSettings().getAllowUniversalAccessFromFileURLs());
+  }
 }

--- a/app/src/test/java/io/github/sheepdestroyer/materialisheep/widget/CacheableWebViewTest.java
+++ b/app/src/test/java/io/github/sheepdestroyer/materialisheep/widget/CacheableWebViewTest.java
@@ -1,0 +1,32 @@
+package io.github.sheepdestroyer.materialisheep.widget;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import android.app.Application;
+import androidx.test.core.app.ApplicationProvider;
+import io.github.sheepdestroyer.materialisheep.BuildConfig;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 34) // Robolectric supports up to 34 currently, checking if 36 works might fail
+public class CacheableWebViewTest {
+    private CacheableWebView webView;
+
+    @Before
+    public void setUp() {
+        Application application = ApplicationProvider.getApplicationContext();
+        webView = new CacheableWebView(application);
+    }
+
+    @Test
+    public void testFileAccessDisabledByDefault() {
+        assertFalse(webView.getSettings().getAllowFileAccess());
+        assertFalse(webView.getSettings().getAllowFileAccessFromFileURLs());
+        assertFalse(webView.getSettings().getAllowUniversalAccessFromFileURLs());
+    }
+}


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Restrict WebView file access

**Severity:** HIGH
**Vulnerability:**
The `CacheableWebView` class enabled `setAllowFileAccess(true)` globally, and the `WebView` base class used `file:///` as a base URL when loading HTML content. This could allow malicious content to access local files if it bypassed other restrictions.

**Impact:**
If an attacker could inject malicious HTML or script into the WebView (e.g., via a compromised article or MITM), they might be able to read sensitive local files from the application's data directory.

**Fix:**
1.  Modified `CacheableWebView` to disable `setAllowFileAccess` by default.
2.  Updated logic to only enable `setAllowFileAccess(true)` temporarily when loading a specific, verified cache file.
3.  Changed the base URL for `loadDataWithBaseURL` in `WebView` from `file:///` to `file:///android_asset/`, restricting access scope to assets only.
4.  Explicitly disabled `setAllowFileAccessFromFileURLs` and `setAllowUniversalAccessFromFileURLs`.

**Verification:**
-   Added `CacheableWebViewTest` to verify that file access settings are disabled by default.
-   Ran unit tests to ensure no regressions in caching logic.

---
*PR created automatically by Jules for task [9396335781179605306](https://jules.google.com/task/9396335781179605306) started by @sheepdestroyer*

## Summary by Sourcery

Harden WebView file access and document the resolved vulnerability while adding regression tests.

Bug Fixes:
- Disable WebView file access by default and only enable it when loading verified cache files to prevent unauthorized local file reads.

Enhancements:
- Restrict the WebView base file URL to the android_asset directory instead of the root file scheme for loaded HTML content.

Documentation:
- Add a Sentinel security journal entry documenting the WebView file access vulnerability, its impact, and prevention measures.

Tests:
- Introduce a Robolectric test ensuring CacheableWebView file access settings are disabled by default.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Restrict `CacheableWebView` file access by default and change `WebView` base URL to enhance security.
> 
>   - **Security Fix**:
>     - `CacheableWebView`: Disable `setAllowFileAccess` by default; enable only for verified cache files.
>     - `WebView`: Change base URL in `loadDataWithBaseURL` from `file:///` to `file:///android_asset/`.
>     - Disable `setAllowFileAccessFromFileURLs` and `setAllowUniversalAccessFromFileURLs`.
>   - **Testing**:
>     - Add `CacheableWebViewTest` to verify file access settings are disabled by default.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sheepdestroyer%2Fmaterialisheep&utm_source=github&utm_medium=referral)<sup> for 6da007237e1e96d6e075323ed218b9d8aa3d0a18. You can [customize](https://app.ellipsis.dev/sheepdestroyer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Hardened WebView file access controls. File access is now disabled by default and selectively enabled only when loading cached content.
  * Updated asset loading mechanism to use more restrictive paths.

* **Tests**
  * Added verification tests for default file access restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->