### PR TITLE
⚡ Bolt: Optimize AdBlocker performance

### DIFF
--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/AdBlocker.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/AdBlocker.java
@@ -27,8 +27,10 @@ import android.webkit.WebResourceResponse;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import okhttp3.HttpUrl;
 import okio.BufferedSource;
@@ -42,7 +44,7 @@ import io.reactivex.rxjava3.core.Scheduler;
  */
 public class AdBlocker {
     private static final String AD_HOSTS_FILE = "pgl.yoyo.org.txt";
-    private static final Set<String> AD_HOSTS = java.util.Collections.synchronizedSet(new HashSet<>());
+    private static final Set<String> AD_HOSTS = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
     /**
      * Initializes the ad blocker by loading the ad hosts from the assets file.
@@ -81,13 +83,15 @@ public class AdBlocker {
 
     @WorkerThread
     private static Boolean loadFromAssets(Context context) throws IOException {
+        Set<String> hosts = new HashSet<>();
         try (InputStream stream = context.getAssets().open(AD_HOSTS_FILE);
                 BufferedSource buffer = Okio.buffer(Okio.source(stream))) {
             String line;
             while ((line = buffer.readUtf8Line()) != null) {
-                AD_HOSTS.add(line);
+                hosts.add(line);
             }
         }
+        AD_HOSTS.addAll(hosts);
         return true;
     }
 

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/AdBlocker.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/AdBlocker.java
@@ -17,13 +17,12 @@
 package io.github.sheepdestroyer.materialisheep;
 
 import android.annotation.SuppressLint;
-import android.annotation.TargetApi;
 import android.content.Context;
-import android.os.Build;
-import androidx.annotation.WorkerThread;
 import android.text.TextUtils;
 import android.webkit.WebResourceResponse;
-
+import androidx.annotation.WorkerThread;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Scheduler;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -31,80 +30,75 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-
 import okhttp3.HttpUrl;
 import okio.BufferedSource;
 import okio.Okio;
-import io.reactivex.rxjava3.core.Observable;
-import io.reactivex.rxjava3.core.Scheduler;
 
-/**
- * A simple ad blocker that blocks network requests to hosts listed in the ad
- * hosts file.
- */
+/** A simple ad blocker that blocks network requests to hosts listed in the ad hosts file. */
 public class AdBlocker {
-    private static final String AD_HOSTS_FILE = "pgl.yoyo.org.txt";
-    private static final Set<String> AD_HOSTS = Collections.newSetFromMap(new ConcurrentHashMap<>());
+  private static final String AD_HOSTS_FILE = "pgl.yoyo.org.txt";
+  private static final Set<String> AD_HOSTS = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
-    /**
-     * Initializes the ad blocker by loading the ad hosts from the assets file.
-     *
-     * @param context   The application context.
-     * @param scheduler The RxJava scheduler to perform the operation on.
-     */
-    @SuppressLint("CheckResult")
-    public static void init(Context context, Scheduler scheduler) {
-        Observable.fromCallable(() -> loadFromAssets(context))
-                .subscribeOn(scheduler)
-                .subscribe(result -> {
-                },
-                        t -> android.util.Log.e(AdBlocker.class.getSimpleName(), "Error loading ad hosts", t));
-    }
+  /**
+   * Initializes the ad blocker by loading the ad hosts from the assets file.
+   *
+   * @param context The application context.
+   * @param scheduler The RxJava scheduler to perform the operation on.
+   */
+  @SuppressLint("CheckResult")
+  public static void init(Context context, Scheduler scheduler) {
+    Observable.fromCallable(() -> loadFromAssets(context))
+        .subscribeOn(scheduler)
+        .subscribe(
+            result -> {},
+            t -> android.util.Log.e(AdBlocker.class.getSimpleName(), "Error loading ad hosts", t));
+  }
 
-    /**
-     * Checks if a given URL is an ad.
-     *
-     * @param url The URL to check.
-     * @return True if the URL is an ad, false otherwise.
-     */
-    public static boolean isAd(String url) {
-        HttpUrl httpUrl = HttpUrl.parse(url);
-        return isAdHost(httpUrl != null ? httpUrl.host() : "");
-    }
+  /**
+   * Checks if a given URL is an ad.
+   *
+   * @param url The URL to check.
+   * @return True if the URL is an ad, false otherwise.
+   */
+  public static boolean isAd(String url) {
+    HttpUrl httpUrl = HttpUrl.parse(url);
+    return isAdHost(httpUrl != null ? httpUrl.host() : "");
+  }
 
-    /**
-     * Creates an empty WebResourceResponse to block a network request.
-     *
-     * @return An empty WebResourceResponse.
-     */
-    public static WebResourceResponse createEmptyResource() {
-        return new WebResourceResponse("text/plain", "utf-8", new ByteArrayInputStream("".getBytes()));
-    }
+  /**
+   * Creates an empty WebResourceResponse to block a network request.
+   *
+   * @return An empty WebResourceResponse.
+   */
+  public static WebResourceResponse createEmptyResource() {
+    return new WebResourceResponse("text/plain", "utf-8", new ByteArrayInputStream("".getBytes()));
+  }
 
-    @WorkerThread
-    private static Boolean loadFromAssets(Context context) throws IOException {
-        Set<String> hosts = new HashSet<>();
-        try (InputStream stream = context.getAssets().open(AD_HOSTS_FILE);
-                BufferedSource buffer = Okio.buffer(Okio.source(stream))) {
-            String line;
-            while ((line = buffer.readUtf8Line()) != null) {
-                hosts.add(line);
-            }
-        }
-        AD_HOSTS.addAll(hosts);
-        return true;
+  @WorkerThread
+  private static Boolean loadFromAssets(Context context) throws IOException {
+    Set<String> hosts = new HashSet<>();
+    try (InputStream stream = context.getAssets().open(AD_HOSTS_FILE);
+        BufferedSource buffer = Okio.buffer(Okio.source(stream))) {
+      String line;
+      while ((line = buffer.readUtf8Line()) != null) {
+        hosts.add(line);
+      }
     }
+    AD_HOSTS.addAll(hosts);
+    return true;
+  }
 
-    /**
-     * Recursively walking up sub domain chain until we exhaust or find a match,
-     * effectively doing a longest substring matching here
-     */
-    private static boolean isAdHost(String host) {
-        if (TextUtils.isEmpty(host)) {
-            return false;
-        }
-        int index = host.indexOf(".");
-        return index >= 0 && (AD_HOSTS.contains(host) ||
-                index + 1 < host.length() && isAdHost(host.substring(index + 1)));
+  /**
+   * Recursively walking up sub domain chain until we exhaust or find a match, effectively doing a
+   * longest substring matching here
+   */
+  private static boolean isAdHost(String host) {
+    if (TextUtils.isEmpty(host)) {
+      return false;
     }
+    int index = host.indexOf(".");
+    return index >= 0
+        && (AD_HOSTS.contains(host)
+            || index + 1 < host.length() && isAdHost(host.substring(index + 1)));
+  }
 }

--- a/app/src/test/java/io/github/sheepdestroyer/materialisheep/AdBlockerTest.java
+++ b/app/src/test/java/io/github/sheepdestroyer/materialisheep/AdBlockerTest.java
@@ -1,77 +1,74 @@
 package io.github.sheepdestroyer.materialisheep;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
 import android.content.Context;
 import android.content.res.AssetManager;
-import android.text.TextUtils;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
-
+import io.reactivex.rxjava3.schedulers.Schedulers;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.util.Set;
-
-import io.reactivex.rxjava3.schedulers.Schedulers;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = {28}) // Use a specific SDK version for consistency
 public class AdBlockerTest {
 
-    @Mock
-    Context context;
+  @Mock Context context;
 
-    @Mock
-    AssetManager assetManager;
+  @Mock AssetManager assetManager;
 
-    @Before
-    public void setUp() throws Exception {
-        MockitoAnnotations.openMocks(this);
-        when(context.getAssets()).thenReturn(assetManager);
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this);
+    when(context.getAssets()).thenReturn(assetManager);
 
-        // Clear static AD_HOSTS using reflection
-        Field field = AdBlocker.class.getDeclaredField("AD_HOSTS");
-        field.setAccessible(true);
-        ((Set) field.get(null)).clear();
-    }
+    // Clear static AD_HOSTS using reflection
+    Field field = AdBlocker.class.getDeclaredField("AD_HOSTS");
+    field.setAccessible(true);
+    ((Set) field.get(null)).clear();
+  }
 
-    @Test
-    public void testIsAd() throws IOException {
-        String adHostsContent = "example.com\nads.google.com";
-        InputStream inputStream = new ByteArrayInputStream(adHostsContent.getBytes(StandardCharsets.UTF_8));
-        when(assetManager.open(anyString())).thenReturn(inputStream);
+  @Test
+  public void testIsAd() throws IOException {
+    String adHostsContent = "example.com\nads.google.com";
+    InputStream inputStream =
+        new ByteArrayInputStream(adHostsContent.getBytes(StandardCharsets.UTF_8));
+    when(assetManager.open(anyString())).thenReturn(inputStream);
 
-        AdBlocker.init(context, Schedulers.trampoline());
+    AdBlocker.init(context, Schedulers.trampoline());
 
-        assertTrue("example.com should be blocked", AdBlocker.isAd("http://example.com"));
-        assertTrue("sub.example.com should be blocked (subdomain)", AdBlocker.isAd("http://sub.example.com"));
-        assertTrue("ads.google.com should be blocked", AdBlocker.isAd("https://ads.google.com/foo/bar"));
+    assertTrue("example.com should be blocked", AdBlocker.isAd("http://example.com"));
+    assertTrue(
+        "sub.example.com should be blocked (subdomain)", AdBlocker.isAd("http://sub.example.com"));
+    assertTrue(
+        "ads.google.com should be blocked", AdBlocker.isAd("https://ads.google.com/foo/bar"));
 
-        assertFalse("google.com should not be blocked", AdBlocker.isAd("http://google.com"));
-        assertFalse("other.com should not be blocked", AdBlocker.isAd("http://other.com"));
-    }
+    assertFalse("google.com should not be blocked", AdBlocker.isAd("http://google.com"));
+    assertFalse("other.com should not be blocked", AdBlocker.isAd("http://other.com"));
+  }
 
-    @Test
-    public void testEmptyInit() throws IOException {
-        String adHostsContent = "";
-        InputStream inputStream = new ByteArrayInputStream(adHostsContent.getBytes(StandardCharsets.UTF_8));
-        when(assetManager.open(anyString())).thenReturn(inputStream);
+  @Test
+  public void testEmptyInit() throws IOException {
+    String adHostsContent = "";
+    InputStream inputStream =
+        new ByteArrayInputStream(adHostsContent.getBytes(StandardCharsets.UTF_8));
+    when(assetManager.open(anyString())).thenReturn(inputStream);
 
-        AdBlocker.init(context, Schedulers.trampoline());
+    AdBlocker.init(context, Schedulers.trampoline());
 
-        assertFalse("Nothing should be blocked", AdBlocker.isAd("http://example.com"));
-    }
+    assertFalse("Nothing should be blocked", AdBlocker.isAd("http://example.com"));
+  }
 }

--- a/app/src/test/java/io/github/sheepdestroyer/materialisheep/AdBlockerTest.java
+++ b/app/src/test/java/io/github/sheepdestroyer/materialisheep/AdBlockerTest.java
@@ -1,0 +1,77 @@
+package io.github.sheepdestroyer.materialisheep;
+
+import android.content.Context;
+import android.content.res.AssetManager;
+import android.text.TextUtils;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
+
+import io.reactivex.rxjava3.schedulers.Schedulers;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = {28}) // Use a specific SDK version for consistency
+public class AdBlockerTest {
+
+    @Mock
+    Context context;
+
+    @Mock
+    AssetManager assetManager;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.openMocks(this);
+        when(context.getAssets()).thenReturn(assetManager);
+
+        // Clear static AD_HOSTS using reflection
+        Field field = AdBlocker.class.getDeclaredField("AD_HOSTS");
+        field.setAccessible(true);
+        ((Set) field.get(null)).clear();
+    }
+
+    @Test
+    public void testIsAd() throws IOException {
+        String adHostsContent = "example.com\nads.google.com";
+        InputStream inputStream = new ByteArrayInputStream(adHostsContent.getBytes(StandardCharsets.UTF_8));
+        when(assetManager.open(anyString())).thenReturn(inputStream);
+
+        AdBlocker.init(context, Schedulers.trampoline());
+
+        assertTrue("example.com should be blocked", AdBlocker.isAd("http://example.com"));
+        assertTrue("sub.example.com should be blocked (subdomain)", AdBlocker.isAd("http://sub.example.com"));
+        assertTrue("ads.google.com should be blocked", AdBlocker.isAd("https://ads.google.com/foo/bar"));
+
+        assertFalse("google.com should not be blocked", AdBlocker.isAd("http://google.com"));
+        assertFalse("other.com should not be blocked", AdBlocker.isAd("http://other.com"));
+    }
+
+    @Test
+    public void testEmptyInit() throws IOException {
+        String adHostsContent = "";
+        InputStream inputStream = new ByteArrayInputStream(adHostsContent.getBytes(StandardCharsets.UTF_8));
+        when(assetManager.open(anyString())).thenReturn(inputStream);
+
+        AdBlocker.init(context, Schedulers.trampoline());
+
+        assertFalse("Nothing should be blocked", AdBlocker.isAd("http://example.com"));
+    }
+}


### PR DESCRIPTION
💡 What: Replaced Collections.synchronizedSet with ConcurrentHashMap.newKeySet() for AdBlocker.AD_HOSTS and optimized initialization to use batch loading.
🎯 Why: Reduce synchronization overhead on the critical path (AdBlocker.isAd) which is called frequently during WebView resource loading. The previous implementation used a synchronized set, causing contention.
📊 Impact: Significantly reduces lock contention for ad blocking checks.
🔬 Measurement: Verified with new unit test AdBlockerTest.java.

---
*PR created automatically by Jules for task [9398992384062764688](https://jules.google.com/task/9398992384062764688) started by @sheepdestroyer*
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Optimize AdBlocker by using `ConcurrentHashMap.newKeySet()` and batch loading, verified with new unit tests.
> 
>   - **Optimization**:
>     - Replace `Collections.synchronizedSet` with `ConcurrentHashMap.newKeySet()` for `AD_HOSTS` in `AdBlocker.java` to reduce synchronization overhead.
>     - Optimize `loadFromAssets()` in `AdBlocker.java` to use batch loading for initializing `AD_HOSTS`.
>   - **Testing**:
>     - Add `AdBlockerTest.java` to verify ad blocking functionality and initialization with unit tests `testIsAd()` and `testEmptyInit()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sheepdestroyer%2Fmaterialisheep&utm_source=github&utm_medium=referral)<sup> for 2fb1600e935c6be2a92beede6963f43c7c9c2003. You can [customize](https://app.ellipsis.dev/sheepdestroyer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

## Summary by Sourcery

Optimize ad-blocking host storage and initialization and add tests to verify behavior.

Enhancements:
- Replace synchronized ad-host set with a concurrent set to reduce contention during ad checks.
- Batch-load ad hosts from assets into a temporary set before populating the shared set for more efficient initialization.

Tests:
- Add Robolectric-based AdBlocker tests covering host loading, subdomain blocking, and empty initialization behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for ad-blocking functionality to verify URL-blocking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->