### PR TITLE
⚡ Bolt: Optimize AdBlocker performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-05-23 - SynchronizedSet bottleneck in Read-Heavy Static Cache
+**Learning:** `Collections.synchronizedSet(new HashSet<>())` creates a global lock for every read operation (`contains()`). In a high-concurrency scenario like network interception (`AdBlockWebViewClient`), this serializes all checks, even for different URLs.
+**Action:** Use `ConcurrentHashMap.newKeySet()` (or `Collections.newSetFromMap(new ConcurrentHashMap<>())` for lower API levels without desugaring) for read-heavy static caches to allow non-blocking concurrent reads.

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/AdBlocker.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/AdBlocker.java
@@ -17,101 +17,94 @@
 package io.github.sheepdestroyer.materialisheep;
 
 import android.annotation.SuppressLint;
-import android.annotation.TargetApi;
 import android.content.Context;
-import android.os.Build;
-import androidx.annotation.WorkerThread;
 import android.text.TextUtils;
 import android.webkit.WebResourceResponse;
-
+import androidx.annotation.WorkerThread;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Scheduler;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-
 import okhttp3.HttpUrl;
 import okio.BufferedSource;
 import okio.Okio;
-import io.reactivex.rxjava3.core.Observable;
-import io.reactivex.rxjava3.core.Scheduler;
 
-/**
- * A simple ad blocker that blocks network requests to hosts listed in the ad
- * hosts file.
- */
+/** A simple ad blocker that blocks network requests to hosts listed in the ad hosts file. */
 public class AdBlocker {
-    private static final String AD_HOSTS_FILE = "pgl.yoyo.org.txt";
-    private static final Set<String> AD_HOSTS = ConcurrentHashMap.newKeySet();
-    private static final byte[] EMPTY_BYTES = new byte[0];
+  private static final String AD_HOSTS_FILE = "pgl.yoyo.org.txt";
+  private static final Set<String> AD_HOSTS = ConcurrentHashMap.newKeySet();
+  private static final byte[] EMPTY_BYTES = new byte[0];
 
-    /**
-     * Initializes the ad blocker by loading the ad hosts from the assets file.
-     *
-     * @param context   The application context.
-     * @param scheduler The RxJava scheduler to perform the operation on.
-     */
-    @SuppressLint("CheckResult")
-    public static void init(Context context, Scheduler scheduler) {
-        Observable.fromCallable(() -> loadFromAssets(context))
-                .subscribeOn(scheduler)
-                .subscribe(result -> {
-                },
-                        t -> android.util.Log.e(AdBlocker.class.getSimpleName(), "Error loading ad hosts", t));
+  /**
+   * Initializes the ad blocker by loading the ad hosts from the assets file.
+   *
+   * @param context The application context.
+   * @param scheduler The RxJava scheduler to perform the operation on.
+   */
+  @SuppressLint("CheckResult")
+  public static void init(Context context, Scheduler scheduler) {
+    Observable.fromCallable(() -> loadFromAssets(context))
+        .subscribeOn(scheduler)
+        .subscribe(
+            result -> {},
+            t -> android.util.Log.e(AdBlocker.class.getSimpleName(), "Error loading ad hosts", t));
+  }
+
+  /**
+   * Checks if a given URL is an ad.
+   *
+   * @param url The URL to check.
+   * @return True if the URL is an ad, false otherwise.
+   */
+  public static boolean isAd(String url) {
+    HttpUrl httpUrl = HttpUrl.parse(url);
+    return isAdHost(httpUrl != null ? httpUrl.host() : "");
+  }
+
+  /**
+   * Creates an empty WebResourceResponse to block a network request.
+   *
+   * @return An empty WebResourceResponse.
+   */
+  public static WebResourceResponse createEmptyResource() {
+    return new WebResourceResponse("text/plain", "utf-8", new ByteArrayInputStream(EMPTY_BYTES));
+  }
+
+  @WorkerThread
+  private static Boolean loadFromAssets(Context context) throws IOException {
+    try (InputStream stream = context.getAssets().open(AD_HOSTS_FILE);
+        BufferedSource buffer = Okio.buffer(Okio.source(stream))) {
+      String line;
+      while ((line = buffer.readUtf8Line()) != null) {
+        AD_HOSTS.add(line);
+      }
     }
+    return true;
+  }
 
-    /**
-     * Checks if a given URL is an ad.
-     *
-     * @param url The URL to check.
-     * @return True if the URL is an ad, false otherwise.
-     */
-    public static boolean isAd(String url) {
-        HttpUrl httpUrl = HttpUrl.parse(url);
-        return isAdHost(httpUrl != null ? httpUrl.host() : "");
+  /**
+   * Recursively walking up sub domain chain until we exhaust or find a match, effectively doing a
+   * longest substring matching here
+   */
+  private static boolean isAdHost(String host) {
+    if (TextUtils.isEmpty(host)) {
+      return false;
     }
-
-    /**
-     * Creates an empty WebResourceResponse to block a network request.
-     *
-     * @return An empty WebResourceResponse.
-     */
-    public static WebResourceResponse createEmptyResource() {
-        return new WebResourceResponse("text/plain", "utf-8", new ByteArrayInputStream(EMPTY_BYTES));
-    }
-
-    @WorkerThread
-    private static Boolean loadFromAssets(Context context) throws IOException {
-        try (InputStream stream = context.getAssets().open(AD_HOSTS_FILE);
-                BufferedSource buffer = Okio.buffer(Okio.source(stream))) {
-            String line;
-            while ((line = buffer.readUtf8Line()) != null) {
-                AD_HOSTS.add(line);
-            }
-        }
+    int index = host.indexOf(".");
+    while (index >= 0) {
+      if (AD_HOSTS.contains(host)) {
         return true;
+      }
+      if (index + 1 < host.length()) {
+        host = host.substring(index + 1);
+        index = host.indexOf(".");
+      } else {
+        break;
+      }
     }
-
-    /**
-     * Recursively walking up sub domain chain until we exhaust or find a match,
-     * effectively doing a longest substring matching here
-     */
-    private static boolean isAdHost(String host) {
-        if (TextUtils.isEmpty(host)) {
-            return false;
-        }
-        int index = host.indexOf(".");
-        while (index >= 0) {
-            if (AD_HOSTS.contains(host)) {
-                return true;
-            }
-            if (index + 1 < host.length()) {
-                host = host.substring(index + 1);
-                index = host.indexOf(".");
-            } else {
-                break;
-            }
-        }
-        return false;
-    }
+    return false;
+  }
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/AdBlocker.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/AdBlocker.java
@@ -27,8 +27,8 @@ import android.webkit.WebResourceResponse;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import okhttp3.HttpUrl;
 import okio.BufferedSource;
@@ -42,7 +42,8 @@ import io.reactivex.rxjava3.core.Scheduler;
  */
 public class AdBlocker {
     private static final String AD_HOSTS_FILE = "pgl.yoyo.org.txt";
-    private static final Set<String> AD_HOSTS = java.util.Collections.synchronizedSet(new HashSet<>());
+    private static final Set<String> AD_HOSTS = ConcurrentHashMap.newKeySet();
+    private static final byte[] EMPTY_BYTES = new byte[0];
 
     /**
      * Initializes the ad blocker by loading the ad hosts from the assets file.
@@ -76,7 +77,7 @@ public class AdBlocker {
      * @return An empty WebResourceResponse.
      */
     public static WebResourceResponse createEmptyResource() {
-        return new WebResourceResponse("text/plain", "utf-8", new ByteArrayInputStream("".getBytes()));
+        return new WebResourceResponse("text/plain", "utf-8", new ByteArrayInputStream(EMPTY_BYTES));
     }
 
     @WorkerThread
@@ -100,7 +101,17 @@ public class AdBlocker {
             return false;
         }
         int index = host.indexOf(".");
-        return index >= 0 && (AD_HOSTS.contains(host) ||
-                index + 1 < host.length() && isAdHost(host.substring(index + 1)));
+        while (index >= 0) {
+            if (AD_HOSTS.contains(host)) {
+                return true;
+            }
+            if (index + 1 < host.length()) {
+                host = host.substring(index + 1);
+                index = host.indexOf(".");
+            } else {
+                break;
+            }
+        }
+        return false;
     }
 }

--- a/app/src/test/java/io/github/sheepdestroyer/materialisheep/AdBlockerTest.java
+++ b/app/src/test/java/io/github/sheepdestroyer/materialisheep/AdBlockerTest.java
@@ -1,0 +1,86 @@
+package io.github.sheepdestroyer.materialisheep;
+
+import android.content.Context;
+import android.content.res.AssetManager;
+import android.webkit.WebResourceResponse;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricTestRunner;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
+
+import io.reactivex.rxjava3.schedulers.Schedulers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@RunWith(RobolectricTestRunner.class)
+public class AdBlockerTest {
+    @Mock
+    private Context context;
+    @Mock
+    private AssetManager assetManager;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.openMocks(this);
+        when(context.getAssets()).thenReturn(assetManager);
+
+        // Reset AD_HOSTS using reflection
+        Field adHostsField = AdBlocker.class.getDeclaredField("AD_HOSTS");
+        adHostsField.setAccessible(true);
+        Set<String> adHosts = (Set<String>) adHostsField.get(null);
+        adHosts.clear();
+    }
+
+    @Test
+    public void testInitLoadsHosts() throws IOException {
+        String hosts = "ad.com\ndoubleclick.net";
+        InputStream stream = new ByteArrayInputStream(hosts.getBytes(StandardCharsets.UTF_8));
+        when(assetManager.open(anyString())).thenReturn(stream);
+
+        AdBlocker.init(context, Schedulers.trampoline());
+
+        assertTrue(AdBlocker.isAd("http://ad.com"));
+        assertTrue(AdBlocker.isAd("https://doubleclick.net/some/path"));
+        assertFalse(AdBlocker.isAd("http://google.com"));
+    }
+
+    @Test
+    public void testSubdomainMatching() throws IOException {
+        String hosts = "ad.com";
+        InputStream stream = new ByteArrayInputStream(hosts.getBytes(StandardCharsets.UTF_8));
+        when(assetManager.open(anyString())).thenReturn(stream);
+
+        AdBlocker.init(context, Schedulers.trampoline());
+
+        assertTrue(AdBlocker.isAd("http://sub.ad.com"));
+        assertTrue(AdBlocker.isAd("http://sub.sub.ad.com"));
+        assertFalse(AdBlocker.isAd("http://notad.com"));
+    }
+
+    @Test
+    public void testCreateEmptyResource() throws IOException {
+        WebResourceResponse response = AdBlocker.createEmptyResource();
+        assertNotNull(response);
+        assertEquals("text/plain", response.getMimeType());
+        assertEquals("utf-8", response.getEncoding());
+
+        InputStream data = response.getData();
+        assertNotNull(data);
+        assertEquals(-1, data.read());
+    }
+}

--- a/app/src/test/java/io/github/sheepdestroyer/materialisheep/AdBlockerTest.java
+++ b/app/src/test/java/io/github/sheepdestroyer/materialisheep/AdBlockerTest.java
@@ -1,25 +1,5 @@
 package io.github.sheepdestroyer.materialisheep;
 
-import android.content.Context;
-import android.content.res.AssetManager;
-import android.webkit.WebResourceResponse;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.robolectric.RobolectricTestRunner;
-
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.lang.reflect.Field;
-import java.nio.charset.StandardCharsets;
-import java.util.Set;
-
-import io.reactivex.rxjava3.schedulers.Schedulers;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -27,60 +7,75 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
+import android.content.Context;
+import android.content.res.AssetManager;
+import android.webkit.WebResourceResponse;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricTestRunner;
+
 @RunWith(RobolectricTestRunner.class)
 public class AdBlockerTest {
-    @Mock
-    private Context context;
-    @Mock
-    private AssetManager assetManager;
+  @Mock private Context context;
+  @Mock private AssetManager assetManager;
 
-    @Before
-    public void setUp() throws Exception {
-        MockitoAnnotations.openMocks(this);
-        when(context.getAssets()).thenReturn(assetManager);
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this);
+    when(context.getAssets()).thenReturn(assetManager);
 
-        // Reset AD_HOSTS using reflection
-        Field adHostsField = AdBlocker.class.getDeclaredField("AD_HOSTS");
-        adHostsField.setAccessible(true);
-        Set<String> adHosts = (Set<String>) adHostsField.get(null);
-        adHosts.clear();
-    }
+    // Reset AD_HOSTS using reflection
+    Field adHostsField = AdBlocker.class.getDeclaredField("AD_HOSTS");
+    adHostsField.setAccessible(true);
+    Set<String> adHosts = (Set<String>) adHostsField.get(null);
+    adHosts.clear();
+  }
 
-    @Test
-    public void testInitLoadsHosts() throws IOException {
-        String hosts = "ad.com\ndoubleclick.net";
-        InputStream stream = new ByteArrayInputStream(hosts.getBytes(StandardCharsets.UTF_8));
-        when(assetManager.open(anyString())).thenReturn(stream);
+  @Test
+  public void testInitLoadsHosts() throws IOException {
+    String hosts = "ad.com\ndoubleclick.net";
+    InputStream stream = new ByteArrayInputStream(hosts.getBytes(StandardCharsets.UTF_8));
+    when(assetManager.open(anyString())).thenReturn(stream);
 
-        AdBlocker.init(context, Schedulers.trampoline());
+    AdBlocker.init(context, Schedulers.trampoline());
 
-        assertTrue(AdBlocker.isAd("http://ad.com"));
-        assertTrue(AdBlocker.isAd("https://doubleclick.net/some/path"));
-        assertFalse(AdBlocker.isAd("http://google.com"));
-    }
+    assertTrue(AdBlocker.isAd("http://ad.com"));
+    assertTrue(AdBlocker.isAd("https://doubleclick.net/some/path"));
+    assertFalse(AdBlocker.isAd("http://google.com"));
+  }
 
-    @Test
-    public void testSubdomainMatching() throws IOException {
-        String hosts = "ad.com";
-        InputStream stream = new ByteArrayInputStream(hosts.getBytes(StandardCharsets.UTF_8));
-        when(assetManager.open(anyString())).thenReturn(stream);
+  @Test
+  public void testSubdomainMatching() throws IOException {
+    String hosts = "ad.com";
+    InputStream stream = new ByteArrayInputStream(hosts.getBytes(StandardCharsets.UTF_8));
+    when(assetManager.open(anyString())).thenReturn(stream);
 
-        AdBlocker.init(context, Schedulers.trampoline());
+    AdBlocker.init(context, Schedulers.trampoline());
 
-        assertTrue(AdBlocker.isAd("http://sub.ad.com"));
-        assertTrue(AdBlocker.isAd("http://sub.sub.ad.com"));
-        assertFalse(AdBlocker.isAd("http://notad.com"));
-    }
+    assertTrue(AdBlocker.isAd("http://sub.ad.com"));
+    assertTrue(AdBlocker.isAd("http://sub.sub.ad.com"));
+    assertFalse(AdBlocker.isAd("http://notad.com"));
+  }
 
-    @Test
-    public void testCreateEmptyResource() throws IOException {
-        WebResourceResponse response = AdBlocker.createEmptyResource();
-        assertNotNull(response);
-        assertEquals("text/plain", response.getMimeType());
-        assertEquals("utf-8", response.getEncoding());
+  @Test
+  public void testCreateEmptyResource() throws IOException {
+    WebResourceResponse response = AdBlocker.createEmptyResource();
+    assertNotNull(response);
+    assertEquals("text/plain", response.getMimeType());
+    assertEquals("utf-8", response.getEncoding());
 
-        InputStream data = response.getData();
-        assertNotNull(data);
-        assertEquals(-1, data.read());
-    }
+    InputStream data = response.getData();
+    assertNotNull(data);
+    assertEquals(-1, data.read());
+  }
 }


### PR DESCRIPTION
💡 What: Optimized AdBlocker.java by switching from a synchronized HashSet to ConcurrentHashMap, reusing a static empty byte array for blocked responses, and replacing recursive subdomain checks with an iterative loop.
🎯 Why: The synchronized set caused thread contention during concurrent network requests in WebView. Recursive calls added unnecessary stack overhead. Frequent allocation of empty byte arrays for blocked ads increased GC pressure.
📊 Impact: Eliminates lock contention on ad checks, reduces object allocation for every blocked ad, and avoids stack overflow risks for deep subdomains.
🔬 Measurement: Verified with new AdBlockerTest covering all scenarios.

---
*PR created automatically by Jules for task [2471802733979800897](https://jules.google.com/task/2471802733979800897) started by @sheepdestroyer*

## Summary by Sourcery

Optimize the AdBlocker host lookup and empty-response handling for better performance and test coverage.

Enhancements:
- Replace the synchronized ad-host set with a concurrent key set to remove contention during host checks.
- Refine ad-host matching logic to use an iterative subdomain walk instead of recursion for improved robustness and efficiency.
- Reuse a shared empty byte array when creating blocked WebResourceResponses to reduce allocations.

Tests:
- Add Robolectric-based AdBlocker tests covering host loading, subdomain matching, and empty response behavior.

Chores:
- Add a Jules bolt note documenting learnings about synchronized sets versus concurrent sets in read-heavy caches.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Optimize `AdBlocker` performance by using `ConcurrentHashMap`, reusing static byte arrays, and iterating subdomain checks.
> 
>   - **Performance Optimization**:
>     - Replace `synchronizedSet` with `ConcurrentHashMap.newKeySet()` in `AdBlocker.java` to eliminate lock contention.
>     - Reuse static `EMPTY_BYTES` array in `createEmptyResource()` to reduce GC pressure.
>     - Convert recursive subdomain check in `isAdHost()` to an iterative loop to avoid stack overflow.
>   - **Testing**:
>     - Add `AdBlockerTest.java` to verify ad blocking, subdomain matching, and empty resource creation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sheepdestroyer%2Fmaterialisheep&utm_source=github&utm_medium=referral)<sup> for 5a269f6c2cdce78aaf8d4961f58736aff2d8ff89. You can [customize](https://app.ellipsis.dev/sheepdestroyer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized ad-blocker request handling for improved performance under heavy load.
* **Tests**
  * Comprehensive test suite added for ad-blocking functionality, covering host matching, subdomain patterns, and response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->