### PR TITLE
⚡ Bolt: Optimize viewed state tracking in StoryRecyclerViewAdapter

### DIFF
--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/StoryRecyclerViewAdapter.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/StoryRecyclerViewAdapter.java
@@ -567,6 +567,7 @@ public class StoryRecyclerViewAdapter extends
         if (item == null || !isItemAvailable(item) || item.isViewed()) {
             return;
         }
+        item.setIsViewed(true); // Optimistically mark as viewed to avoid repeated processing
         mSessionManager.view(item.getId());
     }
 

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/StoryRecyclerViewAdapter.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/StoryRecyclerViewAdapter.java
@@ -16,38 +16,32 @@
 
 package io.github.sheepdestroyer.materialisheep.widget;
 
-import androidx.lifecycle.Observer;
+import static androidx.recyclerview.widget.RecyclerView.NO_POSITION;
+import static io.github.sheepdestroyer.materialisheep.DataModule.HN;
+import static io.github.sheepdestroyer.materialisheep.Preferences.SwipeAction.Save;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
-import androidx.annotation.Nullable;
-import androidx.core.content.ContextCompat;
-import androidx.collection.ArrayMap;
-import androidx.collection.ArraySet;
-import androidx.recyclerview.widget.DiffUtil;
-import androidx.recyclerview.widget.ListUpdateCallback;
-import androidx.recyclerview.widget.SortedList;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
-import androidx.recyclerview.widget.ItemTouchHelper;
-import androidx.recyclerview.widget.SortedListAdapterCallback;
 import android.text.TextUtils;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Toast;
-
-import java.lang.ref.WeakReference;
-import java.util.List;
-
-import javax.inject.Inject;
-import javax.inject.Named;
-
-import static io.github.sheepdestroyer.materialisheep.DataModule.HN;
-import io.github.sheepdestroyer.materialisheep.ActivityModule;
+import androidx.annotation.Nullable;
+import androidx.collection.ArrayMap;
+import androidx.collection.ArraySet;
+import androidx.core.content.ContextCompat;
+import androidx.lifecycle.Observer;
+import androidx.recyclerview.widget.DiffUtil;
+import androidx.recyclerview.widget.ItemTouchHelper;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.ListUpdateCallback;
+import androidx.recyclerview.widget.RecyclerView;
+import androidx.recyclerview.widget.SortedList;
+import androidx.recyclerview.widget.SortedListAdapterCallback;
 import io.github.sheepdestroyer.materialisheep.AppUtils;
 import io.github.sheepdestroyer.materialisheep.ComposeActivity;
 import io.github.sheepdestroyer.materialisheep.MaterialisticApplication;
@@ -62,657 +56,678 @@ import io.github.sheepdestroyer.materialisheep.data.ItemManager;
 import io.github.sheepdestroyer.materialisheep.data.MaterialisticDatabase;
 import io.github.sheepdestroyer.materialisheep.data.ResponseListener;
 import io.github.sheepdestroyer.materialisheep.data.SessionManager;
+import java.lang.ref.WeakReference;
+import java.util.List;
+import javax.inject.Inject;
+import javax.inject.Named;
 
-import static androidx.recyclerview.widget.RecyclerView.NO_POSITION;
-import static io.github.sheepdestroyer.materialisheep.Preferences.SwipeAction.Save;
-
-public class StoryRecyclerViewAdapter extends
-        ListRecyclerViewAdapter<ListRecyclerViewAdapter.ItemViewHolder, Item> {
-    private static final String STATE_SHOW_ALL = "state:showAll";
-    private static final String STATE_USERNAME = "state:username";
-    private final Object VOTED = new Object();
-    private final RecyclerView.OnScrollListener mAutoViewScrollListener = new RecyclerView.OnScrollListener() {
+public class StoryRecyclerViewAdapter
+    extends ListRecyclerViewAdapter<ListRecyclerViewAdapter.ItemViewHolder, Item> {
+  private static final String STATE_SHOW_ALL = "state:showAll";
+  private static final String STATE_USERNAME = "state:username";
+  private final Object VOTED = new Object();
+  private final RecyclerView.OnScrollListener mAutoViewScrollListener =
+      new RecyclerView.OnScrollListener() {
         @Override
         public void onScrolled(RecyclerView recyclerView, int dx, int dy) {
-            if (dy > 0) { // scrolling
-                          // down
-                markAsViewed(
-                        ((LinearLayoutManager) recyclerView.getLayoutManager()).findFirstVisibleItemPosition() - 1);
-            }
+          if (dy > 0) { // scrolling
+            // down
+            markAsViewed(
+                ((LinearLayoutManager) recyclerView.getLayoutManager())
+                        .findFirstVisibleItemPosition()
+                    - 1);
+          }
         }
-    };
-    private final Preferences.Observable mPrefObservable = new Preferences.Observable();
-    private final SortedList.Callback<Item> mSortedListCallback = new SortedListAdapterCallback<Item>(this) {
+      };
+  private final Preferences.Observable mPrefObservable = new Preferences.Observable();
+  private final SortedList.Callback<Item> mSortedListCallback =
+      new SortedListAdapterCallback<Item>(this) {
         @Override
         public int compare(Item o1, Item o2) {
-            return o1.getRank() - o2.getRank();
+          return o1.getRank() - o2.getRank();
         }
 
         @Override
         public boolean areContentsTheSame(Item item1, Item item2) {
-            return areItemsTheSame(item1, item2) && item1.getLocalRevision() == item2.getLocalRevision();
+          return areItemsTheSame(item1, item2)
+              && item1.getLocalRevision() == item2.getLocalRevision();
         }
 
         @Override
         public boolean areItemsTheSame(Item item1, Item item2) {
-            return item1.getLongId() == item2.getLongId();
+          return item1.getLongId() == item2.getLongId();
         }
-    };
-    @Inject
-    @Named(HN)
-    ItemManager mItemManager;
-    @Inject
-    SessionManager mSessionManager;
-    @Synthetic
-    final SortedList<Item> mItems = new SortedList<>(Item.class, mSortedListCallback);
-    @Synthetic
-    final ArraySet<Item> mAdded = new ArraySet<>();
-    @Synthetic
-    final ArrayMap<String, Integer> mPromoted = new ArrayMap<>();
-    @Synthetic
-    int mFavoriteRevision = 1;
-    private String mUsername;
-    private boolean mHighlightUpdated = true;
-    private boolean mShowAll = true;
-    private int mCacheMode = ItemManager.MODE_DEFAULT;
-    private ItemTouchHelper mItemTouchHelper;
-    @Synthetic
-    ItemTouchHelperCallback mCallback;
-    @SuppressLint("NotifyDataSetChanged")
-    private final Observer<Uri> mObserver = uri -> {
+      };
+
+  @Inject
+  @Named(HN)
+  ItemManager mItemManager;
+
+  @Inject SessionManager mSessionManager;
+  @Synthetic final SortedList<Item> mItems = new SortedList<>(Item.class, mSortedListCallback);
+  @Synthetic final ArraySet<Item> mAdded = new ArraySet<>();
+  @Synthetic final ArrayMap<String, Integer> mPromoted = new ArrayMap<>();
+  @Synthetic int mFavoriteRevision = 1;
+  private String mUsername;
+  private boolean mHighlightUpdated = true;
+  private boolean mShowAll = true;
+  private int mCacheMode = ItemManager.MODE_DEFAULT;
+  private ItemTouchHelper mItemTouchHelper;
+  @Synthetic ItemTouchHelperCallback mCallback;
+
+  @SuppressLint("NotifyDataSetChanged")
+  private final Observer<Uri> mObserver =
+      uri -> {
         if (uri == null) {
-            return;
+          return;
         }
         if (FavoriteManager.Companion.isCleared(uri)) {
-            mFavoriteRevision++; // invalidate all favorite statuses
-            notifyDataSetChanged();
-            return;
+          mFavoriteRevision++; // invalidate all favorite statuses
+          notifyDataSetChanged();
+          return;
         }
         int position = NO_POSITION;
         for (int i = 0; i < mItems.size(); i++) {
-            if (TextUtils.equals(mItems.get(i).getId(), uri.getLastPathSegment())) {
-                position = i;
-                break;
-            }
+          if (TextUtils.equals(mItems.get(i).getId(), uri.getLastPathSegment())) {
+            position = i;
+            break;
+          }
         }
         if (position == NO_POSITION) {
-            return;
+          return;
         }
         Item item = mItems.get(position);
         if (FavoriteManager.Companion.isAdded(uri)) {
-            item.setFavorite(true);
-            item.setLocalRevision(mFavoriteRevision);
+          item.setFavorite(true);
+          item.setLocalRevision(mFavoriteRevision);
         } else if (FavoriteManager.Companion.isRemoved(uri)) {
-            item.setFavorite(false);
-            item.setLocalRevision(mFavoriteRevision);
+          item.setFavorite(false);
+          item.setLocalRevision(mFavoriteRevision);
         } else {
-            item.setIsViewed(true);
+          item.setIsViewed(true);
         }
         notifyItemChanged(position);
-    };
-    private UpdateListener mUpdateListener;
+      };
 
-    public interface UpdateListener {
-        void onUpdated(boolean showAll, int itemCount, View.OnClickListener actionClickListener);
-    }
+  private UpdateListener mUpdateListener;
 
-    public StoryRecyclerViewAdapter(Context context) {
-        super(context);
-        ((MaterialisticApplication) context.getApplicationContext()).applicationComponent.inject(this);
-        mCallback = new ItemTouchHelperCallback(context,
-                Preferences.getListSwipePreferences(context)) {
-            @Override
-            public int getSwipeDirs(RecyclerView recyclerView, RecyclerView.ViewHolder viewHolder) {
-                int position = viewHolder.getBindingAdapterPosition();
-                if (position == NO_POSITION) {
-                    return 0;
-                }
-                Item item = getItem(position);
-                if (item == null) {
-                    return 0;
-                }
-                mSaved = item.isFavorite();
-                return checkSwipeDir(0, ItemTouchHelper.LEFT, mCallback.getLeftSwipeAction(), item) |
-                        checkSwipeDir(0, ItemTouchHelper.RIGHT, mCallback.getRightSwipeAction(), item);
+  public interface UpdateListener {
+    void onUpdated(boolean showAll, int itemCount, View.OnClickListener actionClickListener);
+  }
+
+  public StoryRecyclerViewAdapter(Context context) {
+    super(context);
+    ((MaterialisticApplication) context.getApplicationContext()).applicationComponent.inject(this);
+    mCallback =
+        new ItemTouchHelperCallback(context, Preferences.getListSwipePreferences(context)) {
+          @Override
+          public int getSwipeDirs(RecyclerView recyclerView, RecyclerView.ViewHolder viewHolder) {
+            int position = viewHolder.getBindingAdapterPosition();
+            if (position == NO_POSITION) {
+              return 0;
             }
-
-            @Override
-            public void onSwiped(RecyclerView.ViewHolder viewHolder, int direction) {
-                Preferences.SwipeAction action = direction == ItemTouchHelper.LEFT ? getLeftSwipeAction()
-                        : getRightSwipeAction();
-                int position = viewHolder.getBindingAdapterPosition();
-                if (position == NO_POSITION) {
-                    return;
-                }
-                Item item = getItem(position);
-                if (item == null) {
-                    return;
-                }
-                switch (action) {
-                    case Save:
-                        toggleSave(item);
-                        break;
-                    case Refresh:
-                        refresh(item, viewHolder);
-                        break;
-                    case Vote:
-                        int votePosition = viewHolder.getBindingAdapterPosition();
-                        if (votePosition == NO_POSITION) {
-                            return;
-                        }
-                        notifyItemChanged(votePosition);
-                        vote(item, viewHolder);
-                        break;
-                    case Share:
-                        notifyItemChanged(viewHolder.getBindingAdapterPosition());
-                        AppUtils.share(mContext, item.getDisplayedTitle(), item.getUrl());
-                        break;
-                }
+            Item item = getItem(position);
+            if (item == null) {
+              return 0;
             }
+            mSaved = item.isFavorite();
+            return checkSwipeDir(0, ItemTouchHelper.LEFT, mCallback.getLeftSwipeAction(), item)
+                | checkSwipeDir(0, ItemTouchHelper.RIGHT, mCallback.getRightSwipeAction(), item);
+          }
 
-            private int checkSwipeDir(int swipeDirs, int swipeDir, Preferences.SwipeAction action, Item item) {
-                switch (action) {
-                    case None:
-                        break;
-                    case Vote:
-                        if (!item.isVoted() && !item.isPendingVoted()) {
-                            swipeDirs |= swipeDir;
-                        }
-                        break;
-                    default:
-                        swipeDirs |= swipeDir;
-                        break;
-                }
-                return swipeDirs;
+          @Override
+          public void onSwiped(RecyclerView.ViewHolder viewHolder, int direction) {
+            Preferences.SwipeAction action =
+                direction == ItemTouchHelper.LEFT ? getLeftSwipeAction() : getRightSwipeAction();
+            int position = viewHolder.getBindingAdapterPosition();
+            if (position == NO_POSITION) {
+              return;
             }
-
-        };
-        mItemTouchHelper = new ItemTouchHelper(mCallback);
-    }
-
-    @SuppressLint("NotifyDataSetChanged")
-    @Override
-    public void onAttachedToRecyclerView(RecyclerView recyclerView) {
-        super.onAttachedToRecyclerView(recyclerView);
-        MaterialisticDatabase.getInstance(recyclerView.getContext()).getLiveData().observeForever(mObserver);
-        mItemTouchHelper.attachToRecyclerView(recyclerView);
-        toggleAutoMarkAsViewed(recyclerView);
-        mPrefObservable.subscribe(recyclerView.getContext(),
-                (key, contextChanged) -> {
-                    mCallback.setSwipePreferences(recyclerView.getContext(),
-                            Preferences.getListSwipePreferences(recyclerView.getContext()));
-                    notifyDataSetChanged();
-                },
-                R.string.pref_list_swipe_left,
-                R.string.pref_list_swipe_right);
-    }
-
-    @Override
-    public void onDetachedFromRecyclerView(RecyclerView recyclerView) {
-        super.onDetachedFromRecyclerView(recyclerView);
-        MaterialisticDatabase.getInstance(recyclerView.getContext()).getLiveData().removeObserver(mObserver);
-        mItemTouchHelper.attachToRecyclerView(null);
-        mPrefObservable.unsubscribe(recyclerView.getContext());
-    }
-
-    @Override
-    protected ItemViewHolder create(ViewGroup parent, int viewType) {
-        return new ItemViewHolder(mInflater.inflate(R.layout.item_story, parent, false));
-    }
-
-    @Override
-    public void onBindViewHolder(ItemViewHolder holder, int position, List<Object> payloads) {
-        if (payloads.contains(VOTED)) {
-            holder.animateVote(getItem(position).getScore());
-        } else {
-            super.onBindViewHolder(holder, position, payloads);
-        }
-    }
-
-    @Override
-    public int getItemCount() {
-        if (mShowAll) {
-            return mItems.size();
-        } else {
-            return mAdded.size();
-        }
-    }
-
-    @Override
-    public Bundle saveState() {
-        Bundle savedState = super.saveState();
-        savedState.putBoolean(STATE_SHOW_ALL, mShowAll);
-        savedState.putString(STATE_USERNAME, mUsername);
-        return savedState;
-    }
-
-    @Override
-    public void restoreState(Bundle savedState) {
-        if (savedState == null) {
-            return;
-        }
-        super.restoreState(savedState);
-        mShowAll = savedState.getBoolean(STATE_SHOW_ALL, true);
-        mUsername = savedState.getString(STATE_USERNAME);
-    }
-
-    public void setUpdateListener(UpdateListener updateListener) {
-        mUpdateListener = updateListener;
-    }
-
-    @Synthetic
-    int getPosition(Item item) {
-        return mItems.indexOf(item);
-    }
-
-    public SortedList<Item> getItems() {
-        return mItems;
-    }
-
-    public void setItems(Item[] items) {
-        setUpdated(items);
-        mItems.clear();
-        mItems.addAll(items);
-    }
-
-    public void setHighlightUpdated(boolean highlightUpdated) {
-        mHighlightUpdated = highlightUpdated;
-    }
-
-    public void setShowAll(boolean showAll) {
-        mShowAll = showAll;
-    }
-
-    @SuppressLint("NotifyDataSetChanged")
-    public void initDisplayOptions(RecyclerView recyclerView) {
-        mHighlightUpdated = Preferences.highlightUpdatedEnabled(recyclerView.getContext());
-        mUsername = Preferences.getUsername(recyclerView.getContext());
-        if (isAttached()) {
-            toggleAutoMarkAsViewed(recyclerView);
-            notifyDataSetChanged();
-        }
-    }
-
-    public void toggleSave(String itemId) {
-        int position = NO_POSITION;
-        for (int i = 0; i < mItems.size(); i++) {
-            if (TextUtils.equals(mItems.get(i).getId(), itemId)) {
-                position = i;
+            Item item = getItem(position);
+            if (item == null) {
+              return;
+            }
+            switch (action) {
+              case Save:
+                toggleSave(item);
+                break;
+              case Refresh:
+                refresh(item, viewHolder);
+                break;
+              case Vote:
+                int votePosition = viewHolder.getBindingAdapterPosition();
+                if (votePosition == NO_POSITION) {
+                  return;
+                }
+                notifyItemChanged(votePosition);
+                vote(item, viewHolder);
+                break;
+              case Share:
+                notifyItemChanged(viewHolder.getBindingAdapterPosition());
+                AppUtils.share(mContext, item.getDisplayedTitle(), item.getUrl());
                 break;
             }
-        }
-        if (position == NO_POSITION) {
-            return;
-        }
-        toggleSave(mItems.get(position));
-    }
+          }
 
-    @Override
-    protected void loadItem(final int adapterPosition) {
-        Item item = getItem(adapterPosition);
-        if (item.getLocalRevision() == 0) {
-            return;
-        }
-        item.setLocalRevision(0);
-        mItemManager.getItem(item.getId(), getItemCacheMode(), new ItemResponseListener(this, item));
-    }
+          private int checkSwipeDir(
+              int swipeDirs, int swipeDir, Preferences.SwipeAction action, Item item) {
+            switch (action) {
+              case None:
+                break;
+              case Vote:
+                if (!item.isVoted() && !item.isPendingVoted()) {
+                  swipeDirs |= swipeDir;
+                }
+                break;
+              default:
+                swipeDirs |= swipeDir;
+                break;
+            }
+            return swipeDirs;
+          }
+        };
+    mItemTouchHelper = new ItemTouchHelper(mCallback);
+  }
 
-    @Override
-    protected void bindItem(final ItemViewHolder holder, int position) {
-        final Item story = getItem(position);
-        if (mHighlightUpdated) {
-            holder.setUpdated(story,
-                    mAdded.contains(story),
-                    mPromoted.containsKey(story.getId()) ? mPromoted.get(story.getId()) : 0);
-        }
-        holder.setChecked(isSelected(story.getId()) ||
-                !TextUtils.isEmpty(mUsername) && TextUtils.equals(mUsername, story.getBy()));
-        holder.setViewed(story.isViewed());
-        if (story.getLocalRevision() < mFavoriteRevision) {
-            story.setFavorite(false);
-        }
-        holder.setFavorite(story.isFavorite());
-        holder.bindMoreOptions(anchor -> showMoreOptions(anchor, story, holder), true);
-    }
+  @SuppressLint("NotifyDataSetChanged")
+  @Override
+  public void onAttachedToRecyclerView(RecyclerView recyclerView) {
+    super.onAttachedToRecyclerView(recyclerView);
+    MaterialisticDatabase.getInstance(recyclerView.getContext())
+        .getLiveData()
+        .observeForever(mObserver);
+    mItemTouchHelper.attachToRecyclerView(recyclerView);
+    toggleAutoMarkAsViewed(recyclerView);
+    mPrefObservable.subscribe(
+        recyclerView.getContext(),
+        (key, contextChanged) -> {
+          mCallback.setSwipePreferences(
+              recyclerView.getContext(),
+              Preferences.getListSwipePreferences(recyclerView.getContext()));
+          notifyDataSetChanged();
+        },
+        R.string.pref_list_swipe_left,
+        R.string.pref_list_swipe_right);
+  }
 
-    @Override
-    protected boolean isItemAvailable(Item item) {
-        return item != null && item.getLocalRevision() > 0;
-    }
+  @Override
+  public void onDetachedFromRecyclerView(RecyclerView recyclerView) {
+    super.onDetachedFromRecyclerView(recyclerView);
+    MaterialisticDatabase.getInstance(recyclerView.getContext())
+        .getLiveData()
+        .removeObserver(mObserver);
+    mItemTouchHelper.attachToRecyclerView(null);
+    mPrefObservable.unsubscribe(recyclerView.getContext());
+  }
 
-    @Override
-    protected Item getItem(int position) {
-        if (position < 0 || position >= getItems().size()) {
-            return null;
-        }
-        return getItems().get(position);
-    }
+  @Override
+  protected ItemViewHolder create(ViewGroup parent, int viewType) {
+    return new ItemViewHolder(mInflater.inflate(R.layout.item_story, parent, false));
+  }
 
-    @Override
-    protected int getItemCacheMode() {
-        return mCacheMode;
+  @Override
+  public void onBindViewHolder(ItemViewHolder holder, int position, List<Object> payloads) {
+    if (payloads.contains(VOTED)) {
+      holder.animateVote(getItem(position).getScore());
+    } else {
+      super.onBindViewHolder(holder, position, payloads);
     }
+  }
 
-    private void setUpdated(Item[] items) {
-        if (!mHighlightUpdated || getItems() == null) {
-            return;
-        }
-        if (mItems.size() == 0) {
-            return;
-        }
-        mAdded.clear();
-        mPromoted.clear();
-        DiffUtil.calculateDiff(new DiffUtil.Callback() {
-            @Override
-            public int getOldListSize() {
+  @Override
+  public int getItemCount() {
+    if (mShowAll) {
+      return mItems.size();
+    } else {
+      return mAdded.size();
+    }
+  }
+
+  @Override
+  public Bundle saveState() {
+    Bundle savedState = super.saveState();
+    savedState.putBoolean(STATE_SHOW_ALL, mShowAll);
+    savedState.putString(STATE_USERNAME, mUsername);
+    return savedState;
+  }
+
+  @Override
+  public void restoreState(Bundle savedState) {
+    if (savedState == null) {
+      return;
+    }
+    super.restoreState(savedState);
+    mShowAll = savedState.getBoolean(STATE_SHOW_ALL, true);
+    mUsername = savedState.getString(STATE_USERNAME);
+  }
+
+  public void setUpdateListener(UpdateListener updateListener) {
+    mUpdateListener = updateListener;
+  }
+
+  @Synthetic
+  int getPosition(Item item) {
+    return mItems.indexOf(item);
+  }
+
+  public SortedList<Item> getItems() {
+    return mItems;
+  }
+
+  public void setItems(Item[] items) {
+    setUpdated(items);
+    mItems.clear();
+    mItems.addAll(items);
+  }
+
+  public void setHighlightUpdated(boolean highlightUpdated) {
+    mHighlightUpdated = highlightUpdated;
+  }
+
+  public void setShowAll(boolean showAll) {
+    mShowAll = showAll;
+  }
+
+  @SuppressLint("NotifyDataSetChanged")
+  public void initDisplayOptions(RecyclerView recyclerView) {
+    mHighlightUpdated = Preferences.highlightUpdatedEnabled(recyclerView.getContext());
+    mUsername = Preferences.getUsername(recyclerView.getContext());
+    if (isAttached()) {
+      toggleAutoMarkAsViewed(recyclerView);
+      notifyDataSetChanged();
+    }
+  }
+
+  public void toggleSave(String itemId) {
+    int position = NO_POSITION;
+    for (int i = 0; i < mItems.size(); i++) {
+      if (TextUtils.equals(mItems.get(i).getId(), itemId)) {
+        position = i;
+        break;
+      }
+    }
+    if (position == NO_POSITION) {
+      return;
+    }
+    toggleSave(mItems.get(position));
+  }
+
+  @Override
+  protected void loadItem(final int adapterPosition) {
+    Item item = getItem(adapterPosition);
+    if (item.getLocalRevision() == 0) {
+      return;
+    }
+    item.setLocalRevision(0);
+    mItemManager.getItem(item.getId(), getItemCacheMode(), new ItemResponseListener(this, item));
+  }
+
+  @Override
+  protected void bindItem(final ItemViewHolder holder, int position) {
+    final Item story = getItem(position);
+    if (mHighlightUpdated) {
+      holder.setUpdated(
+          story,
+          mAdded.contains(story),
+          mPromoted.containsKey(story.getId()) ? mPromoted.get(story.getId()) : 0);
+    }
+    holder.setChecked(
+        isSelected(story.getId())
+            || !TextUtils.isEmpty(mUsername) && TextUtils.equals(mUsername, story.getBy()));
+    holder.setViewed(story.isViewed());
+    if (story.getLocalRevision() < mFavoriteRevision) {
+      story.setFavorite(false);
+    }
+    holder.setFavorite(story.isFavorite());
+    holder.bindMoreOptions(anchor -> showMoreOptions(anchor, story, holder), true);
+  }
+
+  @Override
+  protected boolean isItemAvailable(Item item) {
+    return item != null && item.getLocalRevision() > 0;
+  }
+
+  @Override
+  protected Item getItem(int position) {
+    if (position < 0 || position >= getItems().size()) {
+      return null;
+    }
+    return getItems().get(position);
+  }
+
+  @Override
+  protected int getItemCacheMode() {
+    return mCacheMode;
+  }
+
+  private void setUpdated(Item[] items) {
+    if (!mHighlightUpdated || getItems() == null) {
+      return;
+    }
+    if (mItems.size() == 0) {
+      return;
+    }
+    mAdded.clear();
+    mPromoted.clear();
+    DiffUtil.calculateDiff(
+            new DiffUtil.Callback() {
+              @Override
+              public int getOldListSize() {
                 return mItems.size();
-            }
+              }
 
-            @Override
-            public int getNewListSize() {
+              @Override
+              public int getNewListSize() {
                 return items.length;
-            }
+              }
 
-            @Override
-            public boolean areItemsTheSame(int oldItemPosition, int newItemPosition) {
-                return mItems.get(oldItemPosition).getLongId() == items[newItemPosition].getLongId();
-            }
+              @Override
+              public boolean areItemsTheSame(int oldItemPosition, int newItemPosition) {
+                return mItems.get(oldItemPosition).getLongId()
+                    == items[newItemPosition].getLongId();
+              }
 
-            @Override
-            public boolean areContentsTheSame(int oldItemPosition, int newItemPosition) {
+              @Override
+              public boolean areContentsTheSame(int oldItemPosition, int newItemPosition) {
                 return areItemsTheSame(oldItemPosition, newItemPosition);
-            }
-        }).dispatchUpdatesTo(new ListUpdateCallback() {
-            @Override
-            public void onInserted(int position, int count) {
+              }
+            })
+        .dispatchUpdatesTo(
+            new ListUpdateCallback() {
+              @Override
+              public void onInserted(int position, int count) {
                 mAdded.add(items[position]);
                 notifyUpdated();
-            }
+              }
 
-            @Override
-            public void onRemoved(int position, int count) {
+              @Override
+              public void onRemoved(int position, int count) {
                 // no-op
-            }
+              }
 
-            @Override
-            public void onMoved(int fromPosition, int toPosition) {
+              @Override
+              public void onMoved(int fromPosition, int toPosition) {
                 if (toPosition < fromPosition) {
-                    mPromoted.put(mItems.get(fromPosition).getId(), fromPosition - toPosition);
+                  mPromoted.put(mItems.get(fromPosition).getId(), fromPosition - toPosition);
                 }
-            }
+              }
 
-            @Override
-            public void onChanged(int position, int count, Object payload) {
+              @Override
+              public void onChanged(int position, int count, Object payload) {
                 // no-op
-            }
-        });
-    }
-
-    @SuppressLint("NotifyDataSetChanged")
-    @Synthetic
-    void notifyUpdated() {
-        if (mUpdateListener != null) {
-            mUpdateListener.onUpdated(mShowAll, mAdded.size(), v -> {
-                setShowAll(!mShowAll);
-                notifyUpdated();
-                notifyDataSetChanged();
+              }
             });
-        }
+  }
+
+  @SuppressLint("NotifyDataSetChanged")
+  @Synthetic
+  void notifyUpdated() {
+    if (mUpdateListener != null) {
+      mUpdateListener.onUpdated(
+          mShowAll,
+          mAdded.size(),
+          v -> {
+            setShowAll(!mShowAll);
+            notifyUpdated();
+            notifyDataSetChanged();
+          });
+    }
+  }
+
+  @Synthetic
+  void onItemLoaded(Item item) {
+    int position = getItems().indexOf(item);
+    // ignore changes if item was invalidated by refresh / filter
+    if (position >= 0 && position < getItemCount()) {
+      notifyItemChanged(position);
+    }
+  }
+
+  @Synthetic
+  void showMoreOptions(View v, final Item story, final ItemViewHolder holder) {
+    mPopupMenu
+        .create(mContext, v, Gravity.NO_GRAVITY)
+        .inflate(R.menu.menu_contextual_story)
+        .setMenuItemTitle(
+            R.id.menu_contextual_save, story.isFavorite() ? R.string.unsave : R.string.save)
+        .setMenuItemVisible(
+            R.id.menu_contextual_save, !mCallback.hasAction(Preferences.SwipeAction.Save))
+        .setMenuItemVisible(
+            R.id.menu_contextual_vote, !mCallback.hasAction(Preferences.SwipeAction.Vote))
+        .setMenuItemVisible(
+            R.id.menu_contextual_refresh, !mCallback.hasAction(Preferences.SwipeAction.Refresh))
+        .setOnMenuItemClickListener(
+            item -> {
+              if (item.getItemId() == R.id.menu_contextual_save) {
+                toggleSave(story);
+                return true;
+              }
+              if (item.getItemId() == R.id.menu_contextual_vote) {
+                vote(story, holder);
+                return true;
+              }
+              if (item.getItemId() == R.id.menu_contextual_refresh) {
+                refresh(story, holder);
+                return true;
+              }
+              if (item.getItemId() == R.id.menu_contextual_comment) {
+                mContext.startActivity(
+                    new Intent(mContext, ComposeActivity.class)
+                        .putExtra(ComposeActivity.EXTRA_PARENT_ID, story.getId())
+                        .putExtra(ComposeActivity.EXTRA_PARENT_TEXT, story.getDisplayedTitle()));
+                return true;
+              }
+              if (item.getItemId() == R.id.menu_contextual_profile) {
+                mContext.startActivity(
+                    new Intent(mContext, UserActivity.class)
+                        .putExtra(UserActivity.EXTRA_USERNAME, story.getBy()));
+                return true;
+              }
+              if (item.getItemId() == R.id.menu_contextual_share) {
+                AppUtils.share(mContext, story.getDisplayedTitle(), story.getUrl());
+                return true;
+              }
+              return false;
+            })
+        .show();
+  }
+
+  @Synthetic
+  void toggleSave(final Item story) {
+    if (!story.isFavorite()) {
+      mFavoriteManager.add(mContext, story);
+    } else {
+      mFavoriteManager.remove(mContext, story.getId());
+    }
+  }
+
+  @Synthetic
+  void refresh(Item story, RecyclerView.ViewHolder holder) {
+    int position = holder.getBindingAdapterPosition();
+    if (position == NO_POSITION) {
+      return;
+    }
+    story.setLocalRevision(-1);
+    notifyItemChanged(position);
+  }
+
+  @Synthetic
+  void vote(final Item story, final RecyclerView.ViewHolder holder) {
+    if (!mUserServices.voteUp(mContext, story.getId(), new VoteCallback(this, story))) {
+      AppUtils.showLogin(mContext, mAlertDialogBuilder);
+    }
+  }
+
+  @Synthetic
+  void onVoted(int position, Boolean successful) {
+    if (successful == null) {
+      Toast.makeText(mContext, R.string.vote_failed, Toast.LENGTH_SHORT).show();
+    } else if (successful) {
+      Toast.makeText(mContext, R.string.voted, Toast.LENGTH_SHORT).show();
+      if (position != NO_POSITION && position < getItemCount()) {
+        notifyItemChanged(position, VOTED);
+      }
+    }
+  }
+
+  public void setCacheMode(int cacheMode) {
+    mCacheMode = cacheMode;
+  }
+
+  @Synthetic
+  void markAsViewed(int position) {
+    if (position < 0) {
+      return;
+    }
+    Item item = mItems != null && position < mItems.size() ? mItems.get(position) : null;
+    if (item == null || !isItemAvailable(item) || item.isViewed()) {
+      return;
+    }
+    item.setIsViewed(true); // Optimistically mark as viewed to avoid repeated processing
+    mSessionManager.view(item.getId());
+  }
+
+  private void toggleAutoMarkAsViewed(RecyclerView recyclerView) {
+    if (Preferences.autoMarkAsViewed(recyclerView.getContext())) {
+      recyclerView.addOnScrollListener(mAutoViewScrollListener);
+    } else {
+      recyclerView.removeOnScrollListener(mAutoViewScrollListener);
+    }
+  }
+
+  static class ItemResponseListener implements ResponseListener<Item> {
+    private final WeakReference<StoryRecyclerViewAdapter> mAdapter;
+    private final Item mPartialItem;
+
+    @Synthetic
+    ItemResponseListener(StoryRecyclerViewAdapter adapter, Item partialItem) {
+      mAdapter = new WeakReference<>(adapter);
+      mPartialItem = partialItem;
+    }
+
+    @Override
+    public void onResponse(@Nullable Item response) {
+      if (mAdapter.get() != null && mAdapter.get().isAttached() && response != null) {
+        mPartialItem.populate(response);
+        mAdapter.get().onItemLoaded(mPartialItem);
+      }
+    }
+
+    @Override
+    public void onError(String errorMessage) {
+      // do nothing
+    }
+  }
+
+  static class VoteCallback extends UserServices.Callback {
+    private final WeakReference<StoryRecyclerViewAdapter> mAdapter;
+    private final Item mItem;
+
+    @Synthetic
+    VoteCallback(StoryRecyclerViewAdapter adapter, Item item) {
+      mAdapter = new WeakReference<>(adapter);
+      mItem = item;
+    }
+
+    @Override
+    public void onDone(boolean successful) {
+      // TODO update locally only, as API does not update instantly
+      mItem.incrementScore();
+      mItem.clearPendingVoted();
+      StoryRecyclerViewAdapter adapter = mAdapter.get();
+      if (adapter != null && adapter.isAttached()) {
+        adapter.onVoted(adapter.getPosition(mItem), successful);
+      }
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+      StoryRecyclerViewAdapter adapter = mAdapter.get();
+      if (adapter != null && adapter.isAttached()) {
+        adapter.onVoted(adapter.getPosition(mItem), null);
+      }
+    }
+  }
+
+  abstract static class ItemTouchHelperCallback extends PeekabooTouchHelperCallback {
+    private final String mSaveText;
+    private final String mUnsaveText;
+    boolean mSaved;
+    private Preferences.SwipeAction[] mSwipePreferences;
+    private String[] mTexts = new String[2];
+    private int[] mColors = new int[2];
+
+    ItemTouchHelperCallback(Context context, Preferences.SwipeAction[] swipePreferences) {
+      super(context);
+      mSaveText = context.getString(R.string.save);
+      mUnsaveText = context.getString(R.string.unsave);
+      setSwipePreferences(context, swipePreferences);
+    }
+
+    @Override
+    protected String getLeftText() {
+      return getLeftSwipeAction() == Save ? getSaveText() : mTexts[0];
+    }
+
+    @Override
+    protected String getRightText() {
+      return getRightSwipeAction() == Save ? getSaveText() : mTexts[1];
+    }
+
+    @Override
+    protected int getLeftTextColor() {
+      return mColors[0];
+    }
+
+    @Override
+    protected int getRightTextColor() {
+      return mColors[1];
     }
 
     @Synthetic
-    void onItemLoaded(Item item) {
-        int position = getItems().indexOf(item);
-        // ignore changes if item was invalidated by refresh / filter
-        if (position >= 0 && position < getItemCount()) {
-            notifyItemChanged(position);
+    void setSwipePreferences(Context context, Preferences.SwipeAction[] swipePreferences) {
+      mSwipePreferences = swipePreferences;
+      for (int i = 0; i < 2; i++) {
+        switch (swipePreferences[i]) {
+          case Vote:
+            mTexts[i] = context.getString(R.string.vote_up);
+            mColors[i] = ContextCompat.getColor(context, R.color.greenA700);
+            break;
+          case Save:
+            mTexts[i] = null; // dynamic text
+            mColors[i] = ContextCompat.getColor(context, R.color.orange500);
+            break;
+          case Refresh:
+            mTexts[i] = context.getString(R.string.refresh);
+            mColors[i] = ContextCompat.getColor(context, R.color.lightBlueA700);
+            break;
+          case Share:
+            mTexts[i] = context.getString(R.string.share);
+            mColors[i] = ContextCompat.getColor(context, R.color.lightBlueA700);
+            break;
+          default:
+            mTexts[i] = null;
+            mColors[i] = 0;
+            break;
         }
+      }
     }
 
-    @Synthetic
-    void showMoreOptions(View v, final Item story, final ItemViewHolder holder) {
-        mPopupMenu.create(mContext, v, Gravity.NO_GRAVITY)
-                .inflate(R.menu.menu_contextual_story)
-                .setMenuItemTitle(R.id.menu_contextual_save,
-                        story.isFavorite() ? R.string.unsave : R.string.save)
-                .setMenuItemVisible(R.id.menu_contextual_save,
-                        !mCallback.hasAction(Preferences.SwipeAction.Save))
-                .setMenuItemVisible(R.id.menu_contextual_vote,
-                        !mCallback.hasAction(Preferences.SwipeAction.Vote))
-                .setMenuItemVisible(R.id.menu_contextual_refresh,
-                        !mCallback.hasAction(Preferences.SwipeAction.Refresh))
-                .setOnMenuItemClickListener(item -> {
-                    if (item.getItemId() == R.id.menu_contextual_save) {
-                        toggleSave(story);
-                        return true;
-                    }
-                    if (item.getItemId() == R.id.menu_contextual_vote) {
-                        vote(story, holder);
-                        return true;
-                    }
-                    if (item.getItemId() == R.id.menu_contextual_refresh) {
-                        refresh(story, holder);
-                        return true;
-                    }
-                    if (item.getItemId() == R.id.menu_contextual_comment) {
-                        mContext.startActivity(new Intent(mContext, ComposeActivity.class)
-                                .putExtra(ComposeActivity.EXTRA_PARENT_ID, story.getId())
-                                .putExtra(ComposeActivity.EXTRA_PARENT_TEXT,
-                                        story.getDisplayedTitle()));
-                        return true;
-                    }
-                    if (item.getItemId() == R.id.menu_contextual_profile) {
-                        mContext.startActivity(new Intent(mContext, UserActivity.class)
-                                .putExtra(UserActivity.EXTRA_USERNAME, story.getBy()));
-                        return true;
-                    }
-                    if (item.getItemId() == R.id.menu_contextual_share) {
-                        AppUtils.share(mContext, story.getDisplayedTitle(), story.getUrl());
-                        return true;
-                    }
-                    return false;
-                })
-                .show();
+    Preferences.SwipeAction getLeftSwipeAction() {
+      return mSwipePreferences == null ? Preferences.SwipeAction.None : mSwipePreferences[0];
     }
 
-    @Synthetic
-    void toggleSave(final Item story) {
-        if (!story.isFavorite()) {
-            mFavoriteManager.add(mContext, story);
-        } else {
-            mFavoriteManager.remove(mContext, story.getId());
-        }
+    Preferences.SwipeAction getRightSwipeAction() {
+      return mSwipePreferences == null ? Preferences.SwipeAction.None : mSwipePreferences[1];
     }
 
-    @Synthetic
-    void refresh(Item story, RecyclerView.ViewHolder holder) {
-        int position = holder.getBindingAdapterPosition();
-        if (position == NO_POSITION) {
-            return;
-        }
-        story.setLocalRevision(-1);
-        notifyItemChanged(position);
+    boolean hasAction(Preferences.SwipeAction action) {
+      return mSwipePreferences != null
+          && (mSwipePreferences[0] == action || mSwipePreferences[1] == action);
     }
 
-    @Synthetic
-    void vote(final Item story, final RecyclerView.ViewHolder holder) {
-        if (!mUserServices.voteUp(mContext, story.getId(),
-                new VoteCallback(this, story))) {
-            AppUtils.showLogin(mContext, mAlertDialogBuilder);
-        }
+    private String getSaveText() {
+      return mSaved ? mUnsaveText : mSaveText;
     }
-
-    @Synthetic
-    void onVoted(int position, Boolean successful) {
-        if (successful == null) {
-            Toast.makeText(mContext, R.string.vote_failed, Toast.LENGTH_SHORT).show();
-        } else if (successful) {
-            Toast.makeText(mContext, R.string.voted, Toast.LENGTH_SHORT).show();
-            if (position != NO_POSITION && position < getItemCount()) {
-                notifyItemChanged(position, VOTED);
-            }
-        }
-    }
-
-    public void setCacheMode(int cacheMode) {
-        mCacheMode = cacheMode;
-    }
-
-    @Synthetic
-    void markAsViewed(int position) {
-        if (position < 0) {
-            return;
-        }
-        Item item = mItems != null && position < mItems.size() ? mItems.get(position) : null;
-        if (item == null || !isItemAvailable(item) || item.isViewed()) {
-            return;
-        }
-        item.setIsViewed(true); // Optimistically mark as viewed to avoid repeated processing
-        mSessionManager.view(item.getId());
-    }
-
-    private void toggleAutoMarkAsViewed(RecyclerView recyclerView) {
-        if (Preferences.autoMarkAsViewed(recyclerView.getContext())) {
-            recyclerView.addOnScrollListener(mAutoViewScrollListener);
-        } else {
-            recyclerView.removeOnScrollListener(mAutoViewScrollListener);
-        }
-    }
-
-    static class ItemResponseListener implements ResponseListener<Item> {
-        private final WeakReference<StoryRecyclerViewAdapter> mAdapter;
-        private final Item mPartialItem;
-
-        @Synthetic
-        ItemResponseListener(StoryRecyclerViewAdapter adapter,
-                Item partialItem) {
-            mAdapter = new WeakReference<>(adapter);
-            mPartialItem = partialItem;
-        }
-
-        @Override
-        public void onResponse(@Nullable Item response) {
-            if (mAdapter.get() != null && mAdapter.get().isAttached() && response != null) {
-                mPartialItem.populate(response);
-                mAdapter.get().onItemLoaded(mPartialItem);
-            }
-        }
-
-        @Override
-        public void onError(String errorMessage) {
-            // do nothing
-        }
-    }
-
-    static class VoteCallback extends UserServices.Callback {
-        private final WeakReference<StoryRecyclerViewAdapter> mAdapter;
-        private final Item mItem;
-
-        @Synthetic
-        VoteCallback(StoryRecyclerViewAdapter adapter, Item item) {
-            mAdapter = new WeakReference<>(adapter);
-            mItem = item;
-        }
-
-        @Override
-        public void onDone(boolean successful) {
-            // TODO update locally only, as API does not update instantly
-            mItem.incrementScore();
-            mItem.clearPendingVoted();
-            StoryRecyclerViewAdapter adapter = mAdapter.get();
-            if (adapter != null && adapter.isAttached()) {
-                adapter.onVoted(adapter.getPosition(mItem), successful);
-            }
-        }
-
-        @Override
-        public void onError(Throwable throwable) {
-            StoryRecyclerViewAdapter adapter = mAdapter.get();
-            if (adapter != null && adapter.isAttached()) {
-                adapter.onVoted(adapter.getPosition(mItem), null);
-            }
-        }
-    }
-
-    static abstract class ItemTouchHelperCallback extends PeekabooTouchHelperCallback {
-        private final String mSaveText;
-        private final String mUnsaveText;
-        boolean mSaved;
-        private Preferences.SwipeAction[] mSwipePreferences;
-        private String[] mTexts = new String[2];
-        private int[] mColors = new int[2];
-
-        ItemTouchHelperCallback(Context context, Preferences.SwipeAction[] swipePreferences) {
-            super(context);
-            mSaveText = context.getString(R.string.save);
-            mUnsaveText = context.getString(R.string.unsave);
-            setSwipePreferences(context, swipePreferences);
-        }
-
-        @Override
-        protected String getLeftText() {
-            return getLeftSwipeAction() == Save ? getSaveText() : mTexts[0];
-        }
-
-        @Override
-        protected String getRightText() {
-            return getRightSwipeAction() == Save ? getSaveText() : mTexts[1];
-        }
-
-        @Override
-        protected int getLeftTextColor() {
-            return mColors[0];
-        }
-
-        @Override
-        protected int getRightTextColor() {
-            return mColors[1];
-        }
-
-        @Synthetic
-        void setSwipePreferences(Context context, Preferences.SwipeAction[] swipePreferences) {
-            mSwipePreferences = swipePreferences;
-            for (int i = 0; i < 2; i++) {
-                switch (swipePreferences[i]) {
-                    case Vote:
-                        mTexts[i] = context.getString(R.string.vote_up);
-                        mColors[i] = ContextCompat.getColor(context, R.color.greenA700);
-                        break;
-                    case Save:
-                        mTexts[i] = null; // dynamic text
-                        mColors[i] = ContextCompat.getColor(context, R.color.orange500);
-                        break;
-                    case Refresh:
-                        mTexts[i] = context.getString(R.string.refresh);
-                        mColors[i] = ContextCompat.getColor(context, R.color.lightBlueA700);
-                        break;
-                    case Share:
-                        mTexts[i] = context.getString(R.string.share);
-                        mColors[i] = ContextCompat.getColor(context, R.color.lightBlueA700);
-                        break;
-                    default:
-                        mTexts[i] = null;
-                        mColors[i] = 0;
-                        break;
-                }
-            }
-        }
-
-        Preferences.SwipeAction getLeftSwipeAction() {
-            return mSwipePreferences == null ? Preferences.SwipeAction.None : mSwipePreferences[0];
-        }
-
-        Preferences.SwipeAction getRightSwipeAction() {
-            return mSwipePreferences == null ? Preferences.SwipeAction.None : mSwipePreferences[1];
-        }
-
-        boolean hasAction(Preferences.SwipeAction action) {
-            return mSwipePreferences != null &&
-                    (mSwipePreferences[0] == action || mSwipePreferences[1] == action);
-        }
-
-        private String getSaveText() {
-            return mSaved ? mUnsaveText : mSaveText;
-        }
-    }
+  }
 }

--- a/app/src/test/java/io/github/sheepdestroyer/materialisheep/widget/StoryRecyclerViewAdapterTest.java
+++ b/app/src/test/java/io/github/sheepdestroyer/materialisheep/widget/StoryRecyclerViewAdapterTest.java
@@ -1,6 +1,5 @@
 package io.github.sheepdestroyer.materialisheep.widget;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -8,11 +7,16 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import android.content.Context;
-import androidx.recyclerview.widget.RecyclerView;
-
+import android.content.ContextWrapper;
+import io.github.sheepdestroyer.materialisheep.ApplicationComponent;
+import io.github.sheepdestroyer.materialisheep.MaterialisticApplication;
+import io.github.sheepdestroyer.materialisheep.MultiPaneListener;
+import io.github.sheepdestroyer.materialisheep.data.Item;
+import io.github.sheepdestroyer.materialisheep.data.ItemManager;
+import io.github.sheepdestroyer.materialisheep.data.SessionManager;
+import io.github.sheepdestroyer.materialisheep.data.WebItem;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -20,113 +24,107 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
-import io.github.sheepdestroyer.materialisheep.ApplicationComponent;
-import io.github.sheepdestroyer.materialisheep.MaterialisticApplication;
-import io.github.sheepdestroyer.materialisheep.data.Item;
-import io.github.sheepdestroyer.materialisheep.MultiPaneListener;
-import io.github.sheepdestroyer.materialisheep.data.ItemManager;
-import io.github.sheepdestroyer.materialisheep.data.SessionManager;
-import io.github.sheepdestroyer.materialisheep.data.WebItem;
-
-import android.content.ContextWrapper;
-
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 34)
 public class StoryRecyclerViewAdapterTest {
 
-    private StoryRecyclerViewAdapter adapter;
-    private SessionManager sessionManager;
-    private ItemManager itemManager;
-    private Context context;
+  private StoryRecyclerViewAdapter adapter;
+  private SessionManager sessionManager;
+  private ItemManager itemManager;
+  private Context context;
 
-    // Helper abstract class to combine ContextWrapper and MultiPaneListener
-    public static abstract class TestContext extends ContextWrapper implements MultiPaneListener {
-        public TestContext(Context base) {
-            super(base);
-        }
+  // Helper abstract class to combine ContextWrapper and MultiPaneListener
+  public abstract static class TestContext extends ContextWrapper implements MultiPaneListener {
+    public TestContext(Context base) {
+      super(base);
     }
+  }
 
-    @Before
-    public void setUp() {
-        final MaterialisticApplication mockApp = mock(MaterialisticApplication.class);
-        mockApp.applicationComponent = mock(ApplicationComponent.class);
-        when(mockApp.getApplicationContext()).thenReturn(mockApp);
+  @Before
+  public void setUp() {
+    final MaterialisticApplication mockApp = mock(MaterialisticApplication.class);
+    mockApp.applicationComponent = mock(ApplicationComponent.class);
+    when(mockApp.getApplicationContext()).thenReturn(mockApp);
 
-        // Wrap the real Robolectric context to return our mock Application and implement MultiPaneListener
-        context = new TestContext(RuntimeEnvironment.application) {
-            @Override
-            public Context getApplicationContext() {
-                return mockApp;
-            }
+    // Wrap the real Robolectric context to return our mock Application and implement
+    // MultiPaneListener
+    context =
+        new TestContext(RuntimeEnvironment.application) {
+          @Override
+          public Context getApplicationContext() {
+            return mockApp;
+          }
 
-            @Override
-            public void onItemSelected(WebItem item) {
-            }
+          @Override
+          public void onItemSelected(WebItem item) {}
 
-            @Override
-            public WebItem getSelectedItem() {
-                return null;
-            }
+          @Override
+          public WebItem getSelectedItem() {
+            return null;
+          }
 
-            @Override
-            public boolean isMultiPane() {
-                return false;
-            }
+          @Override
+          public boolean isMultiPane() {
+            return false;
+          }
         };
 
-        adapter = new StoryRecyclerViewAdapter(context);
-        sessionManager = mock(SessionManager.class);
-        itemManager = mock(ItemManager.class);
+    adapter = new StoryRecyclerViewAdapter(context);
+    sessionManager = mock(SessionManager.class);
+    itemManager = mock(ItemManager.class);
 
-        adapter.mSessionManager = sessionManager;
-        adapter.mItemManager = itemManager;
-    }
+    adapter.mSessionManager = sessionManager;
+    adapter.mItemManager = itemManager;
+  }
 
-    @Test
-    public void testMarkAsViewed_callsSessionManagerView() {
-        Item item = mock(Item.class);
-        when(item.getId()).thenReturn("123");
-        when(item.getLongId()).thenReturn(123L);
-        when(item.getLocalRevision()).thenReturn(1);
-        when(item.isViewed()).thenReturn(false);
+  @Test
+  public void testMarkAsViewed_callsSessionManagerView() {
+    Item item = mock(Item.class);
+    when(item.getId()).thenReturn("123");
+    when(item.getLongId()).thenReturn(123L);
+    when(item.getLocalRevision()).thenReturn(1);
+    when(item.isViewed()).thenReturn(false);
 
-        adapter.mItems.add(item);
+    adapter.mItems.add(item);
 
-        // Call markAsViewed for the item at position 0
-        adapter.markAsViewed(0);
+    // Call markAsViewed for the item at position 0
+    adapter.markAsViewed(0);
 
-        verify(sessionManager, times(1)).view("123");
-    }
+    verify(sessionManager, times(1)).view("123");
+  }
 
-    @Test
-    public void testMarkAsViewed_optimized() {
-        Item item = mock(Item.class);
-        when(item.getId()).thenReturn("123");
-        when(item.getLongId()).thenReturn(123L);
-        when(item.getLocalRevision()).thenReturn(1);
+  @Test
+  public void testMarkAsViewed_optimized() {
+    Item item = mock(Item.class);
+    when(item.getId()).thenReturn("123");
+    when(item.getLongId()).thenReturn(123L);
+    when(item.getLocalRevision()).thenReturn(1);
 
-        AtomicBoolean isViewed = new AtomicBoolean(false);
-        when(item.isViewed()).thenAnswer(invocation -> isViewed.get());
-        doAnswer(invocation -> {
-            isViewed.set(invocation.getArgument(0));
-            return null;
-        }).when(item).setIsViewed(anyBoolean());
+    AtomicBoolean isViewed = new AtomicBoolean(false);
+    when(item.isViewed()).thenAnswer(invocation -> isViewed.get());
+    doAnswer(
+            invocation -> {
+              isViewed.set(invocation.getArgument(0));
+              return null;
+            })
+        .when(item)
+        .setIsViewed(anyBoolean());
 
-        adapter.mItems.add(item);
+    adapter.mItems.add(item);
 
-        // Call markAsViewed the first time
-        adapter.markAsViewed(0);
+    // Call markAsViewed the first time
+    adapter.markAsViewed(0);
 
-        // Should call view()
-        verify(sessionManager, times(1)).view("123");
-        verify(item, times(1)).setIsViewed(true);
+    // Should call view()
+    verify(sessionManager, times(1)).view("123");
+    verify(item, times(1)).setIsViewed(true);
 
-        // Call markAsViewed again
-        adapter.markAsViewed(0);
+    // Call markAsViewed again
+    adapter.markAsViewed(0);
 
-        // Verify it is NOT called again
-        verify(sessionManager, times(1)).view("123");
-        // Verify setIsViewed was NOT called again (since it returned early)
-        verify(item, times(1)).setIsViewed(true);
-    }
+    // Verify it is NOT called again
+    verify(sessionManager, times(1)).view("123");
+    // Verify setIsViewed was NOT called again (since it returned early)
+    verify(item, times(1)).setIsViewed(true);
+  }
 }

--- a/app/src/test/java/io/github/sheepdestroyer/materialisheep/widget/StoryRecyclerViewAdapterTest.java
+++ b/app/src/test/java/io/github/sheepdestroyer/materialisheep/widget/StoryRecyclerViewAdapterTest.java
@@ -1,0 +1,132 @@
+package io.github.sheepdestroyer.materialisheep.widget;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import android.content.Context;
+import androidx.recyclerview.widget.RecyclerView;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+import io.github.sheepdestroyer.materialisheep.ApplicationComponent;
+import io.github.sheepdestroyer.materialisheep.MaterialisticApplication;
+import io.github.sheepdestroyer.materialisheep.data.Item;
+import io.github.sheepdestroyer.materialisheep.MultiPaneListener;
+import io.github.sheepdestroyer.materialisheep.data.ItemManager;
+import io.github.sheepdestroyer.materialisheep.data.SessionManager;
+import io.github.sheepdestroyer.materialisheep.data.WebItem;
+
+import android.content.ContextWrapper;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 34)
+public class StoryRecyclerViewAdapterTest {
+
+    private StoryRecyclerViewAdapter adapter;
+    private SessionManager sessionManager;
+    private ItemManager itemManager;
+    private Context context;
+
+    // Helper abstract class to combine ContextWrapper and MultiPaneListener
+    public static abstract class TestContext extends ContextWrapper implements MultiPaneListener {
+        public TestContext(Context base) {
+            super(base);
+        }
+    }
+
+    @Before
+    public void setUp() {
+        final MaterialisticApplication mockApp = mock(MaterialisticApplication.class);
+        mockApp.applicationComponent = mock(ApplicationComponent.class);
+        when(mockApp.getApplicationContext()).thenReturn(mockApp);
+
+        // Wrap the real Robolectric context to return our mock Application and implement MultiPaneListener
+        context = new TestContext(RuntimeEnvironment.application) {
+            @Override
+            public Context getApplicationContext() {
+                return mockApp;
+            }
+
+            @Override
+            public void onItemSelected(WebItem item) {
+            }
+
+            @Override
+            public WebItem getSelectedItem() {
+                return null;
+            }
+
+            @Override
+            public boolean isMultiPane() {
+                return false;
+            }
+        };
+
+        adapter = new StoryRecyclerViewAdapter(context);
+        sessionManager = mock(SessionManager.class);
+        itemManager = mock(ItemManager.class);
+
+        adapter.mSessionManager = sessionManager;
+        adapter.mItemManager = itemManager;
+    }
+
+    @Test
+    public void testMarkAsViewed_callsSessionManagerView() {
+        Item item = mock(Item.class);
+        when(item.getId()).thenReturn("123");
+        when(item.getLongId()).thenReturn(123L);
+        when(item.getLocalRevision()).thenReturn(1);
+        when(item.isViewed()).thenReturn(false);
+
+        adapter.mItems.add(item);
+
+        // Call markAsViewed for the item at position 0
+        adapter.markAsViewed(0);
+
+        verify(sessionManager, times(1)).view("123");
+    }
+
+    @Test
+    public void testMarkAsViewed_optimized() {
+        Item item = mock(Item.class);
+        when(item.getId()).thenReturn("123");
+        when(item.getLongId()).thenReturn(123L);
+        when(item.getLocalRevision()).thenReturn(1);
+
+        AtomicBoolean isViewed = new AtomicBoolean(false);
+        when(item.isViewed()).thenAnswer(invocation -> isViewed.get());
+        doAnswer(invocation -> {
+            isViewed.set(invocation.getArgument(0));
+            return null;
+        }).when(item).setIsViewed(anyBoolean());
+
+        adapter.mItems.add(item);
+
+        // Call markAsViewed the first time
+        adapter.markAsViewed(0);
+
+        // Should call view()
+        verify(sessionManager, times(1)).view("123");
+        verify(item, times(1)).setIsViewed(true);
+
+        // Call markAsViewed again
+        adapter.markAsViewed(0);
+
+        // Verify it is NOT called again
+        verify(sessionManager, times(1)).view("123");
+        // Verify setIsViewed was NOT called again (since it returned early)
+        verify(item, times(1)).setIsViewed(true);
+    }
+}


### PR DESCRIPTION
💡 What: Optimistically mark items as viewed in memory before dispatching the async `SessionManager.view()` call.

🎯 Why: During rapid scrolling, `onScrolled` triggers `markAsViewed` repeatedly for the same item. Because `SessionManager.view()` is asynchronous, the `item.isViewed()` check fails multiple times, causing redundant IO operations and unnecessary thread scheduling.

📊 Impact: Prevents multiple `SessionManager.view` calls for the same item during a single scroll event. Reduces main thread overhead and unnecessary background tasks.

🔬 Measurement: Verified with `StoryRecyclerViewAdapterTest.testMarkAsViewed_optimized`, which confirms `SessionManager.view` is called only once even when `markAsViewed` is called multiple times.

---
*PR created automatically by Jules for task [17340731154416625747](https://jules.google.com/task/17340731154416625747) started by @sheepdestroyer*

## Summary by Sourcery

Optimize viewed state handling in StoryRecyclerViewAdapter to avoid redundant view tracking calls and add tests to verify the behavior.

Bug Fixes:
- Prevent multiple SessionManager.view invocations for the same item when markAsViewed is called repeatedly during scrolling.

Enhancements:
- Optimistically mark items as viewed in memory before dispatching the asynchronous SessionManager.view call to reduce repeated processing.

Tests:
- Add Robolectric tests for StoryRecyclerViewAdapter markAsViewed behavior, including an optimization test ensuring SessionManager.view is called only once per item.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Optimizes `markAsViewed()` in `StoryRecyclerViewAdapter` to prevent redundant `SessionManager.view()` calls by marking items as viewed in memory first.
> 
>   - **Behavior**:
>     - Optimistically marks items as viewed in `markAsViewed()` in `StoryRecyclerViewAdapter.java` before calling `SessionManager.view()` to prevent redundant calls during rapid scrolling.
>   - **Testing**:
>     - Adds `testMarkAsViewed_optimized()` in `StoryRecyclerViewAdapterTest.java` to verify `SessionManager.view()` is called only once per item, even if `markAsViewed()` is called multiple times.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sheepdestroyer%2Fmaterialisheep&utm_source=github&utm_medium=referral)<sup> for fba6c57e17f80689a69ba60cb8ccb09caa6bf156. You can [customize](https://app.ellipsis.dev/sheepdestroyer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured story adapter for improved modularity and maintainability.
  * Enhanced swipe gesture handling with customizable action labels and colors.
  * Improved item state synchronization for favorites and view tracking.

* **Tests**
  * Added unit tests for story adapter functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->