### PR TITLE
⚡ Bolt: Optimize AdBlocker performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,7 @@
+## 2025-02-21 - Recursion vs Iteration in AdBlocker
+**Learning:** Recursive string matching for subdomains in `AdBlocker` can be replaced with an iterative loop to avoid stack overhead and potential StackOverflowError, although domain depth is usually small. The iterative approach is also easier to reason about and debug.
+**Action:** When implementing domain matching or similar hierarchical checks, prefer iterative loops over recursion for performance and safety.
+
+## 2025-02-21 - Concurrent Collections for Read-Heavy Sets
+**Learning:** `Collections.synchronizedSet` blocks all access, including reads. For read-heavy static sets like `AdBlocker.AD_HOSTS`, `Collections.newSetFromMap(new ConcurrentHashMap<>())` allows concurrent non-blocking reads, significantly improving performance in high-concurrency scenarios (e.g., WebView resource interception).
+**Action:** Use `ConcurrentHashMap`-backed sets for static, read-heavy collections accessed by multiple threads.

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/AdBlocker.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/AdBlocker.java
@@ -27,8 +27,10 @@ import android.webkit.WebResourceResponse;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import okhttp3.HttpUrl;
 import okio.BufferedSource;
@@ -42,7 +44,8 @@ import io.reactivex.rxjava3.core.Scheduler;
  */
 public class AdBlocker {
     private static final String AD_HOSTS_FILE = "pgl.yoyo.org.txt";
-    private static final Set<String> AD_HOSTS = java.util.Collections.synchronizedSet(new HashSet<>());
+    private static final Set<String> AD_HOSTS = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    private static final byte[] EMPTY_BYTES = new byte[0];
 
     /**
      * Initializes the ad blocker by loading the ad hosts from the assets file.
@@ -66,6 +69,9 @@ public class AdBlocker {
      * @return True if the URL is an ad, false otherwise.
      */
     public static boolean isAd(String url) {
+        if (url == null) {
+            return false;
+        }
         HttpUrl httpUrl = HttpUrl.parse(url);
         return isAdHost(httpUrl != null ? httpUrl.host() : "");
     }
@@ -76,18 +82,20 @@ public class AdBlocker {
      * @return An empty WebResourceResponse.
      */
     public static WebResourceResponse createEmptyResource() {
-        return new WebResourceResponse("text/plain", "utf-8", new ByteArrayInputStream("".getBytes()));
+        return new WebResourceResponse("text/plain", "utf-8", new ByteArrayInputStream(EMPTY_BYTES));
     }
 
     @WorkerThread
     private static Boolean loadFromAssets(Context context) throws IOException {
+        Set<String> localHosts = new HashSet<>();
         try (InputStream stream = context.getAssets().open(AD_HOSTS_FILE);
                 BufferedSource buffer = Okio.buffer(Okio.source(stream))) {
             String line;
             while ((line = buffer.readUtf8Line()) != null) {
-                AD_HOSTS.add(line);
+                localHosts.add(line);
             }
         }
+        AD_HOSTS.addAll(localHosts);
         return true;
     }
 
@@ -99,8 +107,16 @@ public class AdBlocker {
         if (TextUtils.isEmpty(host)) {
             return false;
         }
-        int index = host.indexOf(".");
-        return index >= 0 && (AD_HOSTS.contains(host) ||
-                index + 1 < host.length() && isAdHost(host.substring(index + 1)));
+        int index;
+        while ((index = host.indexOf(".")) >= 0) {
+            if (AD_HOSTS.contains(host)) {
+                return true;
+            }
+            if (index + 1 >= host.length()) {
+                break;
+            }
+            host = host.substring(index + 1);
+        }
+        return false;
     }
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/AdBlocker.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/AdBlocker.java
@@ -17,13 +17,12 @@
 package io.github.sheepdestroyer.materialisheep;
 
 import android.annotation.SuppressLint;
-import android.annotation.TargetApi;
 import android.content.Context;
-import android.os.Build;
-import androidx.annotation.WorkerThread;
 import android.text.TextUtils;
 import android.webkit.WebResourceResponse;
-
+import androidx.annotation.WorkerThread;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Scheduler;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -31,92 +30,86 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-
 import okhttp3.HttpUrl;
 import okio.BufferedSource;
 import okio.Okio;
-import io.reactivex.rxjava3.core.Observable;
-import io.reactivex.rxjava3.core.Scheduler;
 
-/**
- * A simple ad blocker that blocks network requests to hosts listed in the ad
- * hosts file.
- */
+/** A simple ad blocker that blocks network requests to hosts listed in the ad hosts file. */
 public class AdBlocker {
-    private static final String AD_HOSTS_FILE = "pgl.yoyo.org.txt";
-    private static final Set<String> AD_HOSTS = Collections.newSetFromMap(new ConcurrentHashMap<>());
-    private static final byte[] EMPTY_BYTES = new byte[0];
+  private static final String AD_HOSTS_FILE = "pgl.yoyo.org.txt";
+  private static final Set<String> AD_HOSTS = Collections.newSetFromMap(new ConcurrentHashMap<>());
+  private static final byte[] EMPTY_BYTES = new byte[0];
 
-    /**
-     * Initializes the ad blocker by loading the ad hosts from the assets file.
-     *
-     * @param context   The application context.
-     * @param scheduler The RxJava scheduler to perform the operation on.
-     */
-    @SuppressLint("CheckResult")
-    public static void init(Context context, Scheduler scheduler) {
-        Observable.fromCallable(() -> loadFromAssets(context))
-                .subscribeOn(scheduler)
-                .subscribe(result -> {
-                },
-                        t -> android.util.Log.e(AdBlocker.class.getSimpleName(), "Error loading ad hosts", t));
+  /**
+   * Initializes the ad blocker by loading the ad hosts from the assets file.
+   *
+   * @param context The application context.
+   * @param scheduler The RxJava scheduler to perform the operation on.
+   */
+  @SuppressLint("CheckResult")
+  public static void init(Context context, Scheduler scheduler) {
+    Observable.fromCallable(() -> loadFromAssets(context))
+        .subscribeOn(scheduler)
+        .subscribe(
+            result -> {},
+            t -> android.util.Log.e(AdBlocker.class.getSimpleName(), "Error loading ad hosts", t));
+  }
+
+  /**
+   * Checks if a given URL is an ad.
+   *
+   * @param url The URL to check.
+   * @return True if the URL is an ad, false otherwise.
+   */
+  public static boolean isAd(String url) {
+    if (url == null) {
+      return false;
     }
+    HttpUrl httpUrl = HttpUrl.parse(url);
+    return isAdHost(httpUrl != null ? httpUrl.host() : "");
+  }
 
-    /**
-     * Checks if a given URL is an ad.
-     *
-     * @param url The URL to check.
-     * @return True if the URL is an ad, false otherwise.
-     */
-    public static boolean isAd(String url) {
-        if (url == null) {
-            return false;
-        }
-        HttpUrl httpUrl = HttpUrl.parse(url);
-        return isAdHost(httpUrl != null ? httpUrl.host() : "");
+  /**
+   * Creates an empty WebResourceResponse to block a network request.
+   *
+   * @return An empty WebResourceResponse.
+   */
+  public static WebResourceResponse createEmptyResource() {
+    return new WebResourceResponse("text/plain", "utf-8", new ByteArrayInputStream(EMPTY_BYTES));
+  }
+
+  @WorkerThread
+  private static Boolean loadFromAssets(Context context) throws IOException {
+    Set<String> localHosts = new HashSet<>();
+    try (InputStream stream = context.getAssets().open(AD_HOSTS_FILE);
+        BufferedSource buffer = Okio.buffer(Okio.source(stream))) {
+      String line;
+      while ((line = buffer.readUtf8Line()) != null) {
+        localHosts.add(line);
+      }
     }
+    AD_HOSTS.addAll(localHosts);
+    return true;
+  }
 
-    /**
-     * Creates an empty WebResourceResponse to block a network request.
-     *
-     * @return An empty WebResourceResponse.
-     */
-    public static WebResourceResponse createEmptyResource() {
-        return new WebResourceResponse("text/plain", "utf-8", new ByteArrayInputStream(EMPTY_BYTES));
+  /**
+   * Recursively walking up sub domain chain until we exhaust or find a match, effectively doing a
+   * longest substring matching here
+   */
+  private static boolean isAdHost(String host) {
+    if (TextUtils.isEmpty(host)) {
+      return false;
     }
-
-    @WorkerThread
-    private static Boolean loadFromAssets(Context context) throws IOException {
-        Set<String> localHosts = new HashSet<>();
-        try (InputStream stream = context.getAssets().open(AD_HOSTS_FILE);
-                BufferedSource buffer = Okio.buffer(Okio.source(stream))) {
-            String line;
-            while ((line = buffer.readUtf8Line()) != null) {
-                localHosts.add(line);
-            }
-        }
-        AD_HOSTS.addAll(localHosts);
+    int index;
+    while ((index = host.indexOf(".")) >= 0) {
+      if (AD_HOSTS.contains(host)) {
         return true;
+      }
+      if (index + 1 >= host.length()) {
+        break;
+      }
+      host = host.substring(index + 1);
     }
-
-    /**
-     * Recursively walking up sub domain chain until we exhaust or find a match,
-     * effectively doing a longest substring matching here
-     */
-    private static boolean isAdHost(String host) {
-        if (TextUtils.isEmpty(host)) {
-            return false;
-        }
-        int index;
-        while ((index = host.indexOf(".")) >= 0) {
-            if (AD_HOSTS.contains(host)) {
-                return true;
-            }
-            if (index + 1 >= host.length()) {
-                break;
-            }
-            host = host.substring(index + 1);
-        }
-        return false;
-    }
+    return false;
+  }
 }

--- a/app/src/test/java/io/github/sheepdestroyer/materialisheep/AdBlockerTest.java
+++ b/app/src/test/java/io/github/sheepdestroyer/materialisheep/AdBlockerTest.java
@@ -1,60 +1,60 @@
 package io.github.sheepdestroyer.materialisheep;
 
-import android.webkit.WebResourceResponse;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
-
-import java.io.InputStream;
-import java.lang.reflect.Field;
-import java.util.Set;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import android.webkit.WebResourceResponse;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.util.Set;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
 @RunWith(RobolectricTestRunner.class)
 public class AdBlockerTest {
 
-    @Before
-    public void setUp() throws Exception {
-        // Clear and populate AD_HOSTS using reflection
-        Field adHostsField = AdBlocker.class.getDeclaredField("AD_HOSTS");
-        adHostsField.setAccessible(true);
-        @SuppressWarnings("unchecked")
-        Set<String> adHosts = (Set<String>) adHostsField.get(null);
-        adHosts.clear();
-        adHosts.add("ad.com");
-        adHosts.add("foo.bar.com");
-    }
+  @Before
+  public void setUp() throws Exception {
+    // Clear and populate AD_HOSTS using reflection
+    Field adHostsField = AdBlocker.class.getDeclaredField("AD_HOSTS");
+    adHostsField.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    Set<String> adHosts = (Set<String>) adHostsField.get(null);
+    adHosts.clear();
+    adHosts.add("ad.com");
+    adHosts.add("foo.bar.com");
+  }
 
-    @Test
-    public void testIsAd() {
-        assertTrue(AdBlocker.isAd("http://ad.com"));
-        assertTrue(AdBlocker.isAd("https://ad.com/some/path"));
-        assertTrue(AdBlocker.isAd("http://sub.ad.com"));
-        assertTrue(AdBlocker.isAd("http://foo.bar.com"));
-        assertTrue(AdBlocker.isAd("http://sub.foo.bar.com"));
-        assertFalse(AdBlocker.isAd("http://safe.com"));
-        assertFalse(AdBlocker.isAd("http://bar.com")); // substring match shouldn't trigger unless it's a subdomain
-    }
+  @Test
+  public void testIsAd() {
+    assertTrue(AdBlocker.isAd("http://ad.com"));
+    assertTrue(AdBlocker.isAd("https://ad.com/some/path"));
+    assertTrue(AdBlocker.isAd("http://sub.ad.com"));
+    assertTrue(AdBlocker.isAd("http://foo.bar.com"));
+    assertTrue(AdBlocker.isAd("http://sub.foo.bar.com"));
+    assertFalse(AdBlocker.isAd("http://safe.com"));
+    assertFalse(
+        AdBlocker.isAd(
+            "http://bar.com")); // substring match shouldn't trigger unless it's a subdomain
+  }
 
-    @Test
-    public void testIsAdNull() {
-        assertFalse(AdBlocker.isAd(null));
-    }
+  @Test
+  public void testIsAdNull() {
+    assertFalse(AdBlocker.isAd(null));
+  }
 
-    @Test
-    public void testCreateEmptyResource() throws Exception {
-        WebResourceResponse response = AdBlocker.createEmptyResource();
-        assertNotNull(response);
-        assertEquals("text/plain", response.getMimeType());
-        assertEquals("utf-8", response.getEncoding());
-        InputStream data = response.getData();
-        assertNotNull(data);
-        assertEquals(0, data.available());
-    }
+  @Test
+  public void testCreateEmptyResource() throws Exception {
+    WebResourceResponse response = AdBlocker.createEmptyResource();
+    assertNotNull(response);
+    assertEquals("text/plain", response.getMimeType());
+    assertEquals("utf-8", response.getEncoding());
+    InputStream data = response.getData();
+    assertNotNull(data);
+    assertEquals(0, data.available());
+  }
 }

--- a/app/src/test/java/io/github/sheepdestroyer/materialisheep/AdBlockerTest.java
+++ b/app/src/test/java/io/github/sheepdestroyer/materialisheep/AdBlockerTest.java
@@ -1,0 +1,60 @@
+package io.github.sheepdestroyer.materialisheep;
+
+import android.webkit.WebResourceResponse;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(RobolectricTestRunner.class)
+public class AdBlockerTest {
+
+    @Before
+    public void setUp() throws Exception {
+        // Clear and populate AD_HOSTS using reflection
+        Field adHostsField = AdBlocker.class.getDeclaredField("AD_HOSTS");
+        adHostsField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Set<String> adHosts = (Set<String>) adHostsField.get(null);
+        adHosts.clear();
+        adHosts.add("ad.com");
+        adHosts.add("foo.bar.com");
+    }
+
+    @Test
+    public void testIsAd() {
+        assertTrue(AdBlocker.isAd("http://ad.com"));
+        assertTrue(AdBlocker.isAd("https://ad.com/some/path"));
+        assertTrue(AdBlocker.isAd("http://sub.ad.com"));
+        assertTrue(AdBlocker.isAd("http://foo.bar.com"));
+        assertTrue(AdBlocker.isAd("http://sub.foo.bar.com"));
+        assertFalse(AdBlocker.isAd("http://safe.com"));
+        assertFalse(AdBlocker.isAd("http://bar.com")); // substring match shouldn't trigger unless it's a subdomain
+    }
+
+    @Test
+    public void testIsAdNull() {
+        assertFalse(AdBlocker.isAd(null));
+    }
+
+    @Test
+    public void testCreateEmptyResource() throws Exception {
+        WebResourceResponse response = AdBlocker.createEmptyResource();
+        assertNotNull(response);
+        assertEquals("text/plain", response.getMimeType());
+        assertEquals("utf-8", response.getEncoding());
+        InputStream data = response.getData();
+        assertNotNull(data);
+        assertEquals(0, data.available());
+    }
+}


### PR DESCRIPTION
💡 What: Replaced synchronized `Set` with `ConcurrentHashMap`-backed set for non-blocking reads. Converted recursive domain matching to iterative loop. Reused empty byte array for `WebResourceResponse` to reduce allocations. Batched `AD_HOSTS` initialization.
🎯 Why: `AdBlocker.isAd` is called for every resource in `WebView`. Synchronization on `AD_HOSTS` caused lock contention. Recursion added unnecessary stack overhead. Frequent `byte[]` allocation increased GC pressure.
📊 Impact: Expected to reduce lock contention significantly during page loads with many resources. Reduced memory allocation for blocked requests.
🔬 Measurement: Verified with `AdBlockerTest` covering correctness, null handling, and functionality.

---
*PR created automatically by Jules for task [8513578760795792171](https://jules.google.com/task/8513578760795792171) started by @sheepdestroyer*
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Optimizes `AdBlocker` performance by using concurrent collections, iterative domain matching, and reducing memory allocations, verified with tests.
> 
>   - **Performance Optimization**:
>     - Replaced `Collections.synchronizedSet` with `ConcurrentHashMap`-backed set for `AD_HOSTS` in `AdBlocker.java` to allow non-blocking reads.
>     - Converted recursive domain matching in `isAdHost()` to an iterative loop to reduce stack overhead.
>     - Reused `EMPTY_BYTES` array in `createEmptyResource()` to minimize memory allocations.
>   - **Initialization**:
>     - Batched `AD_HOSTS` initialization by using a local `HashSet` before adding to `AD_HOSTS`.
>   - **Testing**:
>     - Added `AdBlockerTest.java` to verify `isAd()`, `isAdHost()`, and `createEmptyResource()` functions, including null handling and subdomain checks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sheepdestroyer%2Fmaterialisheep&utm_source=github&utm_medium=referral)<sup> for 52558d82f3ddca89bbf15c59258bc4f77248ea4d. You can [customize](https://app.ellipsis.dev/sheepdestroyer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

## Summary by Sourcery

Optimize AdBlocker URL filtering for better performance and safety under heavy WebView load.

Bug Fixes:
- Handle null URLs safely in AdBlocker.isAd to avoid potential runtime errors.

Enhancements:
- Replace synchronized ad host set with a ConcurrentHashMap-backed set to allow concurrent, non-blocking reads.
- Batch-load ad host entries into a local set before adding them to the shared AD_HOSTS collection to reduce contention.
- Convert recursive ad host domain matching to an iterative loop to remove stack overhead and improve robustness.
- Reuse a shared empty byte array when creating empty WebResourceResponse instances to reduce memory allocations.

Documentation:
- Add Jules bolt note documenting learnings about recursion vs iteration and concurrent collections for AdBlocker.

Tests:
- Add Robolectric unit tests for AdBlocker URL classification and empty WebResourceResponse creation, including null handling and subdomain behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced robustness of ad detection with improved null input handling

* **Performance**
  * Optimized ad-blocking operations for better performance under concurrent access patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->