### PR TITLE
⚡ Bolt: Optimize AdBlocker initialization and read performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - SynchronizedSet vs ConcurrentHashMap in Read-Heavy Paths
+**Learning:** `Collections.synchronizedSet` synchronizes *every* method call, including reads (`contains`). In read-heavy scenarios like AdBlocker checking `isAd` for every WebView resource, this creates unnecessary lock contention.
+**Action:** Use `Collections.newSetFromMap(new ConcurrentHashMap<>())` for thread-safe sets that are read frequently. It allows non-blocking reads.

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/AdBlocker.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/AdBlocker.java
@@ -17,13 +17,12 @@
 package io.github.sheepdestroyer.materialisheep;
 
 import android.annotation.SuppressLint;
-import android.annotation.TargetApi;
 import android.content.Context;
-import android.os.Build;
-import androidx.annotation.WorkerThread;
 import android.text.TextUtils;
 import android.webkit.WebResourceResponse;
-
+import androidx.annotation.WorkerThread;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Scheduler;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -31,82 +30,78 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-
 import okhttp3.HttpUrl;
 import okio.BufferedSource;
 import okio.Okio;
-import io.reactivex.rxjava3.core.Observable;
-import io.reactivex.rxjava3.core.Scheduler;
 
-/**
- * A simple ad blocker that blocks network requests to hosts listed in the ad
- * hosts file.
- */
+/** A simple ad blocker that blocks network requests to hosts listed in the ad hosts file. */
 public class AdBlocker {
-    private static final String AD_HOSTS_FILE = "pgl.yoyo.org.txt";
-    // Use ConcurrentHashMap for non-blocking reads (isAdHost) which is critical for WebView performance.
-    private static final Set<String> AD_HOSTS = Collections.newSetFromMap(new ConcurrentHashMap<>());
+  private static final String AD_HOSTS_FILE = "pgl.yoyo.org.txt";
+  // Use ConcurrentHashMap for non-blocking reads (isAdHost) which is critical for WebView
+  // performance.
+  private static final Set<String> AD_HOSTS = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
-    /**
-     * Initializes the ad blocker by loading the ad hosts from the assets file.
-     *
-     * @param context   The application context.
-     * @param scheduler The RxJava scheduler to perform the operation on.
-     */
-    @SuppressLint("CheckResult")
-    public static void init(Context context, Scheduler scheduler) {
-        Observable.fromCallable(() -> loadFromAssets(context))
-                .subscribeOn(scheduler)
-                .subscribe(result -> {
-                },
-                        t -> android.util.Log.e(AdBlocker.class.getSimpleName(), "Error loading ad hosts", t));
-    }
+  /**
+   * Initializes the ad blocker by loading the ad hosts from the assets file.
+   *
+   * @param context The application context.
+   * @param scheduler The RxJava scheduler to perform the operation on.
+   */
+  @SuppressLint("CheckResult")
+  public static void init(Context context, Scheduler scheduler) {
+    Observable.fromCallable(() -> loadFromAssets(context))
+        .subscribeOn(scheduler)
+        .subscribe(
+            result -> {},
+            t -> android.util.Log.e(AdBlocker.class.getSimpleName(), "Error loading ad hosts", t));
+  }
 
-    /**
-     * Checks if a given URL is an ad.
-     *
-     * @param url The URL to check.
-     * @return True if the URL is an ad, false otherwise.
-     */
-    public static boolean isAd(String url) {
-        HttpUrl httpUrl = HttpUrl.parse(url);
-        return isAdHost(httpUrl != null ? httpUrl.host() : "");
-    }
+  /**
+   * Checks if a given URL is an ad.
+   *
+   * @param url The URL to check.
+   * @return True if the URL is an ad, false otherwise.
+   */
+  public static boolean isAd(String url) {
+    HttpUrl httpUrl = HttpUrl.parse(url);
+    return isAdHost(httpUrl != null ? httpUrl.host() : "");
+  }
 
-    /**
-     * Creates an empty WebResourceResponse to block a network request.
-     *
-     * @return An empty WebResourceResponse.
-     */
-    public static WebResourceResponse createEmptyResource() {
-        return new WebResourceResponse("text/plain", "utf-8", new ByteArrayInputStream("".getBytes()));
-    }
+  /**
+   * Creates an empty WebResourceResponse to block a network request.
+   *
+   * @return An empty WebResourceResponse.
+   */
+  public static WebResourceResponse createEmptyResource() {
+    return new WebResourceResponse("text/plain", "utf-8", new ByteArrayInputStream("".getBytes()));
+  }
 
-    @WorkerThread
-    private static Boolean loadFromAssets(Context context) throws IOException {
-        try (InputStream stream = context.getAssets().open(AD_HOSTS_FILE);
-                BufferedSource buffer = Okio.buffer(Okio.source(stream))) {
-            // Use a local set to batch additions, reducing potential contention and overhead
-            Set<String> localHosts = new HashSet<>();
-            String line;
-            while ((line = buffer.readUtf8Line()) != null) {
-                localHosts.add(line);
-            }
-            AD_HOSTS.addAll(localHosts);
-        }
-        return true;
+  @WorkerThread
+  private static Boolean loadFromAssets(Context context) throws IOException {
+    try (InputStream stream = context.getAssets().open(AD_HOSTS_FILE);
+        BufferedSource buffer = Okio.buffer(Okio.source(stream))) {
+      // Use a local set to batch additions, reducing potential contention and overhead
+      Set<String> localHosts = new HashSet<>();
+      String line;
+      while ((line = buffer.readUtf8Line()) != null) {
+        localHosts.add(line);
+      }
+      AD_HOSTS.addAll(localHosts);
     }
+    return true;
+  }
 
-    /**
-     * Recursively walking up sub domain chain until we exhaust or find a match,
-     * effectively doing a longest substring matching here
-     */
-    private static boolean isAdHost(String host) {
-        if (TextUtils.isEmpty(host)) {
-            return false;
-        }
-        int index = host.indexOf(".");
-        return index >= 0 && (AD_HOSTS.contains(host) ||
-                index + 1 < host.length() && isAdHost(host.substring(index + 1)));
+  /**
+   * Recursively walking up sub domain chain until we exhaust or find a match, effectively doing a
+   * longest substring matching here
+   */
+  private static boolean isAdHost(String host) {
+    if (TextUtils.isEmpty(host)) {
+      return false;
     }
+    int index = host.indexOf(".");
+    return index >= 0
+        && (AD_HOSTS.contains(host)
+            || index + 1 < host.length() && isAdHost(host.substring(index + 1)));
+  }
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/AdBlocker.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/AdBlocker.java
@@ -27,8 +27,10 @@ import android.webkit.WebResourceResponse;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import okhttp3.HttpUrl;
 import okio.BufferedSource;
@@ -42,7 +44,8 @@ import io.reactivex.rxjava3.core.Scheduler;
  */
 public class AdBlocker {
     private static final String AD_HOSTS_FILE = "pgl.yoyo.org.txt";
-    private static final Set<String> AD_HOSTS = java.util.Collections.synchronizedSet(new HashSet<>());
+    // Use ConcurrentHashMap for non-blocking reads (isAdHost) which is critical for WebView performance.
+    private static final Set<String> AD_HOSTS = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
     /**
      * Initializes the ad blocker by loading the ad hosts from the assets file.
@@ -83,10 +86,13 @@ public class AdBlocker {
     private static Boolean loadFromAssets(Context context) throws IOException {
         try (InputStream stream = context.getAssets().open(AD_HOSTS_FILE);
                 BufferedSource buffer = Okio.buffer(Okio.source(stream))) {
+            // Use a local set to batch additions, reducing potential contention and overhead
+            Set<String> localHosts = new HashSet<>();
             String line;
             while ((line = buffer.readUtf8Line()) != null) {
-                AD_HOSTS.add(line);
+                localHosts.add(line);
             }
+            AD_HOSTS.addAll(localHosts);
         }
         return true;
     }

--- a/app/src/test/java/io/github/sheepdestroyer/materialisheep/AdBlockerTest.java
+++ b/app/src/test/java/io/github/sheepdestroyer/materialisheep/AdBlockerTest.java
@@ -1,78 +1,75 @@
 package io.github.sheepdestroyer.materialisheep;
 
-import android.content.Context;
-import android.content.res.AssetManager;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
-import org.robolectric.annotation.Config;
-
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.lang.reflect.Field;
-import java.nio.charset.StandardCharsets;
-import java.util.Set;
-
-import io.reactivex.rxjava3.schedulers.Schedulers;
-
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import android.content.Context;
+import android.content.res.AssetManager;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = {33})
 public class AdBlockerTest {
 
-    private Context context;
-    private AssetManager assetManager;
+  private Context context;
+  private AssetManager assetManager;
 
-    @Before
-    public void setUp() throws Exception {
-        context = mock(Context.class);
-        assetManager = mock(AssetManager.class);
-        when(context.getAssets()).thenReturn(assetManager);
+  @Before
+  public void setUp() throws Exception {
+    context = mock(Context.class);
+    assetManager = mock(AssetManager.class);
+    when(context.getAssets()).thenReturn(assetManager);
 
-        // Reset AD_HOSTS using reflection because it's static
-        resetAdHosts();
+    // Reset AD_HOSTS using reflection because it's static
+    resetAdHosts();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    resetAdHosts();
+  }
+
+  private void resetAdHosts() throws Exception {
+    Field field = AdBlocker.class.getDeclaredField("AD_HOSTS");
+    field.setAccessible(true);
+    Set<String> hosts = (Set<String>) field.get(null);
+    if (hosts != null) {
+      hosts.clear();
     }
+  }
 
-    @After
-    public void tearDown() throws Exception {
-        resetAdHosts();
-    }
+  @Test
+  public void testInitAndIsAd() throws IOException {
+    String adHostsContent = "example.com\nad.doubleclick.net";
+    when(assetManager.open(anyString()))
+        .thenReturn(new ByteArrayInputStream(adHostsContent.getBytes(StandardCharsets.UTF_8)));
 
-    private void resetAdHosts() throws Exception {
-        Field field = AdBlocker.class.getDeclaredField("AD_HOSTS");
-        field.setAccessible(true);
-        Set<String> hosts = (Set<String>) field.get(null);
-        if (hosts != null) {
-            hosts.clear();
-        }
-    }
+    AdBlocker.init(context, Schedulers.trampoline());
 
-    @Test
-    public void testInitAndIsAd() throws IOException {
-        String adHostsContent = "example.com\nad.doubleclick.net";
-        when(assetManager.open(anyString())).thenReturn(new ByteArrayInputStream(adHostsContent.getBytes(StandardCharsets.UTF_8)));
+    assertTrue("Should block example.com", AdBlocker.isAd("http://example.com/foo"));
+    assertTrue("Should block ad.doubleclick.net", AdBlocker.isAd("https://ad.doubleclick.net/bar"));
+    assertFalse("Should not block google.com", AdBlocker.isAd("https://google.com"));
 
-        AdBlocker.init(context, Schedulers.trampoline());
+    // Test subdomain blocking
+    assertTrue("Should block sub.example.com", AdBlocker.isAd("http://sub.example.com"));
+  }
 
-        assertTrue("Should block example.com", AdBlocker.isAd("http://example.com/foo"));
-        assertTrue("Should block ad.doubleclick.net", AdBlocker.isAd("https://ad.doubleclick.net/bar"));
-        assertFalse("Should not block google.com", AdBlocker.isAd("https://google.com"));
-
-        // Test subdomain blocking
-        assertTrue("Should block sub.example.com", AdBlocker.isAd("http://sub.example.com"));
-    }
-
-    @Test
-    public void testIsAdEmpty() {
-        assertFalse(AdBlocker.isAd("http://example.com"));
-    }
+  @Test
+  public void testIsAdEmpty() {
+    assertFalse(AdBlocker.isAd("http://example.com"));
+  }
 }

--- a/app/src/test/java/io/github/sheepdestroyer/materialisheep/AdBlockerTest.java
+++ b/app/src/test/java/io/github/sheepdestroyer/materialisheep/AdBlockerTest.java
@@ -1,0 +1,78 @@
+package io.github.sheepdestroyer.materialisheep;
+
+import android.content.Context;
+import android.content.res.AssetManager;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
+
+import io.reactivex.rxjava3.schedulers.Schedulers;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = {33})
+public class AdBlockerTest {
+
+    private Context context;
+    private AssetManager assetManager;
+
+    @Before
+    public void setUp() throws Exception {
+        context = mock(Context.class);
+        assetManager = mock(AssetManager.class);
+        when(context.getAssets()).thenReturn(assetManager);
+
+        // Reset AD_HOSTS using reflection because it's static
+        resetAdHosts();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        resetAdHosts();
+    }
+
+    private void resetAdHosts() throws Exception {
+        Field field = AdBlocker.class.getDeclaredField("AD_HOSTS");
+        field.setAccessible(true);
+        Set<String> hosts = (Set<String>) field.get(null);
+        if (hosts != null) {
+            hosts.clear();
+        }
+    }
+
+    @Test
+    public void testInitAndIsAd() throws IOException {
+        String adHostsContent = "example.com\nad.doubleclick.net";
+        when(assetManager.open(anyString())).thenReturn(new ByteArrayInputStream(adHostsContent.getBytes(StandardCharsets.UTF_8)));
+
+        AdBlocker.init(context, Schedulers.trampoline());
+
+        assertTrue("Should block example.com", AdBlocker.isAd("http://example.com/foo"));
+        assertTrue("Should block ad.doubleclick.net", AdBlocker.isAd("https://ad.doubleclick.net/bar"));
+        assertFalse("Should not block google.com", AdBlocker.isAd("https://google.com"));
+
+        // Test subdomain blocking
+        assertTrue("Should block sub.example.com", AdBlocker.isAd("http://sub.example.com"));
+    }
+
+    @Test
+    public void testIsAdEmpty() {
+        assertFalse(AdBlocker.isAd("http://example.com"));
+    }
+}


### PR DESCRIPTION
This PR optimizes the `AdBlocker` class by replacing the `synchronizedSet` with a `ConcurrentHashMap`-backed Set.

**Changes:**
- Changed `AD_HOSTS` to use `Collections.newSetFromMap(new ConcurrentHashMap<>())`.
- Updated `loadFromAssets` to read all hosts into a local `HashSet` first, then add them to `AD_HOSTS` in a single `addAll` operation.
- Added `AdBlockerTest` to verify correctness and prevent regressions.

**Performance Benefits:**
- **Non-blocking Reads:** `synchronizedSet` synchronizes every method, including `contains()`. `AdBlocker.isAd()` is called frequently (for every resource request in WebViews). `ConcurrentHashMap` allows concurrent non-blocking reads, reducing overhead and potential contention.
- **Batched Initialization:** Batching the additions during initialization reduces the overhead of repeated synchronization or internal map resizing/locking.

---
*PR created automatically by Jules for task [941995844077374545](https://jules.google.com/task/941995844077374545) started by @sheepdestroyer*

## Summary by Sourcery

Optimize the AdBlocker host storage for better concurrent read performance and add regression tests.

Enhancements:
- Replace the synchronized ad host set with a ConcurrentHashMap-backed set to improve concurrent read performance.
- Batch ad host loading into a local set before populating the shared set to reduce initialization overhead.

Documentation:
- Add an internal note documenting the choice of ConcurrentHashMap-backed sets over synchronizedSet for read-heavy paths.

Tests:
- Add Robolectric-based AdBlocker tests to verify initialization and URL blocking behavior, including subdomains and empty-state handling.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Optimize `AdBlocker` by using a `ConcurrentHashMap`-backed set for non-blocking reads and batch initialization, with tests added for validation.
> 
>   - **Optimization**:
>     - Replace `synchronizedSet` with `ConcurrentHashMap`-backed set in `AdBlocker` for `AD_HOSTS`.
>     - Update `loadFromAssets` to batch add hosts using a local `HashSet` before adding to `AD_HOSTS`.
>   - **Testing**:
>     - Add `AdBlockerTest` to verify `AdBlocker` functionality and prevent regressions.
>   - **Performance**:
>     - Non-blocking reads in `isAd()` reduce overhead and contention.
>     - Batched initialization minimizes synchronization overhead.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sheepdestroyer%2Fmaterialisheep&utm_source=github&utm_medium=referral)<sup> for 7adb7d2174c409bb70c72232f9e9409f9df0cd61. You can [customize](https://app.ellipsis.dev/sheepdestroyer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved ad-blocking performance with optimized thread-safety implementation for read-heavy operations.

* **Tests**
  * Added comprehensive unit tests for ad-blocking functionality and host detection.

* **Documentation**
  * Added guidance documentation on collection synchronization strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->