### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix WebView file access vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-18 - WebView File Access Vulnerability
+**Vulnerability:** `CacheableWebView` enables `setAllowFileAccess(true)` to support its offline archive feature, but `AdBlockWebViewClient` did not restrict which `file://` URLs could be loaded. This created a potential for Local File Inclusion (LFI) or path traversal if a malicious URL was loaded.
+**Learning:** Enabling file access in WebView is dangerous and requires strict filtering in `shouldInterceptRequest`. Simple `startsWith` checks are insufficient; canonical paths must be used to prevent `..` traversal attacks.
+**Prevention:** Always use `File.getCanonicalPath()` when validating file paths against an allowlist. Block all `file://` URLs by default and explicitly allow only necessary directories (e.g., `android_asset` or specific cache folders).

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/OfflineWebActivity.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/OfflineWebActivity.java
@@ -18,91 +18,90 @@ package io.github.sheepdestroyer.materialisheep;
 
 import android.graphics.Color;
 import android.os.Bundle;
+import androidx.core.widget.NestedScrollView;
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.widget.Toolbar;
 import android.text.TextUtils;
 import android.view.MenuItem;
 import android.view.View;
 import android.webkit.WebView;
 import android.widget.ProgressBar;
-import androidx.appcompat.app.ActionBar;
-import androidx.appcompat.widget.Toolbar;
-import androidx.core.widget.NestedScrollView;
+
 import io.github.sheepdestroyer.materialisheep.widget.AdBlockWebViewClient;
 import io.github.sheepdestroyer.materialisheep.widget.CacheableWebView;
 
-/** An activity that displays a web page in offline mode. */
+/**
+ * An activity that displays a web page in offline mode.
+ */
 public class OfflineWebActivity extends ThemedActivity {
-  static final String EXTRA_URL = OfflineWebActivity.class.getName() + ".EXTRA_URL";
+    static final String EXTRA_URL = OfflineWebActivity.class.getName() + ".EXTRA_URL";
 
-  /**
-   * Called when the activity is first created.
-   *
-   * @param savedInstanceState If the activity is being re-initialized after previously being shut
-   *     down then this Bundle contains the data it most recently supplied in {@link
-   *     #onSaveInstanceState(Bundle)}. Otherwise it is null.
-   */
-  @SuppressWarnings("ConstantConditions")
-  @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    ((MaterialisticApplication) getApplication()).applicationComponent.inject(this);
-    String url = getIntent().getStringExtra(EXTRA_URL);
-    if (TextUtils.isEmpty(url)) {
-      finish();
-      return;
-    }
-    setTitle(url);
-    setContentView(R.layout.activity_offline_web);
-    final NestedScrollView scrollView = (NestedScrollView) findViewById(R.id.nested_scroll_view);
-    Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
-    toolbar.setOnClickListener(v -> scrollView.smoothScrollTo(0, 0));
-    setSupportActionBar(toolbar);
-    getSupportActionBar()
-        .setDisplayOptions(
-            ActionBar.DISPLAY_SHOW_HOME
-                | ActionBar.DISPLAY_HOME_AS_UP
-                | ActionBar.DISPLAY_SHOW_TITLE);
-    getSupportActionBar().setSubtitle(R.string.offline);
-    final ProgressBar progressBar = (ProgressBar) findViewById(R.id.progress);
-    final WebView webView = (WebView) findViewById(R.id.web_view);
-    webView.setBackgroundColor(Color.TRANSPARENT);
-    webView.setWebViewClient(
-        new AdBlockWebViewClient(this, Preferences.adBlockEnabled(this)) {
-          @Override
-          public void onPageFinished(WebView view, String url) {
-            setTitle(view.getTitle());
-          }
-        });
-    webView.setWebChromeClient(
-        new CacheableWebView.ArchiveClient() {
-          @Override
-          public void onProgressChanged(WebView view, int newProgress) {
-            super.onProgressChanged(view, newProgress);
-            progressBar.setVisibility(View.VISIBLE);
-            progressBar.setProgress(newProgress);
-            if (newProgress == 100) {
-              progressBar.setVisibility(View.GONE);
-              webView.setBackgroundColor(Color.WHITE);
-              webView.setVisibility(View.VISIBLE);
+    /**
+     * Called when the activity is first created.
+     *
+     * @param savedInstanceState If the activity is being re-initialized after
+     *                           previously being shut down then this Bundle contains the data it most
+     *                           recently supplied in {@link #onSaveInstanceState(Bundle)}.
+     *                           Otherwise it is null.
+     */
+    @SuppressWarnings("ConstantConditions")
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        ((MaterialisticApplication) getApplication()).applicationComponent.inject(this);
+        String url = getIntent().getStringExtra(EXTRA_URL);
+        if (TextUtils.isEmpty(url)) {
+            finish();
+            return;
+        }
+        setTitle(url);
+        setContentView(R.layout.activity_offline_web);
+        final NestedScrollView scrollView = (NestedScrollView) findViewById(R.id.nested_scroll_view);
+        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+        toolbar.setOnClickListener(v -> scrollView.smoothScrollTo(0, 0));
+        setSupportActionBar(toolbar);
+        getSupportActionBar().setDisplayOptions(ActionBar.DISPLAY_SHOW_HOME |
+                ActionBar.DISPLAY_HOME_AS_UP | ActionBar.DISPLAY_SHOW_TITLE);
+        getSupportActionBar().setSubtitle(R.string.offline);
+        final ProgressBar progressBar = (ProgressBar) findViewById(R.id.progress);
+        final WebView webView = (WebView) findViewById(R.id.web_view);
+        webView.setBackgroundColor(Color.TRANSPARENT);
+        webView.setWebViewClient(new AdBlockWebViewClient(this, Preferences.adBlockEnabled(this)) {
+            @Override
+            public void onPageFinished(WebView view, String url) {
+                setTitle(view.getTitle());
             }
-          }
         });
-    AppUtils.toggleWebViewZoom(webView.getSettings(), true);
-    webView.loadUrl(url);
-  }
-
-  /**
-   * This hook is called whenever an item in your options menu is selected.
-   *
-   * @param item The menu item that was selected.
-   * @return boolean Return false to allow normal menu processing to proceed, true to consume it
-   *     here.
-   */
-  @Override
-  public boolean onOptionsItemSelected(MenuItem item) {
-    if (item.getItemId() == android.R.id.home) {
-      finish();
-      return true;
+        webView.setWebChromeClient(new CacheableWebView.ArchiveClient() {
+            @Override
+            public void onProgressChanged(WebView view, int newProgress) {
+                super.onProgressChanged(view, newProgress);
+                progressBar.setVisibility(View.VISIBLE);
+                progressBar.setProgress(newProgress);
+                if (newProgress == 100) {
+                    progressBar.setVisibility(View.GONE);
+                    webView.setBackgroundColor(Color.WHITE);
+                    webView.setVisibility(View.VISIBLE);
+                }
+            }
+        });
+        AppUtils.toggleWebViewZoom(webView.getSettings(), true);
+        webView.loadUrl(url);
     }
-    return super.onOptionsItemSelected(item);
-  }
+
+    /**
+     * This hook is called whenever an item in your options menu is selected.
+     *
+     * @param item The menu item that was selected.
+     * @return boolean Return false to allow normal menu processing to
+     *         proceed, true to consume it here.
+     */
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == android.R.id.home) {
+            finish();
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/OfflineWebActivity.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/OfflineWebActivity.java
@@ -18,90 +18,91 @@ package io.github.sheepdestroyer.materialisheep;
 
 import android.graphics.Color;
 import android.os.Bundle;
-import androidx.core.widget.NestedScrollView;
-import androidx.appcompat.app.ActionBar;
-import androidx.appcompat.widget.Toolbar;
 import android.text.TextUtils;
 import android.view.MenuItem;
 import android.view.View;
 import android.webkit.WebView;
 import android.widget.ProgressBar;
-
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.widget.Toolbar;
+import androidx.core.widget.NestedScrollView;
 import io.github.sheepdestroyer.materialisheep.widget.AdBlockWebViewClient;
 import io.github.sheepdestroyer.materialisheep.widget.CacheableWebView;
 
-/**
- * An activity that displays a web page in offline mode.
- */
+/** An activity that displays a web page in offline mode. */
 public class OfflineWebActivity extends ThemedActivity {
-    static final String EXTRA_URL = OfflineWebActivity.class.getName() + ".EXTRA_URL";
+  static final String EXTRA_URL = OfflineWebActivity.class.getName() + ".EXTRA_URL";
 
-    /**
-     * Called when the activity is first created.
-     *
-     * @param savedInstanceState If the activity is being re-initialized after
-     *                           previously being shut down then this Bundle contains the data it most
-     *                           recently supplied in {@link #onSaveInstanceState(Bundle)}.
-     *                           Otherwise it is null.
-     */
-    @SuppressWarnings("ConstantConditions")
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        ((MaterialisticApplication) getApplication()).applicationComponent.inject(this);
-        String url = getIntent().getStringExtra(EXTRA_URL);
-        if (TextUtils.isEmpty(url)) {
-            finish();
-            return;
-        }
-        setTitle(url);
-        setContentView(R.layout.activity_offline_web);
-        final NestedScrollView scrollView = (NestedScrollView) findViewById(R.id.nested_scroll_view);
-        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
-        toolbar.setOnClickListener(v -> scrollView.smoothScrollTo(0, 0));
-        setSupportActionBar(toolbar);
-        getSupportActionBar().setDisplayOptions(ActionBar.DISPLAY_SHOW_HOME |
-                ActionBar.DISPLAY_HOME_AS_UP | ActionBar.DISPLAY_SHOW_TITLE);
-        getSupportActionBar().setSubtitle(R.string.offline);
-        final ProgressBar progressBar = (ProgressBar) findViewById(R.id.progress);
-        final WebView webView = (WebView) findViewById(R.id.web_view);
-        webView.setBackgroundColor(Color.TRANSPARENT);
-        webView.setWebViewClient(new AdBlockWebViewClient(this, Preferences.adBlockEnabled(this)) {
-            @Override
-            public void onPageFinished(WebView view, String url) {
-                setTitle(view.getTitle());
-            }
-        });
-        webView.setWebChromeClient(new CacheableWebView.ArchiveClient() {
-            @Override
-            public void onProgressChanged(WebView view, int newProgress) {
-                super.onProgressChanged(view, newProgress);
-                progressBar.setVisibility(View.VISIBLE);
-                progressBar.setProgress(newProgress);
-                if (newProgress == 100) {
-                    progressBar.setVisibility(View.GONE);
-                    webView.setBackgroundColor(Color.WHITE);
-                    webView.setVisibility(View.VISIBLE);
-                }
-            }
-        });
-        AppUtils.toggleWebViewZoom(webView.getSettings(), true);
-        webView.loadUrl(url);
+  /**
+   * Called when the activity is first created.
+   *
+   * @param savedInstanceState If the activity is being re-initialized after previously being shut
+   *     down then this Bundle contains the data it most recently supplied in {@link
+   *     #onSaveInstanceState(Bundle)}. Otherwise it is null.
+   */
+  @SuppressWarnings("ConstantConditions")
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    ((MaterialisticApplication) getApplication()).applicationComponent.inject(this);
+    String url = getIntent().getStringExtra(EXTRA_URL);
+    if (TextUtils.isEmpty(url)) {
+      finish();
+      return;
     }
+    setTitle(url);
+    setContentView(R.layout.activity_offline_web);
+    final NestedScrollView scrollView = (NestedScrollView) findViewById(R.id.nested_scroll_view);
+    Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+    toolbar.setOnClickListener(v -> scrollView.smoothScrollTo(0, 0));
+    setSupportActionBar(toolbar);
+    getSupportActionBar()
+        .setDisplayOptions(
+            ActionBar.DISPLAY_SHOW_HOME
+                | ActionBar.DISPLAY_HOME_AS_UP
+                | ActionBar.DISPLAY_SHOW_TITLE);
+    getSupportActionBar().setSubtitle(R.string.offline);
+    final ProgressBar progressBar = (ProgressBar) findViewById(R.id.progress);
+    final WebView webView = (WebView) findViewById(R.id.web_view);
+    webView.setBackgroundColor(Color.TRANSPARENT);
+    webView.setWebViewClient(
+        new AdBlockWebViewClient(this, Preferences.adBlockEnabled(this)) {
+          @Override
+          public void onPageFinished(WebView view, String url) {
+            setTitle(view.getTitle());
+          }
+        });
+    webView.setWebChromeClient(
+        new CacheableWebView.ArchiveClient() {
+          @Override
+          public void onProgressChanged(WebView view, int newProgress) {
+            super.onProgressChanged(view, newProgress);
+            progressBar.setVisibility(View.VISIBLE);
+            progressBar.setProgress(newProgress);
+            if (newProgress == 100) {
+              progressBar.setVisibility(View.GONE);
+              webView.setBackgroundColor(Color.WHITE);
+              webView.setVisibility(View.VISIBLE);
+            }
+          }
+        });
+    AppUtils.toggleWebViewZoom(webView.getSettings(), true);
+    webView.loadUrl(url);
+  }
 
-    /**
-     * This hook is called whenever an item in your options menu is selected.
-     *
-     * @param item The menu item that was selected.
-     * @return boolean Return false to allow normal menu processing to
-     *         proceed, true to consume it here.
-     */
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        if (item.getItemId() == android.R.id.home) {
-            finish();
-            return true;
-        }
-        return super.onOptionsItemSelected(item);
+  /**
+   * This hook is called whenever an item in your options menu is selected.
+   *
+   * @param item The menu item that was selected.
+   * @return boolean Return false to allow normal menu processing to proceed, true to consume it
+   *     here.
+   */
+  @Override
+  public boolean onOptionsItemSelected(MenuItem item) {
+    if (item.getItemId() == android.R.id.home) {
+      finish();
+      return true;
     }
+    return super.onOptionsItemSelected(item);
+  }
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/OfflineWebActivity.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/OfflineWebActivity.java
@@ -66,7 +66,7 @@ public class OfflineWebActivity extends ThemedActivity {
         final ProgressBar progressBar = (ProgressBar) findViewById(R.id.progress);
         final WebView webView = (WebView) findViewById(R.id.web_view);
         webView.setBackgroundColor(Color.TRANSPARENT);
-        webView.setWebViewClient(new AdBlockWebViewClient(Preferences.adBlockEnabled(this)) {
+        webView.setWebViewClient(new AdBlockWebViewClient(this, Preferences.adBlockEnabled(this)) {
             @Override
             public void onPageFinished(WebView view, String url) {
                 setTitle(view.getTitle());

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/WebFragment.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/WebFragment.java
@@ -16,15 +16,12 @@
 
 package io.github.sheepdestroyer.materialisheep;
 
-import static android.view.View.GONE;
-import static android.view.View.VISIBLE;
-import static io.github.sheepdestroyer.materialisheep.DataModule.HN;
-
 import android.annotation.SuppressLint;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import androidx.core.os.BundleCompat;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.net.Uri;
@@ -48,10 +45,21 @@ import android.widget.ImageButton;
 import android.widget.ProgressBar;
 import android.widget.Toast;
 import android.widget.ViewSwitcher;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.lang.ref.WeakReference;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import static io.github.sheepdestroyer.materialisheep.DataModule.HN;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.core.os.BundleCompat;
 import androidx.core.widget.NestedScrollView;
+import androidx.fragment.app.DialogFragment;
+import androidx.fragment.app.Fragment;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import io.github.sheepdestroyer.materialisheep.annotation.Synthetic;
 import io.github.sheepdestroyer.materialisheep.data.FileDownloader;
@@ -64,718 +72,693 @@ import io.github.sheepdestroyer.materialisheep.widget.AdBlockWebViewClient;
 import io.github.sheepdestroyer.materialisheep.widget.CacheableWebView;
 import io.github.sheepdestroyer.materialisheep.widget.PopupMenu;
 import io.github.sheepdestroyer.materialisheep.widget.WebView;
-import java.io.File;
-import java.io.IOException;
-import java.io.RandomAccessFile;
-import java.lang.ref.WeakReference;
-import javax.inject.Inject;
-import javax.inject.Named;
 import okhttp3.Call;
 
-/** A fragment that displays a web page. */
+import static android.view.View.GONE;
+import static android.view.View.VISIBLE;
+
+/**
+ * A fragment that displays a web page.
+ */
 @SuppressWarnings("deprecation") // TODO: Uses deprecated LocalBroadcastManager/Fragment APIs
 public class WebFragment extends LazyLoadFragment
-    implements Scrollable, KeyDelegate.BackInterceptor {
-  public static final String EXTRA_ITEM = WebFragment.class.getName() + ".EXTRA_ITEM";
-  private static final String STATE_EMPTY = "state:empty";
-  private static final String STATE_READABILITY = "state:readability";
-  static final String ACTION_FULLSCREEN = WebFragment.class.getName() + ".ACTION_FULLSCREEN";
-  static final String EXTRA_FULLSCREEN = WebFragment.class.getName() + ".EXTRA_FULLSCREEN";
-  private static final String STATE_FULLSCREEN = "state:fullscreen";
-  private static final String STATE_CONTENT = "state:content";
-  private static final int DEFAULT_PROGRESS = 20;
-  public static final String PDF_LOADER_URL = "file:///android_asset/pdf/index.html";
-  private static final String PDF_MIME_TYPE = "application/pdf";
-  @Synthetic WebView mWebView;
-  private NestedScrollView mScrollView;
-  @Synthetic boolean mExternalRequired = false;
-
-  @Inject
-  @Named(HN)
-  ItemManager mItemManager;
-
-  @Inject PopupMenu mPopupMenu;
-  private KeyDelegate.NestedScrollViewHelper mScrollableHelper;
-  private final Preferences.Observable mPreferenceObservable = new Preferences.Observable();
-  private final BroadcastReceiver mReceiver =
-      new BroadcastReceiver() {
+        implements Scrollable, KeyDelegate.BackInterceptor {
+    public static final String EXTRA_ITEM = WebFragment.class.getName() + ".EXTRA_ITEM";
+    private static final String STATE_EMPTY = "state:empty";
+    private static final String STATE_READABILITY = "state:readability";
+    static final String ACTION_FULLSCREEN = WebFragment.class.getName() + ".ACTION_FULLSCREEN";
+    static final String EXTRA_FULLSCREEN = WebFragment.class.getName() + ".EXTRA_FULLSCREEN";
+    private static final String STATE_FULLSCREEN = "state:fullscreen";
+    private static final String STATE_CONTENT = "state:content";
+    private static final int DEFAULT_PROGRESS = 20;
+    public static final String PDF_LOADER_URL = "file:///android_asset/pdf/index.html";
+    private static final String PDF_MIME_TYPE = "application/pdf";
+    @Synthetic
+    WebView mWebView;
+    private NestedScrollView mScrollView;
+    @Synthetic
+    boolean mExternalRequired = false;
+    @Inject
+    @Named(HN)
+    ItemManager mItemManager;
+    @Inject
+    PopupMenu mPopupMenu;
+    private KeyDelegate.NestedScrollViewHelper mScrollableHelper;
+    private final Preferences.Observable mPreferenceObservable = new Preferences.Observable();
+    private final BroadcastReceiver mReceiver = new BroadcastReceiver() {
         @Override
         public void onReceive(Context context, Intent intent) {
-          setFullscreen(intent.getBooleanExtra(WebFragment.EXTRA_FULLSCREEN, false));
+            setFullscreen(intent.getBooleanExtra(WebFragment.EXTRA_FULLSCREEN, false));
         }
-      };
-  private ViewGroup mFullscreenView;
-  private ViewGroup mScrollViewContent;
-  @Synthetic ImageButton mButtonRefresh;
-  private ViewSwitcher mControls;
-  private EditText mEditText;
-  private View mButtonMore;
-  private View mButtonNext;
-  protected ProgressBar mProgressBar;
-  private boolean mFullscreen;
-  private boolean mIsPdf;
-  protected String mContent;
-  private AppUtils.SystemUiHelper mSystemUiHelper;
-  private View mFragmentView;
-  @Inject ReadabilityClient mReadabilityClient;
-  @Inject FileDownloader mFileDownloader;
-  private WebItem mItem;
-  private boolean mIsHackerNewsUrl, mEmpty, mReadability;
-  private PdfAndroidJavascriptBridge mPdfAndroidJavascriptBridge;
+    };
+    private ViewGroup mFullscreenView;
+    private ViewGroup mScrollViewContent;
+    @Synthetic
+    ImageButton mButtonRefresh;
+    private ViewSwitcher mControls;
+    private EditText mEditText;
+    private View mButtonMore;
+    private View mButtonNext;
+    protected ProgressBar mProgressBar;
+    private boolean mFullscreen;
+    private boolean mIsPdf;
+    protected String mContent;
+    private AppUtils.SystemUiHelper mSystemUiHelper;
+    private View mFragmentView;
+    @Inject
+    ReadabilityClient mReadabilityClient;
+    @Inject
+    FileDownloader mFileDownloader;
+    private WebItem mItem;
+    private boolean mIsHackerNewsUrl, mEmpty, mReadability;
+    private PdfAndroidJavascriptBridge mPdfAndroidJavascriptBridge;
 
-  @SuppressWarnings(
-      "deprecation") // Using deprecated LocalBroadcastManager; migration to LiveData/Flow requires
-  // architectural changes
-  @Override
-  public void onAttach(Context context) {
-    super.onAttach(context);
-    ((MaterialisticApplication) getActivity().getApplication()).applicationComponent.inject(this);
-    mPreferenceObservable.subscribe(
-        context,
-        this::onPreferenceChanged,
-        R.string.pref_readability_font,
-        R.string.pref_readability_line_height,
-        R.string.pref_readability_text_size);
-    LocalBroadcastManager.getInstance(context)
-        .registerReceiver(mReceiver, new IntentFilter(ACTION_FULLSCREEN));
-  }
-
-  @Override
-  public void onCreate(@Nullable Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    if (savedInstanceState != null) {
-      mFullscreen = savedInstanceState.getBoolean(STATE_FULLSCREEN, false);
-      mContent = savedInstanceState.getString(STATE_CONTENT);
-      mEmpty = savedInstanceState.getBoolean(STATE_EMPTY, false);
-      mReadability = savedInstanceState.getBoolean(STATE_READABILITY, false);
-      mItem = BundleCompat.getParcelable(savedInstanceState, EXTRA_ITEM, WebItem.class);
-    } else {
-      mReadability =
-          Preferences.getDefaultStoryView(getActivity()) == Preferences.StoryViewMode.Readability;
-      mItem = BundleCompat.getParcelable(getArguments(), EXTRA_ITEM, WebItem.class);
+    @SuppressWarnings("deprecation") // Using deprecated LocalBroadcastManager; migration to LiveData/Flow requires
+                                     // architectural changes
+    @Override
+    public void onAttach(Context context) {
+        super.onAttach(context);
+        ((MaterialisticApplication) getActivity().getApplication()).applicationComponent.inject(this);
+        mPreferenceObservable.subscribe(context, this::onPreferenceChanged,
+                R.string.pref_readability_font,
+                R.string.pref_readability_line_height,
+                R.string.pref_readability_text_size);
+        LocalBroadcastManager.getInstance(context).registerReceiver(mReceiver,
+                new IntentFilter(ACTION_FULLSCREEN));
     }
-    mIsHackerNewsUrl = AppUtils.isHackerNewsUrl(mItem);
-  }
 
-  @Override
-  public View onCreateView(
-      LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-
-    mFragmentView = inflater.inflate(R.layout.fragment_web, container, false);
-    mFullscreenView = (ViewGroup) mFragmentView.findViewById(R.id.fullscreen);
-    mScrollViewContent = (ViewGroup) mFragmentView.findViewById(R.id.scroll_view_content);
-    mScrollView = (NestedScrollView) mFragmentView.findViewById(R.id.nested_scroll_view);
-    mControls = (ViewSwitcher) mFragmentView.findViewById(R.id.control_switcher);
-    mWebView = (WebView) mFragmentView.findViewById(R.id.web_view);
-    mButtonRefresh = (ImageButton) mFragmentView.findViewById(R.id.button_refresh);
-    mButtonMore = mFragmentView.findViewById(R.id.button_more);
-    mButtonNext = mFragmentView.findViewById(R.id.button_next);
-    mButtonNext.setEnabled(false);
-    mEditText = (EditText) mFragmentView.findViewById(R.id.edittext);
-    setUpWebControls(mFragmentView);
-    setUpWebView(mFragmentView);
-
-    return mFragmentView;
-  }
-
-  @SuppressWarnings(
-      "deprecation") // Using deprecated Fragment menu API; migration to MenuProvider requires
-  // Activity cooperation
-  @Override
-  public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
-    super.onViewCreated(view, savedInstanceState);
-
-    mScrollableHelper = new KeyDelegate.NestedScrollViewHelper(mScrollView);
-    mSystemUiHelper = new AppUtils.SystemUiHelper(getActivity().getWindow());
-    mSystemUiHelper.setEnabled(!getResources().getBoolean(R.bool.multi_pane));
-    if (mFullscreen) {
-      setFullscreen(true);
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if (savedInstanceState != null) {
+            mFullscreen = savedInstanceState.getBoolean(STATE_FULLSCREEN, false);
+            mContent = savedInstanceState.getString(STATE_CONTENT);
+            mEmpty = savedInstanceState.getBoolean(STATE_EMPTY, false);
+            mReadability = savedInstanceState.getBoolean(STATE_READABILITY, false);
+            mItem = BundleCompat.getParcelable(savedInstanceState, EXTRA_ITEM, WebItem.class);
+        } else {
+            mReadability = Preferences.getDefaultStoryView(getActivity()) == Preferences.StoryViewMode.Readability;
+            mItem = BundleCompat.getParcelable(getArguments(), EXTRA_ITEM, WebItem.class);
+        }
+        mIsHackerNewsUrl = AppUtils.isHackerNewsUrl(mItem);
     }
-  }
 
-  @Override
-  protected void createOptionsMenu(Menu menu, MenuInflater inflater) {
-    inflater.inflate(R.menu.menu_article, menu);
-  }
+    @Override
+    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container,
+            @Nullable Bundle savedInstanceState) {
 
-  @Override
-  protected void prepareOptionsMenu(Menu menu) {
-    MenuItem menuReadability = menu.findItem(R.id.menu_readability);
-    menuReadability.setVisible(modeToggleEnabled());
-    mMenuTintDelegate.setIcon(
-        menuReadability,
-        mReadability ? R.drawable.ic_web_black_24dp : R.drawable.ic_chrome_reader_mode_black_24dp);
-    menuReadability.setTitle(mReadability ? R.string.article : R.string.readability);
-    menu.findItem(R.id.menu_font_options).setVisible(fontEnabled());
-  }
+        mFragmentView = inflater.inflate(R.layout.fragment_web, container, false);
+        mFullscreenView = (ViewGroup) mFragmentView.findViewById(R.id.fullscreen);
+        mScrollViewContent = (ViewGroup) mFragmentView.findViewById(R.id.scroll_view_content);
+        mScrollView = (NestedScrollView) mFragmentView.findViewById(R.id.nested_scroll_view);
+        mControls = (ViewSwitcher) mFragmentView.findViewById(R.id.control_switcher);
+        mWebView = (WebView) mFragmentView.findViewById(R.id.web_view);
+        mButtonRefresh = (ImageButton) mFragmentView.findViewById(R.id.button_refresh);
+        mButtonMore = mFragmentView.findViewById(R.id.button_more);
+        mButtonNext = mFragmentView.findViewById(R.id.button_next);
+        mButtonNext.setEnabled(false);
+        mEditText = (EditText) mFragmentView.findViewById(R.id.edittext);
+        setUpWebControls(mFragmentView);
+        setUpWebView(mFragmentView);
 
-  @SuppressWarnings(
-      "deprecation") // Using deprecated Fragment menu API; migration to MenuProvider requires
-  // Activity cooperation
-  @Override
-  public boolean onOptionsItemSelected(MenuItem item) {
-    if (item.getItemId() == R.id.menu_font_options) {
-      showPreferences();
-      return true;
+        return mFragmentView;
     }
-    if (item.getItemId() == R.id.menu_readability) {
-      mReadability = !mReadability;
-      load();
-      return true;
+
+    @SuppressWarnings("deprecation") // Using deprecated Fragment menu API; migration to MenuProvider requires
+                                     // Activity cooperation
+    @Override
+    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        mScrollableHelper = new KeyDelegate.NestedScrollViewHelper(mScrollView);
+        mSystemUiHelper = new AppUtils.SystemUiHelper(getActivity().getWindow());
+        mSystemUiHelper.setEnabled(!getResources().getBoolean(R.bool.multi_pane));
+        if (mFullscreen) {
+            setFullscreen(true);
+        }
+
     }
-    return super.onOptionsItemSelected(item);
-  }
 
-  @Override
-  public void onResume() {
-    super.onResume();
-    mWebView.onResume();
-    mWebView.resumeTimers();
-  }
-
-  @Override
-  public void onStop() {
-    super.onStop();
-    pauseWebView();
-  }
-
-  @Override
-  public void onSaveInstanceState(Bundle outState) {
-    super.onSaveInstanceState(outState);
-    outState.putBoolean(STATE_FULLSCREEN, mFullscreen);
-    outState.putString(STATE_CONTENT, mContent);
-    outState.putParcelable(EXTRA_ITEM, mItem);
-    outState.putBoolean(STATE_EMPTY, mEmpty);
-    outState.putBoolean(STATE_READABILITY, mReadability);
-  }
-
-  @Override
-  public void onDestroy() {
-    super.onDestroy();
-    if (mPdfAndroidJavascriptBridge != null) {
-      mPdfAndroidJavascriptBridge.cleanUp();
+    @Override
+    protected void createOptionsMenu(Menu menu, MenuInflater inflater) {
+        inflater.inflate(R.menu.menu_article, menu);
     }
-    mWebView.destroy();
-    // Note: mReadabilityClient is a singleton, do not call destroy() here.
-    // Subscriptions are fire-and-forget and managed internally.
-  }
 
-  @SuppressWarnings(
-      "deprecation") // Using deprecated LocalBroadcastManager; migration to LiveData/Flow requires
-  // architectural changes
-  @Override
-  public void onDetach() {
-    mPreferenceObservable.unsubscribe(getActivity());
-    LocalBroadcastManager.getInstance(getActivity()).unregisterReceiver(mReceiver);
-    super.onDetach();
-  }
-
-  @Override
-  public void scrollToTop() {
-    if (mFullscreen) {
-      mWebView.pageUp(true);
-    } else {
-      mScrollableHelper.scrollToTop();
+    @Override
+    protected void prepareOptionsMenu(Menu menu) {
+        MenuItem menuReadability = menu.findItem(R.id.menu_readability);
+        menuReadability.setVisible(modeToggleEnabled());
+        mMenuTintDelegate.setIcon(menuReadability,
+                mReadability ? R.drawable.ic_web_black_24dp : R.drawable.ic_chrome_reader_mode_black_24dp);
+        menuReadability.setTitle(mReadability ? R.string.article : R.string.readability);
+        menu.findItem(R.id.menu_font_options).setVisible(fontEnabled());
     }
-  }
 
-  @Override
-  public boolean scrollToNext() {
-    if (mFullscreen) {
-      mWebView.pageDown(false);
-      return true;
-    } else {
-      return mScrollableHelper.scrollToNext();
+    @SuppressWarnings("deprecation") // Using deprecated Fragment menu API; migration to MenuProvider requires
+                                     // Activity cooperation
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == R.id.menu_font_options) {
+            showPreferences();
+            return true;
+        }
+        if (item.getItemId() == R.id.menu_readability) {
+            mReadability = !mReadability;
+            load();
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
     }
-  }
 
-  @Override
-  public boolean scrollToPrevious() {
-    if (mFullscreen) {
-      mWebView.pageUp(false);
-      return true;
-    } else {
-      return mScrollableHelper.scrollToPrevious();
+    @Override
+    public void onResume() {
+        super.onResume();
+        mWebView.onResume();
+        mWebView.resumeTimers();
     }
-  }
 
-  @Override
-  public boolean onBackPressed() {
-    if (mWebView.canGoBack()) {
-      mWebView.goBack();
-      return true;
+    @Override
+    public void onStop() {
+        super.onStop();
+        pauseWebView();
     }
-    return false;
-  }
 
-  @Override
-  protected void load() {
-    mWebView.setVisibility(View.INVISIBLE);
-    if (mIsHackerNewsUrl) {
-      bindContent();
-    } else if (mReadability && !mEmpty) {
-      if (TextUtils.isEmpty(mContent)) {
-        parse();
-      } else {
-        loadContent();
-      }
-    } else {
-      loadUrl();
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putBoolean(STATE_FULLSCREEN, mFullscreen);
+        outState.putString(STATE_CONTENT, mContent);
+        outState.putParcelable(EXTRA_ITEM, mItem);
+        outState.putBoolean(STATE_EMPTY, mEmpty);
+        outState.putBoolean(STATE_READABILITY, mReadability);
     }
-  }
 
-  private void loadUrl() {
-    setWebSettings(true);
-    reloadUrl(mItem.getUrl());
-  }
-
-  private void reloadUrl(String url) {
-    reloadUrl(url, null);
-  }
-
-  @SuppressLint("AddJavascriptInterface")
-  private void reloadUrl(String url, @Nullable String pdfFilePath) {
-    mIsPdf = false;
-    if (mPdfAndroidJavascriptBridge != null) {
-      mPdfAndroidJavascriptBridge.cleanUp();
-      mWebView.removeJavascriptInterface("PdfAndroidJavascriptBridge");
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        if (mPdfAndroidJavascriptBridge != null) {
+            mPdfAndroidJavascriptBridge.cleanUp();
+        }
+        mWebView.destroy();
+        // Note: mReadabilityClient is a singleton, do not call destroy() here.
+        // Subscriptions are fire-and-forget and managed internally.
     }
-    if (pdfFilePath != null && TextUtils.equals(PDF_LOADER_URL, url)) {
-      setProgress(80);
-      mIsPdf = true;
-      mPdfAndroidJavascriptBridge =
-          new PdfAndroidJavascriptBridge(
-              pdfFilePath,
-              new PdfAndroidJavascriptBridge.Callbacks() {
-                @Override
-                public void onFailure() {
-                  offerExternalApp();
-                  setProgress(100);
-                }
 
-                @Override
-                public void onLoad() {
-                  setProgress(100);
-                }
-              });
-      mWebView.addJavascriptInterface(mPdfAndroidJavascriptBridge, "PdfAndroidJavascriptBridge");
-      mWebView.setInitialScale(1);
+    @SuppressWarnings("deprecation") // Using deprecated LocalBroadcastManager; migration to LiveData/Flow requires
+                                     // architectural changes
+    @Override
+    public void onDetach() {
+        mPreferenceObservable.unsubscribe(getActivity());
+        LocalBroadcastManager.getInstance(getActivity()).unregisterReceiver(mReceiver);
+        super.onDetach();
     }
-    mWebView.reloadUrl(url);
-  }
 
-  @Synthetic
-  void loadContent() {
-    setWebSettings(false);
-    mWebView.reloadHtml(AppUtils.wrapHtml(getActivity(), mContent));
-  }
-
-  private void parse() {
-    mProgressBar.setProgress(DEFAULT_PROGRESS);
-    mReadabilityClient.parse(mItem.getId(), mItem.getUrl(), new ReadabilityCallback(this));
-  }
-
-  private void bindContent() {
-    if (mItem instanceof Item) {
-      mContent = ((Item) mItem).getText();
-      loadContent();
-    } else {
-      mItemManager.getItem(mItem.getId(), ItemManager.MODE_DEFAULT, new ItemResponseListener(this));
+    @Override
+    public void scrollToTop() {
+        if (mFullscreen) {
+            mWebView.pageUp(true);
+        } else {
+            mScrollableHelper.scrollToTop();
+        }
     }
-  }
 
-  private void pauseWebView() {
-    mWebView.onPause();
-    mWebView.pauseTimers();
-  }
+    @Override
+    public boolean scrollToNext() {
+        if (mFullscreen) {
+            mWebView.pageDown(false);
+            return true;
+        } else {
+            return mScrollableHelper.scrollToNext();
+        }
+    }
 
-  private boolean fontEnabled() {
-    return mReadability && !mEmpty && !TextUtils.isEmpty(mContent);
-  }
+    @Override
+    public boolean scrollToPrevious() {
+        if (mFullscreen) {
+            mWebView.pageUp(false);
+            return true;
+        } else {
+            return mScrollableHelper.scrollToPrevious();
+        }
+    }
 
-  private boolean modeToggleEnabled() {
-    return !mIsHackerNewsUrl && !mWebView.canGoBack();
-  }
+    @Override
+    public boolean onBackPressed() {
+        if (mWebView.canGoBack()) {
+            mWebView.goBack();
+            return true;
+        }
+        return false;
+    }
 
-  private void setUpWebControls(View view) {
-    view.findViewById(R.id.toolbar_web).setOnClickListener(v -> scrollToTop());
-    view.findViewById(R.id.button_back).setOnClickListener(v -> mWebView.goBack());
-    view.findViewById(R.id.button_forward).setOnClickListener(v -> mWebView.goForward());
-    view.findViewById(R.id.button_clear)
-        .setOnClickListener(
-            v -> {
-              mSystemUiHelper.setFullscreen(true);
-              reset();
-              mControls.showNext();
-            });
-    view.findViewById(R.id.button_find)
-        .setOnClickListener(
-            v -> {
-              mEditText.requestFocus();
-              toggleSoftKeyboard(true);
-              mControls.showNext();
-            });
-    mButtonRefresh.setOnClickListener(
-        v -> {
-          if (mWebView.getProgress() < 100) {
-            mWebView.stopLoading();
-          } else {
-            mWebView.reload();
-          }
+    @Override
+    protected void load() {
+        mWebView.setVisibility(View.INVISIBLE);
+        if (mIsHackerNewsUrl) {
+            bindContent();
+        } else if (mReadability && !mEmpty) {
+            if (TextUtils.isEmpty(mContent)) {
+                parse();
+            } else {
+                loadContent();
+            }
+        } else {
+            loadUrl();
+        }
+    }
+
+    private void loadUrl() {
+        setWebSettings(true);
+        reloadUrl(mItem.getUrl());
+    }
+
+    private void reloadUrl(String url) {
+        reloadUrl(url, null);
+    }
+
+    @SuppressLint("AddJavascriptInterface")
+    private void reloadUrl(String url, @Nullable String pdfFilePath) {
+        mIsPdf = false;
+        if (mPdfAndroidJavascriptBridge != null) {
+            mPdfAndroidJavascriptBridge.cleanUp();
+            mWebView.removeJavascriptInterface("PdfAndroidJavascriptBridge");
+        }
+        if (pdfFilePath != null && TextUtils.equals(PDF_LOADER_URL, url)) {
+            setProgress(80);
+            mIsPdf = true;
+            mPdfAndroidJavascriptBridge = new PdfAndroidJavascriptBridge(pdfFilePath,
+                    new PdfAndroidJavascriptBridge.Callbacks() {
+                        @Override
+                        public void onFailure() {
+                            offerExternalApp();
+                            setProgress(100);
+                        }
+
+                        @Override
+                        public void onLoad() {
+                            setProgress(100);
+                        }
+                    });
+            mWebView.addJavascriptInterface(mPdfAndroidJavascriptBridge, "PdfAndroidJavascriptBridge");
+            mWebView.setInitialScale(1);
+        }
+        mWebView.reloadUrl(url);
+    }
+
+    @Synthetic
+    void loadContent() {
+        setWebSettings(false);
+        mWebView.reloadHtml(AppUtils.wrapHtml(getActivity(), mContent));
+    }
+
+    private void parse() {
+        mProgressBar.setProgress(DEFAULT_PROGRESS);
+        mReadabilityClient.parse(mItem.getId(), mItem.getUrl(), new ReadabilityCallback(this));
+    }
+
+    private void bindContent() {
+        if (mItem instanceof Item) {
+            mContent = ((Item) mItem).getText();
+            loadContent();
+        } else {
+            mItemManager.getItem(mItem.getId(), ItemManager.MODE_DEFAULT, new ItemResponseListener(this));
+        }
+    }
+
+    private void pauseWebView() {
+        mWebView.onPause();
+        mWebView.pauseTimers();
+    }
+
+    private boolean fontEnabled() {
+        return mReadability && !mEmpty && !TextUtils.isEmpty(mContent);
+    }
+
+    private boolean modeToggleEnabled() {
+        return !mIsHackerNewsUrl && !mWebView.canGoBack();
+    }
+
+    private void setUpWebControls(View view) {
+        view.findViewById(R.id.toolbar_web).setOnClickListener(v -> scrollToTop());
+        view.findViewById(R.id.button_back).setOnClickListener(v -> mWebView.goBack());
+        view.findViewById(R.id.button_forward).setOnClickListener(v -> mWebView.goForward());
+        view.findViewById(R.id.button_clear).setOnClickListener(v -> {
+            mSystemUiHelper.setFullscreen(true);
+            reset();
+            mControls.showNext();
         });
-    view.findViewById(R.id.button_exit)
-        .setOnClickListener(
-            v -> {
-              @SuppressWarnings("deprecation") // Using deprecated LocalBroadcastManager
-              android.content.Intent intent =
-                  new Intent(WebFragment.ACTION_FULLSCREEN).putExtra(EXTRA_FULLSCREEN, false);
-              LocalBroadcastManager.getInstance(getActivity()).sendBroadcast(intent);
-            });
-    mButtonNext.setOnClickListener(v -> mWebView.findNext(true));
-    mButtonMore.setOnClickListener(
-        v ->
-            mPopupMenu
-                .create(getActivity(), mButtonMore, Gravity.NO_GRAVITY)
+        view.findViewById(R.id.button_find).setOnClickListener(v -> {
+            mEditText.requestFocus();
+            toggleSoftKeyboard(true);
+            mControls.showNext();
+        });
+        mButtonRefresh.setOnClickListener(v -> {
+            if (mWebView.getProgress() < 100) {
+                mWebView.stopLoading();
+            } else {
+                mWebView.reload();
+            }
+        });
+        view.findViewById(R.id.button_exit)
+                .setOnClickListener(v -> {
+                    @SuppressWarnings("deprecation") // Using deprecated LocalBroadcastManager
+                    android.content.Intent intent = new Intent(WebFragment.ACTION_FULLSCREEN)
+                            .putExtra(EXTRA_FULLSCREEN, false);
+                    LocalBroadcastManager.getInstance(getActivity()).sendBroadcast(intent);
+                });
+        mButtonNext.setOnClickListener(v -> mWebView.findNext(true));
+        mButtonMore.setOnClickListener(v -> mPopupMenu.create(getActivity(), mButtonMore, Gravity.NO_GRAVITY)
                 .inflate(R.menu.menu_web)
-                .setOnMenuItemClickListener(
-                    item -> {
-                      if (item.getItemId() == R.id.menu_font_options) {
+                .setOnMenuItemClickListener(item -> {
+                    if (item.getItemId() == R.id.menu_font_options) {
                         showPreferences();
                         return true;
-                      }
-                      if (item.getItemId() == R.id.menu_zoom_in) {
+                    }
+                    if (item.getItemId() == R.id.menu_zoom_in) {
                         mWebView.zoomIn();
                         return true;
-                      }
-                      if (item.getItemId() == R.id.menu_zoom_out) {
+                    }
+                    if (item.getItemId() == R.id.menu_zoom_out) {
                         mWebView.zoomOut();
                         return true;
-                      }
-                      return false;
-                    })
+                    }
+                    return false;
+                })
                 .setMenuItemVisible(R.id.menu_font_options, fontEnabled())
                 .show());
-    mEditText.setOnEditorActionListener(
-        (v, actionId, event) -> {
-          findInPage();
-          return true;
+        mEditText.setOnEditorActionListener((v, actionId, event) -> {
+            findInPage();
+            return true;
         });
-  }
+    }
 
-  private void setUpWebView(View view) {
-    mProgressBar = (ProgressBar) view.findViewById(R.id.progress);
-    mWebView.setBackgroundColor(Color.TRANSPARENT);
-    mWebView.setWebViewClient(
-        new AdBlockWebViewClient(getActivity(), Preferences.adBlockEnabled(getActivity())) {
-          @Override
-          public void onPageStarted(android.webkit.WebView view, String url, Bitmap favicon) {
-            super.onPageStarted(view, url, favicon);
-            if (getActivity() != null) {
-              getActivity().invalidateOptionsMenu();
+    private void setUpWebView(View view) {
+        mProgressBar = (ProgressBar) view.findViewById(R.id.progress);
+        mWebView.setBackgroundColor(Color.TRANSPARENT);
+        mWebView.setWebViewClient(new AdBlockWebViewClient(getActivity(), Preferences.adBlockEnabled(getActivity())) {
+            @Override
+            public void onPageStarted(android.webkit.WebView view, String url, Bitmap favicon) {
+                super.onPageStarted(view, url, favicon);
+                if (getActivity() != null) {
+                    getActivity().invalidateOptionsMenu();
+                }
             }
-          }
 
-          @Override
-          public void onPageFinished(android.webkit.WebView view, String url) {
-            super.onPageFinished(view, url);
-            if (getActivity() != null) {
-              getActivity().invalidateOptionsMenu();
+            @Override
+            public void onPageFinished(android.webkit.WebView view, String url) {
+                super.onPageFinished(view, url);
+                if (getActivity() != null) {
+                    getActivity().invalidateOptionsMenu();
+                }
             }
-          }
         });
-    mWebView.setWebChromeClient(
-        new CacheableWebView.ArchiveClient() {
-          @Override
-          public void onProgressChanged(android.webkit.WebView view, int newProgress) {
-            super.onProgressChanged(view, newProgress);
-            if (!mIsPdf) {
-              setProgress(newProgress);
+        mWebView.setWebChromeClient(new CacheableWebView.ArchiveClient() {
+            @Override
+            public void onProgressChanged(android.webkit.WebView view, int newProgress) {
+                super.onProgressChanged(view, newProgress);
+                if (!mIsPdf) {
+                    setProgress(newProgress);
+                }
             }
-          }
         });
-    mWebView.setDownloadListener(
-        (url, userAgent, contentDisposition, mimetype, contentLength) -> {
-          if (getActivity() == null) {
+        mWebView.setDownloadListener((url, userAgent, contentDisposition, mimetype, contentLength) -> {
+            if (getActivity() == null) {
+                return;
+            }
+            if (mimetype.equals(PDF_MIME_TYPE)) {
+                setProgress(10);
+                mIsPdf = true;
+                downloadFileAndRenderPdf();
+            } else {
+                offerExternalApp();
+            }
+        });
+        AppUtils.toggleWebViewZoom(mWebView.getSettings(), false);
+    }
+
+    private void offerExternalApp() {
+        final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(mItem.getUrl()));
+        if (intent.resolveActivity(getActivity().getPackageManager()) == null) {
             return;
-          }
-          if (mimetype.equals(PDF_MIME_TYPE)) {
-            setProgress(10);
-            mIsPdf = true;
-            downloadFileAndRenderPdf();
-          } else {
-            offerExternalApp();
-          }
-        });
-    AppUtils.toggleWebViewZoom(mWebView.getSettings(), false);
-  }
-
-  private void offerExternalApp() {
-    final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(mItem.getUrl()));
-    if (intent.resolveActivity(getActivity().getPackageManager()) == null) {
-      return;
-    }
-    mExternalRequired = true;
-    mWebView.setVisibility(GONE);
-    getActivity().findViewById(R.id.empty).setVisibility(VISIBLE);
-    getActivity().findViewById(R.id.download_button).setOnClickListener(v -> startActivity(intent));
-  }
-
-  private void setProgress(int progress) {
-    mProgressBar.setProgress(progress);
-    mProgressBar.setVisibility(progress == 100 ? GONE : VISIBLE);
-    mButtonRefresh.setImageResource(
-        progress == 100 ? R.drawable.ic_refresh_white_24dp : R.drawable.ic_clear_white_24dp);
-  }
-
-  @SuppressLint("SetJavaScriptEnabled")
-  private void setWebSettings(boolean isRemote) {
-    mReadability = !isRemote;
-    mWebView.setBackgroundColor(isRemote ? Color.WHITE : Color.TRANSPARENT);
-    mWebView.getSettings().setLoadWithOverviewMode(isRemote);
-    mWebView.getSettings().setUseWideViewPort(isRemote);
-    mWebView.getSettings().setJavaScriptEnabled(true);
-    getActivity().invalidateOptionsMenu();
-  }
-
-  @Synthetic
-  void setFullscreen(boolean isFullscreen) {
-    if (getView() == null) {
-      return;
-    }
-    mFullscreen = isFullscreen;
-    mControls.setVisibility(isFullscreen ? VISIBLE : View.GONE);
-    AppUtils.toggleWebViewZoom(mWebView.getSettings(), isFullscreen);
-    ViewGroup.LayoutParams params = mWebView.getLayoutParams();
-    if (isFullscreen) {
-      mScrollView.removeView(mScrollViewContent);
-      mWebView.scrollTo(mScrollView.getScrollX(), mScrollView.getScrollY());
-      mFullscreenView.addView(mScrollViewContent);
-      params.height = ViewGroup.LayoutParams.MATCH_PARENT;
-    } else {
-      reset();
-      // We'll zoom out until it returns false, which means it has min zoom level.
-      // It's quite dangerous piece of code - potentially could lead to infinite loop,
-      // so let's add some reasonable limit just in case
-      int i = 0;
-      while (mWebView.zoomOut() && i < 30) {
-        i++;
-      }
-      mFullscreenView.removeView(mScrollViewContent);
-      mScrollView.addView(mScrollViewContent);
-      mScrollView.post(() -> mScrollView.scrollTo(mWebView.getScrollX(), mWebView.getScrollY()));
-      params.height = ViewGroup.LayoutParams.WRAP_CONTENT;
-    }
-    mWebView.setLayoutParams(params);
-  }
-
-  private void showPreferences() {
-    Bundle args = new Bundle();
-    args.putInt(PopupSettingsFragment.EXTRA_TITLE, R.string.font_options);
-    args.putIntArray(
-        PopupSettingsFragment.EXTRA_XML_PREFERENCES, new int[] {R.xml.preferences_readability});
-    PopupSettingsFragment fragment = new PopupSettingsFragment();
-    fragment.setArguments(args);
-    fragment.show(getParentFragmentManager(), PopupSettingsFragment.class.getName());
-  }
-
-  private void onPreferenceChanged(int key, boolean contextChanged) {
-    if (!contextChanged) {
-      load();
-    }
-  }
-
-  private void reset() {
-    mEditText.setText(null);
-    mButtonNext.setEnabled(false);
-    toggleSoftKeyboard(false);
-    mWebView.clearMatches();
-  }
-
-  private void findInPage() {
-    String query = mEditText.getText().toString().trim();
-    if (TextUtils.isEmpty(query)) {
-      return;
-    }
-    mWebView.setFindListener(
-        (activeMatchOrdinal, numberOfMatches, isDoneCounting) -> {
-          if (isDoneCounting) {
-            handleFindResults(numberOfMatches);
-          }
-        });
-    mWebView.findAllAsync(query);
-  }
-
-  private void handleFindResults(int numberOfMatches) {
-    mButtonNext.setEnabled(numberOfMatches > 0);
-    if (numberOfMatches == 0) {
-      Toast.makeText(getContext(), R.string.no_matches, Toast.LENGTH_SHORT).show();
-    } else {
-      toggleSoftKeyboard(false);
-    }
-  }
-
-  private void toggleSoftKeyboard(boolean visible) {
-    InputMethodManager imm =
-        (InputMethodManager) getActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
-    if (visible) {
-      imm.showSoftInput(mEditText, InputMethodManager.SHOW_IMPLICIT);
-    } else {
-      imm.hideSoftInputFromWindow(mEditText.getWindowToken(), 0);
-    }
-  }
-
-  @Synthetic
-  void onParsed(String content) {
-    if (isAttached()) {
-      mContent = content;
-      if (!TextUtils.isEmpty(mContent)) {
-        loadContent();
-      } else {
-        mEmpty = true;
-        if (mReadability) {
-          Toast.makeText(getActivity(), R.string.readability_failed, Toast.LENGTH_SHORT).show();
         }
-        loadUrl();
-      }
+        mExternalRequired = true;
+        mWebView.setVisibility(GONE);
+        getActivity().findViewById(R.id.empty).setVisibility(VISIBLE);
+        getActivity().findViewById(R.id.download_button).setOnClickListener(v -> startActivity(intent));
     }
-  }
 
-  @Synthetic
-  void onItemLoaded(@NonNull Item response) {
-    getActivity().invalidateOptionsMenu();
-    mItem = response;
-    bindContent();
-  }
+    private void setProgress(int progress) {
+        mProgressBar.setProgress(progress);
+        mProgressBar.setVisibility(progress == 100 ? GONE : VISIBLE);
+        mButtonRefresh
+                .setImageResource(progress == 100 ? R.drawable.ic_refresh_white_24dp : R.drawable.ic_clear_white_24dp);
+    }
 
-  private void downloadFileAndRenderPdf() {
-    mFileDownloader.downloadFile(
-        mItem.getUrl(),
-        PDF_MIME_TYPE,
-        new FileDownloader.FileDownloaderCallback() {
-          @Override
-          public void onFailure(Call call, IOException e) {
-            offerExternalApp();
-          }
-
-          @Override
-          public void onSuccess(String filePath) {
-            reloadUrl(PDF_LOADER_URL, filePath);
-          }
-        });
-  }
-
-  static class ReadabilityCallback implements ReadabilityClient.Callback {
-    private final WeakReference<WebFragment> mReadabilityFragment;
+    @SuppressLint("SetJavaScriptEnabled")
+    private void setWebSettings(boolean isRemote) {
+        mReadability = !isRemote;
+        mWebView.setBackgroundColor(isRemote ? Color.WHITE : Color.TRANSPARENT);
+        mWebView.getSettings().setLoadWithOverviewMode(isRemote);
+        mWebView.getSettings().setUseWideViewPort(isRemote);
+        mWebView.getSettings().setJavaScriptEnabled(true);
+        getActivity().invalidateOptionsMenu();
+    }
 
     @Synthetic
-    ReadabilityCallback(WebFragment webFragment) {
-      mReadabilityFragment = new WeakReference<>(webFragment);
-    }
-
-    @Override
-    public void onResponse(String content) {
-      if (mReadabilityFragment.get() != null && mReadabilityFragment.get().isAttached()) {
-        mReadabilityFragment.get().onParsed(content);
-      }
-    }
-  }
-
-  static class ItemResponseListener implements ResponseListener<Item> {
-    private final WeakReference<WebFragment> mFragment;
-
-    @Synthetic
-    ItemResponseListener(WebFragment webFragment) {
-      mFragment = new WeakReference<>(webFragment);
-    }
-
-    @Override
-    public void onResponse(@Nullable Item response) {
-      if (mFragment.get() != null && mFragment.get().isAttached() && response != null) {
-        mFragment.get().onItemLoaded(response);
-      }
-    }
-
-    @Override
-    public void onError(String errorMessage) {
-      // do nothing
-    }
-  }
-
-  static class PdfAndroidJavascriptBridge {
-    private File mFile;
-    private @Nullable RandomAccessFile mRandomAccessFile;
-    private @Nullable Callbacks mCallback;
-    private Handler mHandler;
-
-    PdfAndroidJavascriptBridge(String filePath, @Nullable Callbacks callback) {
-      mFile = new File(filePath);
-      mCallback = callback;
-      mHandler = new Handler(Looper.getMainLooper());
-    }
-
-    @JavascriptInterface
-    public String getChunk(long begin, long end) {
-      try {
-        if (mRandomAccessFile == null) {
-          mRandomAccessFile = new RandomAccessFile(mFile, "r");
+    void setFullscreen(boolean isFullscreen) {
+        if (getView() == null) {
+            return;
         }
-        if (mRandomAccessFile != null) {
-          final int bufferSize = (int) (end - begin);
-          byte[] data = new byte[bufferSize];
-          mRandomAccessFile.seek(begin);
-          mRandomAccessFile.read(data);
-          return Base64.encodeToString(data, Base64.DEFAULT);
+        mFullscreen = isFullscreen;
+        mControls.setVisibility(isFullscreen ? VISIBLE : View.GONE);
+        AppUtils.toggleWebViewZoom(mWebView.getSettings(), isFullscreen);
+        ViewGroup.LayoutParams params = mWebView.getLayoutParams();
+        if (isFullscreen) {
+            mScrollView.removeView(mScrollViewContent);
+            mWebView.scrollTo(mScrollView.getScrollX(), mScrollView.getScrollY());
+            mFullscreenView.addView(mScrollViewContent);
+            params.height = ViewGroup.LayoutParams.MATCH_PARENT;
         } else {
-          return "";
+            reset();
+            // We'll zoom out until it returns false, which means it has min zoom level.
+            // It's quite dangerous piece of code - potentially could lead to infinite loop,
+            // so let's add some reasonable limit just in case
+            int i = 0;
+            while (mWebView.zoomOut() && i < 30) {
+                i++;
+            }
+            mFullscreenView.removeView(mScrollViewContent);
+            mScrollView.addView(mScrollViewContent);
+            mScrollView.post(() -> mScrollView.scrollTo(mWebView.getScrollX(), mWebView.getScrollY()));
+            params.height = ViewGroup.LayoutParams.WRAP_CONTENT;
         }
-      } catch (IOException e) {
-        Log.e("Exception", e.toString());
-        return "";
-      }
+        mWebView.setLayoutParams(params);
     }
 
-    @JavascriptInterface
-    public long getSize() {
-      return mFile.length();
+    private void showPreferences() {
+        Bundle args = new Bundle();
+        args.putInt(PopupSettingsFragment.EXTRA_TITLE, R.string.font_options);
+        args.putIntArray(PopupSettingsFragment.EXTRA_XML_PREFERENCES,
+                new int[] { R.xml.preferences_readability });
+        PopupSettingsFragment fragment = new PopupSettingsFragment();
+        fragment.setArguments(args);
+        fragment.show(getParentFragmentManager(), PopupSettingsFragment.class.getName());
     }
 
-    @JavascriptInterface
-    public void onLoad() {
-      if (mCallback != null) {
-        mHandler.post(() -> mCallback.onLoad());
-      }
-    }
-
-    @JavascriptInterface
-    public void onFailure() {
-      if (mCallback != null) {
-        mHandler.post(() -> mCallback.onFailure());
-      }
-    }
-
-    public void cleanUp() {
-      try {
-        if (mRandomAccessFile != null) {
-          mRandomAccessFile.close();
+    private void onPreferenceChanged(int key, boolean contextChanged) {
+        if (!contextChanged) {
+            load();
         }
-      } catch (IOException e) {
-        Log.e("Exception", e.toString());
-      }
     }
 
-    @Override
-    public void finalize() throws Throwable {
-      try {
-        cleanUp();
-      } finally {
-        super.finalize();
-      }
+    private void reset() {
+        mEditText.setText(null);
+        mButtonNext.setEnabled(false);
+        toggleSoftKeyboard(false);
+        mWebView.clearMatches();
     }
 
-    interface Callbacks {
-      void onFailure();
-
-      void onLoad();
+    private void findInPage() {
+        String query = mEditText.getText().toString().trim();
+        if (TextUtils.isEmpty(query)) {
+            return;
+        }
+        mWebView.setFindListener((activeMatchOrdinal, numberOfMatches, isDoneCounting) -> {
+            if (isDoneCounting) {
+                handleFindResults(numberOfMatches);
+            }
+        });
+        mWebView.findAllAsync(query);
     }
-  }
+
+    private void handleFindResults(int numberOfMatches) {
+        mButtonNext.setEnabled(numberOfMatches > 0);
+        if (numberOfMatches == 0) {
+            Toast.makeText(getContext(), R.string.no_matches, Toast.LENGTH_SHORT).show();
+        } else {
+            toggleSoftKeyboard(false);
+        }
+    }
+
+    private void toggleSoftKeyboard(boolean visible) {
+        InputMethodManager imm = (InputMethodManager) getActivity().getSystemService(
+                Context.INPUT_METHOD_SERVICE);
+        if (visible) {
+            imm.showSoftInput(mEditText, InputMethodManager.SHOW_IMPLICIT);
+        } else {
+            imm.hideSoftInputFromWindow(mEditText.getWindowToken(), 0);
+        }
+    }
+
+    @Synthetic
+    void onParsed(String content) {
+        if (isAttached()) {
+            mContent = content;
+            if (!TextUtils.isEmpty(mContent)) {
+                loadContent();
+            } else {
+                mEmpty = true;
+                if (mReadability) {
+                    Toast.makeText(getActivity(), R.string.readability_failed, Toast.LENGTH_SHORT).show();
+                }
+                loadUrl();
+            }
+        }
+    }
+
+    @Synthetic
+    void onItemLoaded(@NonNull Item response) {
+        getActivity().invalidateOptionsMenu();
+        mItem = response;
+        bindContent();
+    }
+
+    private void downloadFileAndRenderPdf() {
+        mFileDownloader.downloadFile(mItem.getUrl(), PDF_MIME_TYPE, new FileDownloader.FileDownloaderCallback() {
+            @Override
+            public void onFailure(Call call, IOException e) {
+                offerExternalApp();
+            }
+
+            @Override
+            public void onSuccess(String filePath) {
+                reloadUrl(PDF_LOADER_URL, filePath);
+            }
+        });
+    }
+
+    static class ReadabilityCallback implements ReadabilityClient.Callback {
+        private final WeakReference<WebFragment> mReadabilityFragment;
+
+        @Synthetic
+        ReadabilityCallback(WebFragment webFragment) {
+            mReadabilityFragment = new WeakReference<>(webFragment);
+        }
+
+        @Override
+        public void onResponse(String content) {
+            if (mReadabilityFragment.get() != null && mReadabilityFragment.get().isAttached()) {
+                mReadabilityFragment.get().onParsed(content);
+            }
+        }
+    }
+
+    static class ItemResponseListener implements ResponseListener<Item> {
+        private final WeakReference<WebFragment> mFragment;
+
+        @Synthetic
+        ItemResponseListener(WebFragment webFragment) {
+            mFragment = new WeakReference<>(webFragment);
+        }
+
+        @Override
+        public void onResponse(@Nullable Item response) {
+            if (mFragment.get() != null && mFragment.get().isAttached() && response != null) {
+                mFragment.get().onItemLoaded(response);
+            }
+        }
+
+        @Override
+        public void onError(String errorMessage) {
+            // do nothing
+        }
+    }
+
+    static class PdfAndroidJavascriptBridge {
+        private File mFile;
+        private @Nullable RandomAccessFile mRandomAccessFile;
+        private @Nullable Callbacks mCallback;
+        private Handler mHandler;
+
+        PdfAndroidJavascriptBridge(String filePath, @Nullable Callbacks callback) {
+            mFile = new File(filePath);
+            mCallback = callback;
+            mHandler = new Handler(Looper.getMainLooper());
+        }
+
+        @JavascriptInterface
+        public String getChunk(long begin, long end) {
+            try {
+                if (mRandomAccessFile == null) {
+                    mRandomAccessFile = new RandomAccessFile(mFile, "r");
+                }
+                if (mRandomAccessFile != null) {
+                    final int bufferSize = (int) (end - begin);
+                    byte[] data = new byte[bufferSize];
+                    mRandomAccessFile.seek(begin);
+                    mRandomAccessFile.read(data);
+                    return Base64.encodeToString(data, Base64.DEFAULT);
+                } else {
+                    return "";
+                }
+            } catch (IOException e) {
+                Log.e("Exception", e.toString());
+                return "";
+            }
+        }
+
+        @JavascriptInterface
+        public long getSize() {
+            return mFile.length();
+        }
+
+        @JavascriptInterface
+        public void onLoad() {
+            if (mCallback != null) {
+                mHandler.post(() -> mCallback.onLoad());
+            }
+        }
+
+        @JavascriptInterface
+        public void onFailure() {
+            if (mCallback != null) {
+                mHandler.post(() -> mCallback.onFailure());
+            }
+        }
+
+        public void cleanUp() {
+            try {
+                if (mRandomAccessFile != null) {
+                    mRandomAccessFile.close();
+                }
+            } catch (IOException e) {
+                Log.e("Exception", e.toString());
+            }
+        }
+
+        @Override
+        public void finalize() throws Throwable {
+            try {
+                cleanUp();
+            } finally {
+                super.finalize();
+            }
+        }
+
+        interface Callbacks {
+            void onFailure();
+
+            void onLoad();
+        }
+    }
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/WebFragment.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/WebFragment.java
@@ -455,7 +455,7 @@ public class WebFragment extends LazyLoadFragment
     private void setUpWebView(View view) {
         mProgressBar = (ProgressBar) view.findViewById(R.id.progress);
         mWebView.setBackgroundColor(Color.TRANSPARENT);
-        mWebView.setWebViewClient(new AdBlockWebViewClient(Preferences.adBlockEnabled(getActivity())) {
+        mWebView.setWebViewClient(new AdBlockWebViewClient(getActivity(), Preferences.adBlockEnabled(getActivity())) {
             @Override
             public void onPageStarted(android.webkit.WebView view, String url, Bitmap favicon) {
                 super.onPageStarted(view, url, favicon);

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/WebFragment.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/WebFragment.java
@@ -16,12 +16,15 @@
 
 package io.github.sheepdestroyer.materialisheep;
 
+import static android.view.View.GONE;
+import static android.view.View.VISIBLE;
+import static io.github.sheepdestroyer.materialisheep.DataModule.HN;
+
 import android.annotation.SuppressLint;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import androidx.core.os.BundleCompat;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.net.Uri;
@@ -45,21 +48,10 @@ import android.widget.ImageButton;
 import android.widget.ProgressBar;
 import android.widget.Toast;
 import android.widget.ViewSwitcher;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.RandomAccessFile;
-import java.lang.ref.WeakReference;
-
-import javax.inject.Inject;
-import javax.inject.Named;
-
-import static io.github.sheepdestroyer.materialisheep.DataModule.HN;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.os.BundleCompat;
 import androidx.core.widget.NestedScrollView;
-import androidx.fragment.app.DialogFragment;
-import androidx.fragment.app.Fragment;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import io.github.sheepdestroyer.materialisheep.annotation.Synthetic;
 import io.github.sheepdestroyer.materialisheep.data.FileDownloader;
@@ -72,693 +64,718 @@ import io.github.sheepdestroyer.materialisheep.widget.AdBlockWebViewClient;
 import io.github.sheepdestroyer.materialisheep.widget.CacheableWebView;
 import io.github.sheepdestroyer.materialisheep.widget.PopupMenu;
 import io.github.sheepdestroyer.materialisheep.widget.WebView;
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.lang.ref.WeakReference;
+import javax.inject.Inject;
+import javax.inject.Named;
 import okhttp3.Call;
 
-import static android.view.View.GONE;
-import static android.view.View.VISIBLE;
-
-/**
- * A fragment that displays a web page.
- */
+/** A fragment that displays a web page. */
 @SuppressWarnings("deprecation") // TODO: Uses deprecated LocalBroadcastManager/Fragment APIs
 public class WebFragment extends LazyLoadFragment
-        implements Scrollable, KeyDelegate.BackInterceptor {
-    public static final String EXTRA_ITEM = WebFragment.class.getName() + ".EXTRA_ITEM";
-    private static final String STATE_EMPTY = "state:empty";
-    private static final String STATE_READABILITY = "state:readability";
-    static final String ACTION_FULLSCREEN = WebFragment.class.getName() + ".ACTION_FULLSCREEN";
-    static final String EXTRA_FULLSCREEN = WebFragment.class.getName() + ".EXTRA_FULLSCREEN";
-    private static final String STATE_FULLSCREEN = "state:fullscreen";
-    private static final String STATE_CONTENT = "state:content";
-    private static final int DEFAULT_PROGRESS = 20;
-    public static final String PDF_LOADER_URL = "file:///android_asset/pdf/index.html";
-    private static final String PDF_MIME_TYPE = "application/pdf";
-    @Synthetic
-    WebView mWebView;
-    private NestedScrollView mScrollView;
-    @Synthetic
-    boolean mExternalRequired = false;
-    @Inject
-    @Named(HN)
-    ItemManager mItemManager;
-    @Inject
-    PopupMenu mPopupMenu;
-    private KeyDelegate.NestedScrollViewHelper mScrollableHelper;
-    private final Preferences.Observable mPreferenceObservable = new Preferences.Observable();
-    private final BroadcastReceiver mReceiver = new BroadcastReceiver() {
+    implements Scrollable, KeyDelegate.BackInterceptor {
+  public static final String EXTRA_ITEM = WebFragment.class.getName() + ".EXTRA_ITEM";
+  private static final String STATE_EMPTY = "state:empty";
+  private static final String STATE_READABILITY = "state:readability";
+  static final String ACTION_FULLSCREEN = WebFragment.class.getName() + ".ACTION_FULLSCREEN";
+  static final String EXTRA_FULLSCREEN = WebFragment.class.getName() + ".EXTRA_FULLSCREEN";
+  private static final String STATE_FULLSCREEN = "state:fullscreen";
+  private static final String STATE_CONTENT = "state:content";
+  private static final int DEFAULT_PROGRESS = 20;
+  public static final String PDF_LOADER_URL = "file:///android_asset/pdf/index.html";
+  private static final String PDF_MIME_TYPE = "application/pdf";
+  @Synthetic WebView mWebView;
+  private NestedScrollView mScrollView;
+  @Synthetic boolean mExternalRequired = false;
+
+  @Inject
+  @Named(HN)
+  ItemManager mItemManager;
+
+  @Inject PopupMenu mPopupMenu;
+  private KeyDelegate.NestedScrollViewHelper mScrollableHelper;
+  private final Preferences.Observable mPreferenceObservable = new Preferences.Observable();
+  private final BroadcastReceiver mReceiver =
+      new BroadcastReceiver() {
         @Override
         public void onReceive(Context context, Intent intent) {
-            setFullscreen(intent.getBooleanExtra(WebFragment.EXTRA_FULLSCREEN, false));
+          setFullscreen(intent.getBooleanExtra(WebFragment.EXTRA_FULLSCREEN, false));
         }
-    };
-    private ViewGroup mFullscreenView;
-    private ViewGroup mScrollViewContent;
-    @Synthetic
-    ImageButton mButtonRefresh;
-    private ViewSwitcher mControls;
-    private EditText mEditText;
-    private View mButtonMore;
-    private View mButtonNext;
-    protected ProgressBar mProgressBar;
-    private boolean mFullscreen;
-    private boolean mIsPdf;
-    protected String mContent;
-    private AppUtils.SystemUiHelper mSystemUiHelper;
-    private View mFragmentView;
-    @Inject
-    ReadabilityClient mReadabilityClient;
-    @Inject
-    FileDownloader mFileDownloader;
-    private WebItem mItem;
-    private boolean mIsHackerNewsUrl, mEmpty, mReadability;
-    private PdfAndroidJavascriptBridge mPdfAndroidJavascriptBridge;
+      };
+  private ViewGroup mFullscreenView;
+  private ViewGroup mScrollViewContent;
+  @Synthetic ImageButton mButtonRefresh;
+  private ViewSwitcher mControls;
+  private EditText mEditText;
+  private View mButtonMore;
+  private View mButtonNext;
+  protected ProgressBar mProgressBar;
+  private boolean mFullscreen;
+  private boolean mIsPdf;
+  protected String mContent;
+  private AppUtils.SystemUiHelper mSystemUiHelper;
+  private View mFragmentView;
+  @Inject ReadabilityClient mReadabilityClient;
+  @Inject FileDownloader mFileDownloader;
+  private WebItem mItem;
+  private boolean mIsHackerNewsUrl, mEmpty, mReadability;
+  private PdfAndroidJavascriptBridge mPdfAndroidJavascriptBridge;
 
-    @SuppressWarnings("deprecation") // Using deprecated LocalBroadcastManager; migration to LiveData/Flow requires
-                                     // architectural changes
-    @Override
-    public void onAttach(Context context) {
-        super.onAttach(context);
-        ((MaterialisticApplication) getActivity().getApplication()).applicationComponent.inject(this);
-        mPreferenceObservable.subscribe(context, this::onPreferenceChanged,
-                R.string.pref_readability_font,
-                R.string.pref_readability_line_height,
-                R.string.pref_readability_text_size);
-        LocalBroadcastManager.getInstance(context).registerReceiver(mReceiver,
-                new IntentFilter(ACTION_FULLSCREEN));
+  @SuppressWarnings(
+      "deprecation") // Using deprecated LocalBroadcastManager; migration to LiveData/Flow requires
+  // architectural changes
+  @Override
+  public void onAttach(Context context) {
+    super.onAttach(context);
+    ((MaterialisticApplication) getActivity().getApplication()).applicationComponent.inject(this);
+    mPreferenceObservable.subscribe(
+        context,
+        this::onPreferenceChanged,
+        R.string.pref_readability_font,
+        R.string.pref_readability_line_height,
+        R.string.pref_readability_text_size);
+    LocalBroadcastManager.getInstance(context)
+        .registerReceiver(mReceiver, new IntentFilter(ACTION_FULLSCREEN));
+  }
+
+  @Override
+  public void onCreate(@Nullable Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    if (savedInstanceState != null) {
+      mFullscreen = savedInstanceState.getBoolean(STATE_FULLSCREEN, false);
+      mContent = savedInstanceState.getString(STATE_CONTENT);
+      mEmpty = savedInstanceState.getBoolean(STATE_EMPTY, false);
+      mReadability = savedInstanceState.getBoolean(STATE_READABILITY, false);
+      mItem = BundleCompat.getParcelable(savedInstanceState, EXTRA_ITEM, WebItem.class);
+    } else {
+      mReadability =
+          Preferences.getDefaultStoryView(getActivity()) == Preferences.StoryViewMode.Readability;
+      mItem = BundleCompat.getParcelable(getArguments(), EXTRA_ITEM, WebItem.class);
     }
+    mIsHackerNewsUrl = AppUtils.isHackerNewsUrl(mItem);
+  }
 
-    @Override
-    public void onCreate(@Nullable Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        if (savedInstanceState != null) {
-            mFullscreen = savedInstanceState.getBoolean(STATE_FULLSCREEN, false);
-            mContent = savedInstanceState.getString(STATE_CONTENT);
-            mEmpty = savedInstanceState.getBoolean(STATE_EMPTY, false);
-            mReadability = savedInstanceState.getBoolean(STATE_READABILITY, false);
-            mItem = BundleCompat.getParcelable(savedInstanceState, EXTRA_ITEM, WebItem.class);
-        } else {
-            mReadability = Preferences.getDefaultStoryView(getActivity()) == Preferences.StoryViewMode.Readability;
-            mItem = BundleCompat.getParcelable(getArguments(), EXTRA_ITEM, WebItem.class);
-        }
-        mIsHackerNewsUrl = AppUtils.isHackerNewsUrl(mItem);
+  @Override
+  public View onCreateView(
+      LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+
+    mFragmentView = inflater.inflate(R.layout.fragment_web, container, false);
+    mFullscreenView = (ViewGroup) mFragmentView.findViewById(R.id.fullscreen);
+    mScrollViewContent = (ViewGroup) mFragmentView.findViewById(R.id.scroll_view_content);
+    mScrollView = (NestedScrollView) mFragmentView.findViewById(R.id.nested_scroll_view);
+    mControls = (ViewSwitcher) mFragmentView.findViewById(R.id.control_switcher);
+    mWebView = (WebView) mFragmentView.findViewById(R.id.web_view);
+    mButtonRefresh = (ImageButton) mFragmentView.findViewById(R.id.button_refresh);
+    mButtonMore = mFragmentView.findViewById(R.id.button_more);
+    mButtonNext = mFragmentView.findViewById(R.id.button_next);
+    mButtonNext.setEnabled(false);
+    mEditText = (EditText) mFragmentView.findViewById(R.id.edittext);
+    setUpWebControls(mFragmentView);
+    setUpWebView(mFragmentView);
+
+    return mFragmentView;
+  }
+
+  @SuppressWarnings(
+      "deprecation") // Using deprecated Fragment menu API; migration to MenuProvider requires
+  // Activity cooperation
+  @Override
+  public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+    super.onViewCreated(view, savedInstanceState);
+
+    mScrollableHelper = new KeyDelegate.NestedScrollViewHelper(mScrollView);
+    mSystemUiHelper = new AppUtils.SystemUiHelper(getActivity().getWindow());
+    mSystemUiHelper.setEnabled(!getResources().getBoolean(R.bool.multi_pane));
+    if (mFullscreen) {
+      setFullscreen(true);
     }
+  }
 
-    @Override
-    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container,
-            @Nullable Bundle savedInstanceState) {
+  @Override
+  protected void createOptionsMenu(Menu menu, MenuInflater inflater) {
+    inflater.inflate(R.menu.menu_article, menu);
+  }
 
-        mFragmentView = inflater.inflate(R.layout.fragment_web, container, false);
-        mFullscreenView = (ViewGroup) mFragmentView.findViewById(R.id.fullscreen);
-        mScrollViewContent = (ViewGroup) mFragmentView.findViewById(R.id.scroll_view_content);
-        mScrollView = (NestedScrollView) mFragmentView.findViewById(R.id.nested_scroll_view);
-        mControls = (ViewSwitcher) mFragmentView.findViewById(R.id.control_switcher);
-        mWebView = (WebView) mFragmentView.findViewById(R.id.web_view);
-        mButtonRefresh = (ImageButton) mFragmentView.findViewById(R.id.button_refresh);
-        mButtonMore = mFragmentView.findViewById(R.id.button_more);
-        mButtonNext = mFragmentView.findViewById(R.id.button_next);
-        mButtonNext.setEnabled(false);
-        mEditText = (EditText) mFragmentView.findViewById(R.id.edittext);
-        setUpWebControls(mFragmentView);
-        setUpWebView(mFragmentView);
+  @Override
+  protected void prepareOptionsMenu(Menu menu) {
+    MenuItem menuReadability = menu.findItem(R.id.menu_readability);
+    menuReadability.setVisible(modeToggleEnabled());
+    mMenuTintDelegate.setIcon(
+        menuReadability,
+        mReadability ? R.drawable.ic_web_black_24dp : R.drawable.ic_chrome_reader_mode_black_24dp);
+    menuReadability.setTitle(mReadability ? R.string.article : R.string.readability);
+    menu.findItem(R.id.menu_font_options).setVisible(fontEnabled());
+  }
 
-        return mFragmentView;
+  @SuppressWarnings(
+      "deprecation") // Using deprecated Fragment menu API; migration to MenuProvider requires
+  // Activity cooperation
+  @Override
+  public boolean onOptionsItemSelected(MenuItem item) {
+    if (item.getItemId() == R.id.menu_font_options) {
+      showPreferences();
+      return true;
     }
-
-    @SuppressWarnings("deprecation") // Using deprecated Fragment menu API; migration to MenuProvider requires
-                                     // Activity cooperation
-    @Override
-    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
-        super.onViewCreated(view, savedInstanceState);
-
-        mScrollableHelper = new KeyDelegate.NestedScrollViewHelper(mScrollView);
-        mSystemUiHelper = new AppUtils.SystemUiHelper(getActivity().getWindow());
-        mSystemUiHelper.setEnabled(!getResources().getBoolean(R.bool.multi_pane));
-        if (mFullscreen) {
-            setFullscreen(true);
-        }
-
+    if (item.getItemId() == R.id.menu_readability) {
+      mReadability = !mReadability;
+      load();
+      return true;
     }
+    return super.onOptionsItemSelected(item);
+  }
 
-    @Override
-    protected void createOptionsMenu(Menu menu, MenuInflater inflater) {
-        inflater.inflate(R.menu.menu_article, menu);
+  @Override
+  public void onResume() {
+    super.onResume();
+    mWebView.onResume();
+    mWebView.resumeTimers();
+  }
+
+  @Override
+  public void onStop() {
+    super.onStop();
+    pauseWebView();
+  }
+
+  @Override
+  public void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    outState.putBoolean(STATE_FULLSCREEN, mFullscreen);
+    outState.putString(STATE_CONTENT, mContent);
+    outState.putParcelable(EXTRA_ITEM, mItem);
+    outState.putBoolean(STATE_EMPTY, mEmpty);
+    outState.putBoolean(STATE_READABILITY, mReadability);
+  }
+
+  @Override
+  public void onDestroy() {
+    super.onDestroy();
+    if (mPdfAndroidJavascriptBridge != null) {
+      mPdfAndroidJavascriptBridge.cleanUp();
     }
+    mWebView.destroy();
+    // Note: mReadabilityClient is a singleton, do not call destroy() here.
+    // Subscriptions are fire-and-forget and managed internally.
+  }
 
-    @Override
-    protected void prepareOptionsMenu(Menu menu) {
-        MenuItem menuReadability = menu.findItem(R.id.menu_readability);
-        menuReadability.setVisible(modeToggleEnabled());
-        mMenuTintDelegate.setIcon(menuReadability,
-                mReadability ? R.drawable.ic_web_black_24dp : R.drawable.ic_chrome_reader_mode_black_24dp);
-        menuReadability.setTitle(mReadability ? R.string.article : R.string.readability);
-        menu.findItem(R.id.menu_font_options).setVisible(fontEnabled());
+  @SuppressWarnings(
+      "deprecation") // Using deprecated LocalBroadcastManager; migration to LiveData/Flow requires
+  // architectural changes
+  @Override
+  public void onDetach() {
+    mPreferenceObservable.unsubscribe(getActivity());
+    LocalBroadcastManager.getInstance(getActivity()).unregisterReceiver(mReceiver);
+    super.onDetach();
+  }
+
+  @Override
+  public void scrollToTop() {
+    if (mFullscreen) {
+      mWebView.pageUp(true);
+    } else {
+      mScrollableHelper.scrollToTop();
     }
+  }
 
-    @SuppressWarnings("deprecation") // Using deprecated Fragment menu API; migration to MenuProvider requires
-                                     // Activity cooperation
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        if (item.getItemId() == R.id.menu_font_options) {
-            showPreferences();
-            return true;
-        }
-        if (item.getItemId() == R.id.menu_readability) {
-            mReadability = !mReadability;
-            load();
-            return true;
-        }
-        return super.onOptionsItemSelected(item);
+  @Override
+  public boolean scrollToNext() {
+    if (mFullscreen) {
+      mWebView.pageDown(false);
+      return true;
+    } else {
+      return mScrollableHelper.scrollToNext();
     }
+  }
 
-    @Override
-    public void onResume() {
-        super.onResume();
-        mWebView.onResume();
-        mWebView.resumeTimers();
+  @Override
+  public boolean scrollToPrevious() {
+    if (mFullscreen) {
+      mWebView.pageUp(false);
+      return true;
+    } else {
+      return mScrollableHelper.scrollToPrevious();
     }
+  }
 
-    @Override
-    public void onStop() {
-        super.onStop();
-        pauseWebView();
+  @Override
+  public boolean onBackPressed() {
+    if (mWebView.canGoBack()) {
+      mWebView.goBack();
+      return true;
     }
+    return false;
+  }
 
-    @Override
-    public void onSaveInstanceState(Bundle outState) {
-        super.onSaveInstanceState(outState);
-        outState.putBoolean(STATE_FULLSCREEN, mFullscreen);
-        outState.putString(STATE_CONTENT, mContent);
-        outState.putParcelable(EXTRA_ITEM, mItem);
-        outState.putBoolean(STATE_EMPTY, mEmpty);
-        outState.putBoolean(STATE_READABILITY, mReadability);
+  @Override
+  protected void load() {
+    mWebView.setVisibility(View.INVISIBLE);
+    if (mIsHackerNewsUrl) {
+      bindContent();
+    } else if (mReadability && !mEmpty) {
+      if (TextUtils.isEmpty(mContent)) {
+        parse();
+      } else {
+        loadContent();
+      }
+    } else {
+      loadUrl();
     }
+  }
 
-    @Override
-    public void onDestroy() {
-        super.onDestroy();
-        if (mPdfAndroidJavascriptBridge != null) {
-            mPdfAndroidJavascriptBridge.cleanUp();
-        }
-        mWebView.destroy();
-        // Note: mReadabilityClient is a singleton, do not call destroy() here.
-        // Subscriptions are fire-and-forget and managed internally.
+  private void loadUrl() {
+    setWebSettings(true);
+    reloadUrl(mItem.getUrl());
+  }
+
+  private void reloadUrl(String url) {
+    reloadUrl(url, null);
+  }
+
+  @SuppressLint("AddJavascriptInterface")
+  private void reloadUrl(String url, @Nullable String pdfFilePath) {
+    mIsPdf = false;
+    if (mPdfAndroidJavascriptBridge != null) {
+      mPdfAndroidJavascriptBridge.cleanUp();
+      mWebView.removeJavascriptInterface("PdfAndroidJavascriptBridge");
     }
+    if (pdfFilePath != null && TextUtils.equals(PDF_LOADER_URL, url)) {
+      setProgress(80);
+      mIsPdf = true;
+      mPdfAndroidJavascriptBridge =
+          new PdfAndroidJavascriptBridge(
+              pdfFilePath,
+              new PdfAndroidJavascriptBridge.Callbacks() {
+                @Override
+                public void onFailure() {
+                  offerExternalApp();
+                  setProgress(100);
+                }
 
-    @SuppressWarnings("deprecation") // Using deprecated LocalBroadcastManager; migration to LiveData/Flow requires
-                                     // architectural changes
-    @Override
-    public void onDetach() {
-        mPreferenceObservable.unsubscribe(getActivity());
-        LocalBroadcastManager.getInstance(getActivity()).unregisterReceiver(mReceiver);
-        super.onDetach();
+                @Override
+                public void onLoad() {
+                  setProgress(100);
+                }
+              });
+      mWebView.addJavascriptInterface(mPdfAndroidJavascriptBridge, "PdfAndroidJavascriptBridge");
+      mWebView.setInitialScale(1);
     }
+    mWebView.reloadUrl(url);
+  }
 
-    @Override
-    public void scrollToTop() {
-        if (mFullscreen) {
-            mWebView.pageUp(true);
-        } else {
-            mScrollableHelper.scrollToTop();
-        }
+  @Synthetic
+  void loadContent() {
+    setWebSettings(false);
+    mWebView.reloadHtml(AppUtils.wrapHtml(getActivity(), mContent));
+  }
+
+  private void parse() {
+    mProgressBar.setProgress(DEFAULT_PROGRESS);
+    mReadabilityClient.parse(mItem.getId(), mItem.getUrl(), new ReadabilityCallback(this));
+  }
+
+  private void bindContent() {
+    if (mItem instanceof Item) {
+      mContent = ((Item) mItem).getText();
+      loadContent();
+    } else {
+      mItemManager.getItem(mItem.getId(), ItemManager.MODE_DEFAULT, new ItemResponseListener(this));
     }
+  }
 
-    @Override
-    public boolean scrollToNext() {
-        if (mFullscreen) {
-            mWebView.pageDown(false);
-            return true;
-        } else {
-            return mScrollableHelper.scrollToNext();
-        }
-    }
+  private void pauseWebView() {
+    mWebView.onPause();
+    mWebView.pauseTimers();
+  }
 
-    @Override
-    public boolean scrollToPrevious() {
-        if (mFullscreen) {
-            mWebView.pageUp(false);
-            return true;
-        } else {
-            return mScrollableHelper.scrollToPrevious();
-        }
-    }
+  private boolean fontEnabled() {
+    return mReadability && !mEmpty && !TextUtils.isEmpty(mContent);
+  }
 
-    @Override
-    public boolean onBackPressed() {
-        if (mWebView.canGoBack()) {
-            mWebView.goBack();
-            return true;
-        }
-        return false;
-    }
+  private boolean modeToggleEnabled() {
+    return !mIsHackerNewsUrl && !mWebView.canGoBack();
+  }
 
-    @Override
-    protected void load() {
-        mWebView.setVisibility(View.INVISIBLE);
-        if (mIsHackerNewsUrl) {
-            bindContent();
-        } else if (mReadability && !mEmpty) {
-            if (TextUtils.isEmpty(mContent)) {
-                parse();
-            } else {
-                loadContent();
-            }
-        } else {
-            loadUrl();
-        }
-    }
-
-    private void loadUrl() {
-        setWebSettings(true);
-        reloadUrl(mItem.getUrl());
-    }
-
-    private void reloadUrl(String url) {
-        reloadUrl(url, null);
-    }
-
-    @SuppressLint("AddJavascriptInterface")
-    private void reloadUrl(String url, @Nullable String pdfFilePath) {
-        mIsPdf = false;
-        if (mPdfAndroidJavascriptBridge != null) {
-            mPdfAndroidJavascriptBridge.cleanUp();
-            mWebView.removeJavascriptInterface("PdfAndroidJavascriptBridge");
-        }
-        if (pdfFilePath != null && TextUtils.equals(PDF_LOADER_URL, url)) {
-            setProgress(80);
-            mIsPdf = true;
-            mPdfAndroidJavascriptBridge = new PdfAndroidJavascriptBridge(pdfFilePath,
-                    new PdfAndroidJavascriptBridge.Callbacks() {
-                        @Override
-                        public void onFailure() {
-                            offerExternalApp();
-                            setProgress(100);
-                        }
-
-                        @Override
-                        public void onLoad() {
-                            setProgress(100);
-                        }
-                    });
-            mWebView.addJavascriptInterface(mPdfAndroidJavascriptBridge, "PdfAndroidJavascriptBridge");
-            mWebView.setInitialScale(1);
-        }
-        mWebView.reloadUrl(url);
-    }
-
-    @Synthetic
-    void loadContent() {
-        setWebSettings(false);
-        mWebView.reloadHtml(AppUtils.wrapHtml(getActivity(), mContent));
-    }
-
-    private void parse() {
-        mProgressBar.setProgress(DEFAULT_PROGRESS);
-        mReadabilityClient.parse(mItem.getId(), mItem.getUrl(), new ReadabilityCallback(this));
-    }
-
-    private void bindContent() {
-        if (mItem instanceof Item) {
-            mContent = ((Item) mItem).getText();
-            loadContent();
-        } else {
-            mItemManager.getItem(mItem.getId(), ItemManager.MODE_DEFAULT, new ItemResponseListener(this));
-        }
-    }
-
-    private void pauseWebView() {
-        mWebView.onPause();
-        mWebView.pauseTimers();
-    }
-
-    private boolean fontEnabled() {
-        return mReadability && !mEmpty && !TextUtils.isEmpty(mContent);
-    }
-
-    private boolean modeToggleEnabled() {
-        return !mIsHackerNewsUrl && !mWebView.canGoBack();
-    }
-
-    private void setUpWebControls(View view) {
-        view.findViewById(R.id.toolbar_web).setOnClickListener(v -> scrollToTop());
-        view.findViewById(R.id.button_back).setOnClickListener(v -> mWebView.goBack());
-        view.findViewById(R.id.button_forward).setOnClickListener(v -> mWebView.goForward());
-        view.findViewById(R.id.button_clear).setOnClickListener(v -> {
-            mSystemUiHelper.setFullscreen(true);
-            reset();
-            mControls.showNext();
+  private void setUpWebControls(View view) {
+    view.findViewById(R.id.toolbar_web).setOnClickListener(v -> scrollToTop());
+    view.findViewById(R.id.button_back).setOnClickListener(v -> mWebView.goBack());
+    view.findViewById(R.id.button_forward).setOnClickListener(v -> mWebView.goForward());
+    view.findViewById(R.id.button_clear)
+        .setOnClickListener(
+            v -> {
+              mSystemUiHelper.setFullscreen(true);
+              reset();
+              mControls.showNext();
+            });
+    view.findViewById(R.id.button_find)
+        .setOnClickListener(
+            v -> {
+              mEditText.requestFocus();
+              toggleSoftKeyboard(true);
+              mControls.showNext();
+            });
+    mButtonRefresh.setOnClickListener(
+        v -> {
+          if (mWebView.getProgress() < 100) {
+            mWebView.stopLoading();
+          } else {
+            mWebView.reload();
+          }
         });
-        view.findViewById(R.id.button_find).setOnClickListener(v -> {
-            mEditText.requestFocus();
-            toggleSoftKeyboard(true);
-            mControls.showNext();
-        });
-        mButtonRefresh.setOnClickListener(v -> {
-            if (mWebView.getProgress() < 100) {
-                mWebView.stopLoading();
-            } else {
-                mWebView.reload();
-            }
-        });
-        view.findViewById(R.id.button_exit)
-                .setOnClickListener(v -> {
-                    @SuppressWarnings("deprecation") // Using deprecated LocalBroadcastManager
-                    android.content.Intent intent = new Intent(WebFragment.ACTION_FULLSCREEN)
-                            .putExtra(EXTRA_FULLSCREEN, false);
-                    LocalBroadcastManager.getInstance(getActivity()).sendBroadcast(intent);
-                });
-        mButtonNext.setOnClickListener(v -> mWebView.findNext(true));
-        mButtonMore.setOnClickListener(v -> mPopupMenu.create(getActivity(), mButtonMore, Gravity.NO_GRAVITY)
+    view.findViewById(R.id.button_exit)
+        .setOnClickListener(
+            v -> {
+              @SuppressWarnings("deprecation") // Using deprecated LocalBroadcastManager
+              android.content.Intent intent =
+                  new Intent(WebFragment.ACTION_FULLSCREEN).putExtra(EXTRA_FULLSCREEN, false);
+              LocalBroadcastManager.getInstance(getActivity()).sendBroadcast(intent);
+            });
+    mButtonNext.setOnClickListener(v -> mWebView.findNext(true));
+    mButtonMore.setOnClickListener(
+        v ->
+            mPopupMenu
+                .create(getActivity(), mButtonMore, Gravity.NO_GRAVITY)
                 .inflate(R.menu.menu_web)
-                .setOnMenuItemClickListener(item -> {
-                    if (item.getItemId() == R.id.menu_font_options) {
+                .setOnMenuItemClickListener(
+                    item -> {
+                      if (item.getItemId() == R.id.menu_font_options) {
                         showPreferences();
                         return true;
-                    }
-                    if (item.getItemId() == R.id.menu_zoom_in) {
+                      }
+                      if (item.getItemId() == R.id.menu_zoom_in) {
                         mWebView.zoomIn();
                         return true;
-                    }
-                    if (item.getItemId() == R.id.menu_zoom_out) {
+                      }
+                      if (item.getItemId() == R.id.menu_zoom_out) {
                         mWebView.zoomOut();
                         return true;
-                    }
-                    return false;
-                })
+                      }
+                      return false;
+                    })
                 .setMenuItemVisible(R.id.menu_font_options, fontEnabled())
                 .show());
-        mEditText.setOnEditorActionListener((v, actionId, event) -> {
-            findInPage();
-            return true;
+    mEditText.setOnEditorActionListener(
+        (v, actionId, event) -> {
+          findInPage();
+          return true;
         });
-    }
+  }
 
-    private void setUpWebView(View view) {
-        mProgressBar = (ProgressBar) view.findViewById(R.id.progress);
-        mWebView.setBackgroundColor(Color.TRANSPARENT);
-        mWebView.setWebViewClient(new AdBlockWebViewClient(getActivity(), Preferences.adBlockEnabled(getActivity())) {
-            @Override
-            public void onPageStarted(android.webkit.WebView view, String url, Bitmap favicon) {
-                super.onPageStarted(view, url, favicon);
-                if (getActivity() != null) {
-                    getActivity().invalidateOptionsMenu();
-                }
+  private void setUpWebView(View view) {
+    mProgressBar = (ProgressBar) view.findViewById(R.id.progress);
+    mWebView.setBackgroundColor(Color.TRANSPARENT);
+    mWebView.setWebViewClient(
+        new AdBlockWebViewClient(getActivity(), Preferences.adBlockEnabled(getActivity())) {
+          @Override
+          public void onPageStarted(android.webkit.WebView view, String url, Bitmap favicon) {
+            super.onPageStarted(view, url, favicon);
+            if (getActivity() != null) {
+              getActivity().invalidateOptionsMenu();
             }
+          }
 
-            @Override
-            public void onPageFinished(android.webkit.WebView view, String url) {
-                super.onPageFinished(view, url);
-                if (getActivity() != null) {
-                    getActivity().invalidateOptionsMenu();
-                }
+          @Override
+          public void onPageFinished(android.webkit.WebView view, String url) {
+            super.onPageFinished(view, url);
+            if (getActivity() != null) {
+              getActivity().invalidateOptionsMenu();
             }
+          }
         });
-        mWebView.setWebChromeClient(new CacheableWebView.ArchiveClient() {
-            @Override
-            public void onProgressChanged(android.webkit.WebView view, int newProgress) {
-                super.onProgressChanged(view, newProgress);
-                if (!mIsPdf) {
-                    setProgress(newProgress);
-                }
+    mWebView.setWebChromeClient(
+        new CacheableWebView.ArchiveClient() {
+          @Override
+          public void onProgressChanged(android.webkit.WebView view, int newProgress) {
+            super.onProgressChanged(view, newProgress);
+            if (!mIsPdf) {
+              setProgress(newProgress);
             }
+          }
         });
-        mWebView.setDownloadListener((url, userAgent, contentDisposition, mimetype, contentLength) -> {
-            if (getActivity() == null) {
-                return;
-            }
-            if (mimetype.equals(PDF_MIME_TYPE)) {
-                setProgress(10);
-                mIsPdf = true;
-                downloadFileAndRenderPdf();
-            } else {
-                offerExternalApp();
-            }
-        });
-        AppUtils.toggleWebViewZoom(mWebView.getSettings(), false);
-    }
-
-    private void offerExternalApp() {
-        final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(mItem.getUrl()));
-        if (intent.resolveActivity(getActivity().getPackageManager()) == null) {
+    mWebView.setDownloadListener(
+        (url, userAgent, contentDisposition, mimetype, contentLength) -> {
+          if (getActivity() == null) {
             return;
+          }
+          if (mimetype.equals(PDF_MIME_TYPE)) {
+            setProgress(10);
+            mIsPdf = true;
+            downloadFileAndRenderPdf();
+          } else {
+            offerExternalApp();
+          }
+        });
+    AppUtils.toggleWebViewZoom(mWebView.getSettings(), false);
+  }
+
+  private void offerExternalApp() {
+    final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(mItem.getUrl()));
+    if (intent.resolveActivity(getActivity().getPackageManager()) == null) {
+      return;
+    }
+    mExternalRequired = true;
+    mWebView.setVisibility(GONE);
+    getActivity().findViewById(R.id.empty).setVisibility(VISIBLE);
+    getActivity().findViewById(R.id.download_button).setOnClickListener(v -> startActivity(intent));
+  }
+
+  private void setProgress(int progress) {
+    mProgressBar.setProgress(progress);
+    mProgressBar.setVisibility(progress == 100 ? GONE : VISIBLE);
+    mButtonRefresh.setImageResource(
+        progress == 100 ? R.drawable.ic_refresh_white_24dp : R.drawable.ic_clear_white_24dp);
+  }
+
+  @SuppressLint("SetJavaScriptEnabled")
+  private void setWebSettings(boolean isRemote) {
+    mReadability = !isRemote;
+    mWebView.setBackgroundColor(isRemote ? Color.WHITE : Color.TRANSPARENT);
+    mWebView.getSettings().setLoadWithOverviewMode(isRemote);
+    mWebView.getSettings().setUseWideViewPort(isRemote);
+    mWebView.getSettings().setJavaScriptEnabled(true);
+    getActivity().invalidateOptionsMenu();
+  }
+
+  @Synthetic
+  void setFullscreen(boolean isFullscreen) {
+    if (getView() == null) {
+      return;
+    }
+    mFullscreen = isFullscreen;
+    mControls.setVisibility(isFullscreen ? VISIBLE : View.GONE);
+    AppUtils.toggleWebViewZoom(mWebView.getSettings(), isFullscreen);
+    ViewGroup.LayoutParams params = mWebView.getLayoutParams();
+    if (isFullscreen) {
+      mScrollView.removeView(mScrollViewContent);
+      mWebView.scrollTo(mScrollView.getScrollX(), mScrollView.getScrollY());
+      mFullscreenView.addView(mScrollViewContent);
+      params.height = ViewGroup.LayoutParams.MATCH_PARENT;
+    } else {
+      reset();
+      // We'll zoom out until it returns false, which means it has min zoom level.
+      // It's quite dangerous piece of code - potentially could lead to infinite loop,
+      // so let's add some reasonable limit just in case
+      int i = 0;
+      while (mWebView.zoomOut() && i < 30) {
+        i++;
+      }
+      mFullscreenView.removeView(mScrollViewContent);
+      mScrollView.addView(mScrollViewContent);
+      mScrollView.post(() -> mScrollView.scrollTo(mWebView.getScrollX(), mWebView.getScrollY()));
+      params.height = ViewGroup.LayoutParams.WRAP_CONTENT;
+    }
+    mWebView.setLayoutParams(params);
+  }
+
+  private void showPreferences() {
+    Bundle args = new Bundle();
+    args.putInt(PopupSettingsFragment.EXTRA_TITLE, R.string.font_options);
+    args.putIntArray(
+        PopupSettingsFragment.EXTRA_XML_PREFERENCES, new int[] {R.xml.preferences_readability});
+    PopupSettingsFragment fragment = new PopupSettingsFragment();
+    fragment.setArguments(args);
+    fragment.show(getParentFragmentManager(), PopupSettingsFragment.class.getName());
+  }
+
+  private void onPreferenceChanged(int key, boolean contextChanged) {
+    if (!contextChanged) {
+      load();
+    }
+  }
+
+  private void reset() {
+    mEditText.setText(null);
+    mButtonNext.setEnabled(false);
+    toggleSoftKeyboard(false);
+    mWebView.clearMatches();
+  }
+
+  private void findInPage() {
+    String query = mEditText.getText().toString().trim();
+    if (TextUtils.isEmpty(query)) {
+      return;
+    }
+    mWebView.setFindListener(
+        (activeMatchOrdinal, numberOfMatches, isDoneCounting) -> {
+          if (isDoneCounting) {
+            handleFindResults(numberOfMatches);
+          }
+        });
+    mWebView.findAllAsync(query);
+  }
+
+  private void handleFindResults(int numberOfMatches) {
+    mButtonNext.setEnabled(numberOfMatches > 0);
+    if (numberOfMatches == 0) {
+      Toast.makeText(getContext(), R.string.no_matches, Toast.LENGTH_SHORT).show();
+    } else {
+      toggleSoftKeyboard(false);
+    }
+  }
+
+  private void toggleSoftKeyboard(boolean visible) {
+    InputMethodManager imm =
+        (InputMethodManager) getActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
+    if (visible) {
+      imm.showSoftInput(mEditText, InputMethodManager.SHOW_IMPLICIT);
+    } else {
+      imm.hideSoftInputFromWindow(mEditText.getWindowToken(), 0);
+    }
+  }
+
+  @Synthetic
+  void onParsed(String content) {
+    if (isAttached()) {
+      mContent = content;
+      if (!TextUtils.isEmpty(mContent)) {
+        loadContent();
+      } else {
+        mEmpty = true;
+        if (mReadability) {
+          Toast.makeText(getActivity(), R.string.readability_failed, Toast.LENGTH_SHORT).show();
         }
-        mExternalRequired = true;
-        mWebView.setVisibility(GONE);
-        getActivity().findViewById(R.id.empty).setVisibility(VISIBLE);
-        getActivity().findViewById(R.id.download_button).setOnClickListener(v -> startActivity(intent));
+        loadUrl();
+      }
     }
+  }
 
-    private void setProgress(int progress) {
-        mProgressBar.setProgress(progress);
-        mProgressBar.setVisibility(progress == 100 ? GONE : VISIBLE);
-        mButtonRefresh
-                .setImageResource(progress == 100 ? R.drawable.ic_refresh_white_24dp : R.drawable.ic_clear_white_24dp);
-    }
+  @Synthetic
+  void onItemLoaded(@NonNull Item response) {
+    getActivity().invalidateOptionsMenu();
+    mItem = response;
+    bindContent();
+  }
 
-    @SuppressLint("SetJavaScriptEnabled")
-    private void setWebSettings(boolean isRemote) {
-        mReadability = !isRemote;
-        mWebView.setBackgroundColor(isRemote ? Color.WHITE : Color.TRANSPARENT);
-        mWebView.getSettings().setLoadWithOverviewMode(isRemote);
-        mWebView.getSettings().setUseWideViewPort(isRemote);
-        mWebView.getSettings().setJavaScriptEnabled(true);
-        getActivity().invalidateOptionsMenu();
-    }
+  private void downloadFileAndRenderPdf() {
+    mFileDownloader.downloadFile(
+        mItem.getUrl(),
+        PDF_MIME_TYPE,
+        new FileDownloader.FileDownloaderCallback() {
+          @Override
+          public void onFailure(Call call, IOException e) {
+            offerExternalApp();
+          }
+
+          @Override
+          public void onSuccess(String filePath) {
+            reloadUrl(PDF_LOADER_URL, filePath);
+          }
+        });
+  }
+
+  static class ReadabilityCallback implements ReadabilityClient.Callback {
+    private final WeakReference<WebFragment> mReadabilityFragment;
 
     @Synthetic
-    void setFullscreen(boolean isFullscreen) {
-        if (getView() == null) {
-            return;
-        }
-        mFullscreen = isFullscreen;
-        mControls.setVisibility(isFullscreen ? VISIBLE : View.GONE);
-        AppUtils.toggleWebViewZoom(mWebView.getSettings(), isFullscreen);
-        ViewGroup.LayoutParams params = mWebView.getLayoutParams();
-        if (isFullscreen) {
-            mScrollView.removeView(mScrollViewContent);
-            mWebView.scrollTo(mScrollView.getScrollX(), mScrollView.getScrollY());
-            mFullscreenView.addView(mScrollViewContent);
-            params.height = ViewGroup.LayoutParams.MATCH_PARENT;
-        } else {
-            reset();
-            // We'll zoom out until it returns false, which means it has min zoom level.
-            // It's quite dangerous piece of code - potentially could lead to infinite loop,
-            // so let's add some reasonable limit just in case
-            int i = 0;
-            while (mWebView.zoomOut() && i < 30) {
-                i++;
-            }
-            mFullscreenView.removeView(mScrollViewContent);
-            mScrollView.addView(mScrollViewContent);
-            mScrollView.post(() -> mScrollView.scrollTo(mWebView.getScrollX(), mWebView.getScrollY()));
-            params.height = ViewGroup.LayoutParams.WRAP_CONTENT;
-        }
-        mWebView.setLayoutParams(params);
+    ReadabilityCallback(WebFragment webFragment) {
+      mReadabilityFragment = new WeakReference<>(webFragment);
     }
 
-    private void showPreferences() {
-        Bundle args = new Bundle();
-        args.putInt(PopupSettingsFragment.EXTRA_TITLE, R.string.font_options);
-        args.putIntArray(PopupSettingsFragment.EXTRA_XML_PREFERENCES,
-                new int[] { R.xml.preferences_readability });
-        PopupSettingsFragment fragment = new PopupSettingsFragment();
-        fragment.setArguments(args);
-        fragment.show(getParentFragmentManager(), PopupSettingsFragment.class.getName());
+    @Override
+    public void onResponse(String content) {
+      if (mReadabilityFragment.get() != null && mReadabilityFragment.get().isAttached()) {
+        mReadabilityFragment.get().onParsed(content);
+      }
     }
+  }
 
-    private void onPreferenceChanged(int key, boolean contextChanged) {
-        if (!contextChanged) {
-            load();
-        }
-    }
-
-    private void reset() {
-        mEditText.setText(null);
-        mButtonNext.setEnabled(false);
-        toggleSoftKeyboard(false);
-        mWebView.clearMatches();
-    }
-
-    private void findInPage() {
-        String query = mEditText.getText().toString().trim();
-        if (TextUtils.isEmpty(query)) {
-            return;
-        }
-        mWebView.setFindListener((activeMatchOrdinal, numberOfMatches, isDoneCounting) -> {
-            if (isDoneCounting) {
-                handleFindResults(numberOfMatches);
-            }
-        });
-        mWebView.findAllAsync(query);
-    }
-
-    private void handleFindResults(int numberOfMatches) {
-        mButtonNext.setEnabled(numberOfMatches > 0);
-        if (numberOfMatches == 0) {
-            Toast.makeText(getContext(), R.string.no_matches, Toast.LENGTH_SHORT).show();
-        } else {
-            toggleSoftKeyboard(false);
-        }
-    }
-
-    private void toggleSoftKeyboard(boolean visible) {
-        InputMethodManager imm = (InputMethodManager) getActivity().getSystemService(
-                Context.INPUT_METHOD_SERVICE);
-        if (visible) {
-            imm.showSoftInput(mEditText, InputMethodManager.SHOW_IMPLICIT);
-        } else {
-            imm.hideSoftInputFromWindow(mEditText.getWindowToken(), 0);
-        }
-    }
+  static class ItemResponseListener implements ResponseListener<Item> {
+    private final WeakReference<WebFragment> mFragment;
 
     @Synthetic
-    void onParsed(String content) {
-        if (isAttached()) {
-            mContent = content;
-            if (!TextUtils.isEmpty(mContent)) {
-                loadContent();
-            } else {
-                mEmpty = true;
-                if (mReadability) {
-                    Toast.makeText(getActivity(), R.string.readability_failed, Toast.LENGTH_SHORT).show();
-                }
-                loadUrl();
-            }
-        }
+    ItemResponseListener(WebFragment webFragment) {
+      mFragment = new WeakReference<>(webFragment);
     }
 
-    @Synthetic
-    void onItemLoaded(@NonNull Item response) {
-        getActivity().invalidateOptionsMenu();
-        mItem = response;
-        bindContent();
+    @Override
+    public void onResponse(@Nullable Item response) {
+      if (mFragment.get() != null && mFragment.get().isAttached() && response != null) {
+        mFragment.get().onItemLoaded(response);
+      }
     }
 
-    private void downloadFileAndRenderPdf() {
-        mFileDownloader.downloadFile(mItem.getUrl(), PDF_MIME_TYPE, new FileDownloader.FileDownloaderCallback() {
-            @Override
-            public void onFailure(Call call, IOException e) {
-                offerExternalApp();
-            }
+    @Override
+    public void onError(String errorMessage) {
+      // do nothing
+    }
+  }
 
-            @Override
-            public void onSuccess(String filePath) {
-                reloadUrl(PDF_LOADER_URL, filePath);
-            }
-        });
+  static class PdfAndroidJavascriptBridge {
+    private File mFile;
+    private @Nullable RandomAccessFile mRandomAccessFile;
+    private @Nullable Callbacks mCallback;
+    private Handler mHandler;
+
+    PdfAndroidJavascriptBridge(String filePath, @Nullable Callbacks callback) {
+      mFile = new File(filePath);
+      mCallback = callback;
+      mHandler = new Handler(Looper.getMainLooper());
     }
 
-    static class ReadabilityCallback implements ReadabilityClient.Callback {
-        private final WeakReference<WebFragment> mReadabilityFragment;
-
-        @Synthetic
-        ReadabilityCallback(WebFragment webFragment) {
-            mReadabilityFragment = new WeakReference<>(webFragment);
+    @JavascriptInterface
+    public String getChunk(long begin, long end) {
+      try {
+        if (mRandomAccessFile == null) {
+          mRandomAccessFile = new RandomAccessFile(mFile, "r");
         }
-
-        @Override
-        public void onResponse(String content) {
-            if (mReadabilityFragment.get() != null && mReadabilityFragment.get().isAttached()) {
-                mReadabilityFragment.get().onParsed(content);
-            }
+        if (mRandomAccessFile != null) {
+          final int bufferSize = (int) (end - begin);
+          byte[] data = new byte[bufferSize];
+          mRandomAccessFile.seek(begin);
+          mRandomAccessFile.read(data);
+          return Base64.encodeToString(data, Base64.DEFAULT);
+        } else {
+          return "";
         }
+      } catch (IOException e) {
+        Log.e("Exception", e.toString());
+        return "";
+      }
     }
 
-    static class ItemResponseListener implements ResponseListener<Item> {
-        private final WeakReference<WebFragment> mFragment;
-
-        @Synthetic
-        ItemResponseListener(WebFragment webFragment) {
-            mFragment = new WeakReference<>(webFragment);
-        }
-
-        @Override
-        public void onResponse(@Nullable Item response) {
-            if (mFragment.get() != null && mFragment.get().isAttached() && response != null) {
-                mFragment.get().onItemLoaded(response);
-            }
-        }
-
-        @Override
-        public void onError(String errorMessage) {
-            // do nothing
-        }
+    @JavascriptInterface
+    public long getSize() {
+      return mFile.length();
     }
 
-    static class PdfAndroidJavascriptBridge {
-        private File mFile;
-        private @Nullable RandomAccessFile mRandomAccessFile;
-        private @Nullable Callbacks mCallback;
-        private Handler mHandler;
-
-        PdfAndroidJavascriptBridge(String filePath, @Nullable Callbacks callback) {
-            mFile = new File(filePath);
-            mCallback = callback;
-            mHandler = new Handler(Looper.getMainLooper());
-        }
-
-        @JavascriptInterface
-        public String getChunk(long begin, long end) {
-            try {
-                if (mRandomAccessFile == null) {
-                    mRandomAccessFile = new RandomAccessFile(mFile, "r");
-                }
-                if (mRandomAccessFile != null) {
-                    final int bufferSize = (int) (end - begin);
-                    byte[] data = new byte[bufferSize];
-                    mRandomAccessFile.seek(begin);
-                    mRandomAccessFile.read(data);
-                    return Base64.encodeToString(data, Base64.DEFAULT);
-                } else {
-                    return "";
-                }
-            } catch (IOException e) {
-                Log.e("Exception", e.toString());
-                return "";
-            }
-        }
-
-        @JavascriptInterface
-        public long getSize() {
-            return mFile.length();
-        }
-
-        @JavascriptInterface
-        public void onLoad() {
-            if (mCallback != null) {
-                mHandler.post(() -> mCallback.onLoad());
-            }
-        }
-
-        @JavascriptInterface
-        public void onFailure() {
-            if (mCallback != null) {
-                mHandler.post(() -> mCallback.onFailure());
-            }
-        }
-
-        public void cleanUp() {
-            try {
-                if (mRandomAccessFile != null) {
-                    mRandomAccessFile.close();
-                }
-            } catch (IOException e) {
-                Log.e("Exception", e.toString());
-            }
-        }
-
-        @Override
-        public void finalize() throws Throwable {
-            try {
-                cleanUp();
-            } finally {
-                super.finalize();
-            }
-        }
-
-        interface Callbacks {
-            void onFailure();
-
-            void onLoad();
-        }
+    @JavascriptInterface
+    public void onLoad() {
+      if (mCallback != null) {
+        mHandler.post(() -> mCallback.onLoad());
+      }
     }
+
+    @JavascriptInterface
+    public void onFailure() {
+      if (mCallback != null) {
+        mHandler.post(() -> mCallback.onFailure());
+      }
+    }
+
+    public void cleanUp() {
+      try {
+        if (mRandomAccessFile != null) {
+          mRandomAccessFile.close();
+        }
+      } catch (IOException e) {
+        Log.e("Exception", e.toString());
+      }
+    }
+
+    @Override
+    public void finalize() throws Throwable {
+      try {
+        cleanUp();
+      } finally {
+        super.finalize();
+      }
+    }
+
+    interface Callbacks {
+      void onFailure();
+
+      void onLoad();
+    }
+  }
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/data/SyncDelegate.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/data/SyncDelegate.java
@@ -39,16 +39,8 @@ import android.os.Process;
 import android.text.TextUtils;
 import android.text.format.DateUtils;
 import android.webkit.WebView;
-
-import java.io.IOException;
-import java.util.Set;
-import java.util.concurrent.Executor;
-
-import javax.inject.Inject;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.RequiresApi;
 import androidx.annotation.UiThread;
 import androidx.annotation.VisibleForTesting;
 import androidx.core.app.NotificationCompat;
@@ -60,478 +52,502 @@ import io.github.sheepdestroyer.materialisheep.R;
 import io.github.sheepdestroyer.materialisheep.annotation.Synthetic;
 import io.github.sheepdestroyer.materialisheep.widget.AdBlockWebViewClient;
 import io.github.sheepdestroyer.materialisheep.widget.CacheableWebView;
+import java.io.IOException;
+import java.util.Set;
+import java.util.concurrent.Executor;
+import javax.inject.Inject;
 import retrofit2.Call;
 import retrofit2.Callback;
 
-/**
- * A delegate for syncing data.
- */
+/** A delegate for syncing data. */
 @SuppressWarnings("deprecation") // TODO: Uses deprecated NotificationCompat.Builder
 public class SyncDelegate {
-    static final String SYNC_PREFERENCES_FILE = "_syncpreferences";
-    private static final String NOTIFICATION_GROUP_KEY = "group";
-    private static final String SYNC_ACCOUNT_NAME = "Materialistic";
-    private static final long TIMEOUT_MILLIS = DateUtils.MINUTE_IN_MILLIS;
-    private static final String DOWNLOADS_CHANNEL_ID = "downloads";
+  static final String SYNC_PREFERENCES_FILE = "_syncpreferences";
+  private static final String NOTIFICATION_GROUP_KEY = "group";
+  private static final String SYNC_ACCOUNT_NAME = "Materialistic";
+  private static final long TIMEOUT_MILLIS = DateUtils.MINUTE_IN_MILLIS;
+  private static final String DOWNLOADS_CHANNEL_ID = "downloads";
 
-    private final HackerNewsClient.RestService mHnRestService;
-    private final ReadabilityClient mReadabilityClient;
-    private final SharedPreferences mSharedPreferences;
-    private final NotificationManager mNotificationManager;
-    private final NotificationCompat.Builder mNotificationBuilder;
-    private final Handler mHandler = new Handler(Looper.getMainLooper());
-    private SyncProgress mSyncProgress;
-    private final Context mContext;
-    private ProgressListener mListener;
-    private Job mJob;
-    @VisibleForTesting
-    CacheableWebView mWebView;
+  private final HackerNewsClient.RestService mHnRestService;
+  private final ReadabilityClient mReadabilityClient;
+  private final SharedPreferences mSharedPreferences;
+  private final NotificationManager mNotificationManager;
+  private final NotificationCompat.Builder mNotificationBuilder;
+  private final Handler mHandler = new Handler(Looper.getMainLooper());
+  private SyncProgress mSyncProgress;
+  private final Context mContext;
+  private ProgressListener mListener;
+  private Job mJob;
+  @VisibleForTesting CacheableWebView mWebView;
 
-    /**
-     * Constructs a new {@code SyncDelegate}.
-     *
-     * @param context           the application context
-     * @param factory           the {@link RestServiceFactory} to use for creating
-     *                          REST services
-     * @param readabilityClient the {@link ReadabilityClient} to use for fetching
-     *                          readable content
-     */
-    @Inject
-    SyncDelegate(Context context, RestServiceFactory factory,
-            ReadabilityClient readabilityClient) {
-        mContext = context;
-        mSharedPreferences = context.getSharedPreferences(
-                context.getPackageName() + SYNC_PREFERENCES_FILE, Context.MODE_PRIVATE);
-        mHnRestService = factory.create(HackerNewsClient.BASE_API_URL,
-                HackerNewsClient.RestService.class, new BackgroundThreadExecutor());
-        mReadabilityClient = readabilityClient;
-        mNotificationManager = (NotificationManager) context
-                .getSystemService(Context.NOTIFICATION_SERVICE);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            NotificationChannel channel = new NotificationChannel(DOWNLOADS_CHANNEL_ID,
-                    context.getString(R.string.notification_channel_downloads),
-                    NotificationManager.IMPORTANCE_LOW);
-            mNotificationManager.createNotificationChannel(channel);
-            mNotificationBuilder = new NotificationCompat.Builder(context, DOWNLOADS_CHANNEL_ID);
-        } else {
-            // noinspection deprecation
-            mNotificationBuilder = new NotificationCompat.Builder(context);
-        }
-        mNotificationBuilder
-                .setLargeIcon(BitmapFactory.decodeResource(context.getResources(),
-                        R.mipmap.ic_launcher))
-                .setSmallIcon(R.drawable.ic_notification)
-                .setGroup(NOTIFICATION_GROUP_KEY)
-                .setOnlyAlertOnce(true)
-                .setCategory(NotificationCompat.CATEGORY_PROGRESS)
-                .setAutoCancel(true);
+  /**
+   * Constructs a new {@code SyncDelegate}.
+   *
+   * @param context the application context
+   * @param factory the {@link RestServiceFactory} to use for creating REST services
+   * @param readabilityClient the {@link ReadabilityClient} to use for fetching readable content
+   */
+  @Inject
+  SyncDelegate(Context context, RestServiceFactory factory, ReadabilityClient readabilityClient) {
+    mContext = context;
+    mSharedPreferences =
+        context.getSharedPreferences(
+            context.getPackageName() + SYNC_PREFERENCES_FILE, Context.MODE_PRIVATE);
+    mHnRestService =
+        factory.create(
+            HackerNewsClient.BASE_API_URL,
+            HackerNewsClient.RestService.class,
+            new BackgroundThreadExecutor());
+    mReadabilityClient = readabilityClient;
+    mNotificationManager =
+        (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      NotificationChannel channel =
+          new NotificationChannel(
+              DOWNLOADS_CHANNEL_ID,
+              context.getString(R.string.notification_channel_downloads),
+              NotificationManager.IMPORTANCE_LOW);
+      mNotificationManager.createNotificationChannel(channel);
+      mNotificationBuilder = new NotificationCompat.Builder(context, DOWNLOADS_CHANNEL_ID);
+    } else {
+      // noinspection deprecation
+      mNotificationBuilder = new NotificationCompat.Builder(context);
     }
+    mNotificationBuilder
+        .setLargeIcon(BitmapFactory.decodeResource(context.getResources(), R.mipmap.ic_launcher))
+        .setSmallIcon(R.drawable.ic_notification)
+        .setGroup(NOTIFICATION_GROUP_KEY)
+        .setOnlyAlertOnce(true)
+        .setCategory(NotificationCompat.CATEGORY_PROGRESS)
+        .setAutoCancel(true);
+  }
 
-    /**
-     * Schedules a sync job.
-     *
-     * @param context the application context
-     * @param job     the job to schedule
-     */
-    @UiThread
-    static void scheduleSync(Context context, Job job) {
-        if (!Preferences.Offline.isEnabled(context)) {
-            return;
-        }
-        if (!TextUtils.isEmpty(job.id)) {
-            JobInfo.Builder builder = new JobInfo.Builder(Long.valueOf(job.id).intValue(),
-                    new ComponentName(context.getPackageName(),
-                            ItemSyncJobService.class.getName()))
-                    .setRequiredNetworkType(Preferences.Offline.isWifiOnly(context) ? JobInfo.NETWORK_TYPE_UNMETERED
-                            : JobInfo.NETWORK_TYPE_ANY)
-                    .setExtras(job.toPersistableBundle());
-            if (Preferences.Offline.currentConnectionEnabled(context)) {
-                builder.setOverrideDeadline(0);
-            }
-            ((JobScheduler) context.getSystemService(Context.JOB_SCHEDULER_SERVICE))
-                    .schedule(builder.build());
-        } else {
-            Bundle extras = new Bundle(job.toBundle());
-            extras.putBoolean(ContentResolver.SYNC_EXTRAS_MANUAL, true);
-            Account syncAccount;
-            AccountManager accountManager = AccountManager.get(context);
-            Account[] accounts = accountManager.getAccountsByType(BuildConfig.APPLICATION_ID);
-            if (accounts.length == 0) {
-                syncAccount = new Account(SYNC_ACCOUNT_NAME, BuildConfig.APPLICATION_ID);
-                accountManager.addAccountExplicitly(syncAccount, null, null);
-            } else {
-                syncAccount = accounts[0];
-            }
-            ContentResolver.requestSync(syncAccount, SyncContentProvider.PROVIDER_AUTHORITY, extras);
-        }
+  /**
+   * Schedules a sync job.
+   *
+   * @param context the application context
+   * @param job the job to schedule
+   */
+  @UiThread
+  static void scheduleSync(Context context, Job job) {
+    if (!Preferences.Offline.isEnabled(context)) {
+      return;
     }
-
-    void subscribe(ProgressListener listener) {
-        mListener = listener;
+    if (!TextUtils.isEmpty(job.id)) {
+      JobInfo.Builder builder =
+          new JobInfo.Builder(
+                  Long.valueOf(job.id).intValue(),
+                  new ComponentName(context.getPackageName(), ItemSyncJobService.class.getName()))
+              .setRequiredNetworkType(
+                  Preferences.Offline.isWifiOnly(context)
+                      ? JobInfo.NETWORK_TYPE_UNMETERED
+                      : JobInfo.NETWORK_TYPE_ANY)
+              .setExtras(job.toPersistableBundle());
+      if (Preferences.Offline.currentConnectionEnabled(context)) {
+        builder.setOverrideDeadline(0);
+      }
+      ((JobScheduler) context.getSystemService(Context.JOB_SCHEDULER_SERVICE))
+          .schedule(builder.build());
+    } else {
+      Bundle extras = new Bundle(job.toBundle());
+      extras.putBoolean(ContentResolver.SYNC_EXTRAS_MANUAL, true);
+      Account syncAccount;
+      AccountManager accountManager = AccountManager.get(context);
+      Account[] accounts = accountManager.getAccountsByType(BuildConfig.APPLICATION_ID);
+      if (accounts.length == 0) {
+        syncAccount = new Account(SYNC_ACCOUNT_NAME, BuildConfig.APPLICATION_ID);
+        accountManager.addAccountExplicitly(syncAccount, null, null);
+      } else {
+        syncAccount = accounts[0];
+      }
+      ContentResolver.requestSync(syncAccount, SyncContentProvider.PROVIDER_AUTHORITY, extras);
     }
+  }
 
-    void performSync(@NonNull Job job) {
-        // assume that connection wouldn't change until we finish syncing
-        mJob = job;
-        if (!TextUtils.isEmpty(mJob.id)) {
-            Message message = Message.obtain(mHandler, this::stopSync);
-            message.what = Integer.valueOf(mJob.id);
-            mHandler.sendMessageDelayed(message, TIMEOUT_MILLIS);
-            mSyncProgress = new SyncProgress(mJob);
-            sync(mJob.id);
-        } else {
-            syncDeferredItems();
-        }
+  void subscribe(ProgressListener listener) {
+    mListener = listener;
+  }
+
+  void performSync(@NonNull Job job) {
+    // assume that connection wouldn't change until we finish syncing
+    mJob = job;
+    if (!TextUtils.isEmpty(mJob.id)) {
+      Message message = Message.obtain(mHandler, this::stopSync);
+      message.what = Integer.valueOf(mJob.id);
+      mHandler.sendMessageDelayed(message, TIMEOUT_MILLIS);
+      mSyncProgress = new SyncProgress(mJob);
+      sync(mJob.id);
+    } else {
+      syncDeferredItems();
     }
+  }
 
-    private void syncDeferredItems() {
-        Set<String> itemIds = mSharedPreferences.getAll().keySet();
-        for (String itemId : itemIds) {
-            scheduleSync(mContext, new JobBuilder(mContext, itemId).setNotificationEnabled(false).build());
-        }
+  private void syncDeferredItems() {
+    Set<String> itemIds = mSharedPreferences.getAll().keySet();
+    for (String itemId : itemIds) {
+      scheduleSync(
+          mContext, new JobBuilder(mContext, itemId).setNotificationEnabled(false).build());
     }
+  }
 
-    private void sync(String itemId) {
-        if (!mJob.connectionEnabled) {
-            defer(itemId);
-            return;
-        }
-        HackerNewsItem cachedItem;
-        if ((cachedItem = getFromCache(itemId)) != null) {
-            sync(cachedItem);
-        } else {
-            updateProgress();
-            // TODO defer on low battery as well?
-            mHnRestService.networkItem(itemId).enqueue(new Callback<HackerNewsItem>() {
+  private void sync(String itemId) {
+    if (!mJob.connectionEnabled) {
+      defer(itemId);
+      return;
+    }
+    HackerNewsItem cachedItem;
+    if ((cachedItem = getFromCache(itemId)) != null) {
+      sync(cachedItem);
+    } else {
+      updateProgress();
+      // TODO defer on low battery as well?
+      mHnRestService
+          .networkItem(itemId)
+          .enqueue(
+              new Callback<HackerNewsItem>() {
                 @Override
-                public void onResponse(Call<HackerNewsItem> call,
-                        retrofit2.Response<HackerNewsItem> response) {
-                    HackerNewsItem item;
-                    if ((item = response.body()) != null) {
-                        sync(item);
-                    }
+                public void onResponse(
+                    Call<HackerNewsItem> call, retrofit2.Response<HackerNewsItem> response) {
+                  HackerNewsItem item;
+                  if ((item = response.body()) != null) {
+                    sync(item);
+                  }
                 }
 
                 @Override
                 public void onFailure(Call<HackerNewsItem> call, Throwable t) {
-                    notifyItem(itemId, null);
+                  notifyItem(itemId, null);
                 }
-            });
-        }
+              });
     }
+  }
 
-    @Synthetic
-    void sync(@NonNull HackerNewsItem item) {
-        mSharedPreferences.edit().remove(item.getId()).apply();
-        notifyItem(item.getId(), item);
-        syncReadability(item);
-        syncArticle(item);
-        syncChildren(item);
+  @Synthetic
+  void sync(@NonNull HackerNewsItem item) {
+    mSharedPreferences.edit().remove(item.getId()).apply();
+    notifyItem(item.getId(), item);
+    syncReadability(item);
+    syncArticle(item);
+    syncChildren(item);
+  }
+
+  private void syncReadability(@NonNull HackerNewsItem item) {
+    if (mJob.readabilityEnabled && item.isStoryType()) {
+      final String itemId = item.getId();
+      mReadabilityClient.parse(itemId, item.getRawUrl(), content -> notifyReadability());
     }
+  }
 
-    private void syncReadability(@NonNull HackerNewsItem item) {
-        if (mJob.readabilityEnabled && item.isStoryType()) {
-            final String itemId = item.getId();
-            mReadabilityClient.parse(itemId, item.getRawUrl(), content -> notifyReadability());
-        }
+  private void syncArticle(@NonNull HackerNewsItem item) {
+    if (mJob.articleEnabled && item.isStoryType() && !TextUtils.isEmpty(item.getUrl())) {
+      if (Looper.myLooper() == Looper.getMainLooper()) {
+        loadArticle(item);
+      } else {
+        mContext.startService(
+            new Intent(mContext, WebCacheService.class)
+                .putExtra(WebCacheService.EXTRA_URL, item.getUrl()));
+        notifyArticle(100);
+      }
     }
+  }
 
-    private void syncArticle(@NonNull HackerNewsItem item) {
-        if (mJob.articleEnabled && item.isStoryType() && !TextUtils.isEmpty(item.getUrl())) {
-            if (Looper.myLooper() == Looper.getMainLooper()) {
-                loadArticle(item);
-            } else {
-                mContext.startService(new Intent(mContext, WebCacheService.class)
-                        .putExtra(WebCacheService.EXTRA_URL, item.getUrl()));
-                notifyArticle(100);
-            }
-        }
-    }
-
-    private void loadArticle(@NonNull final HackerNewsItem item) {
-        mWebView = new CacheableWebView(mContext);
-        mWebView.setWebViewClient(new AdBlockWebViewClient(mContext, Preferences.adBlockEnabled(mContext)));
-        mWebView.setWebChromeClient(new CacheableWebView.ArchiveClient() {
-            @Override
-            public void onProgressChanged(WebView view, int newProgress) {
-                super.onProgressChanged(view, newProgress);
-                notifyArticle(newProgress);
-            }
+  private void loadArticle(@NonNull final HackerNewsItem item) {
+    mWebView = new CacheableWebView(mContext);
+    mWebView.setWebViewClient(
+        new AdBlockWebViewClient(mContext, Preferences.adBlockEnabled(mContext)));
+    mWebView.setWebChromeClient(
+        new CacheableWebView.ArchiveClient() {
+          @Override
+          public void onProgressChanged(WebView view, int newProgress) {
+            super.onProgressChanged(view, newProgress);
+            notifyArticle(newProgress);
+          }
         });
-        notifyArticle(0);
-        mWebView.loadUrl(item.getUrl());
+    notifyArticle(0);
+    mWebView.loadUrl(item.getUrl());
+  }
+
+  private void syncChildren(@NonNull HackerNewsItem item) {
+    if (mJob.commentsEnabled && item.getKids() != null) {
+      for (long id : item.getKids()) {
+        sync(String.valueOf(id));
+      }
+    }
+  }
+
+  private void defer(String itemId) {
+    mSharedPreferences.edit().putBoolean(itemId, true).apply();
+  }
+
+  private HackerNewsItem getFromCache(String itemId) {
+    try {
+      return mHnRestService.cachedItem(itemId).execute().body();
+    } catch (IOException e) {
+      return null;
+    }
+  }
+
+  @Synthetic
+  void notifyItem(@NonNull String id, @Nullable HackerNewsItem item) {
+    mSyncProgress.finishItem(
+        id,
+        item,
+        mJob.commentsEnabled && mJob.connectionEnabled,
+        mJob.readabilityEnabled && mJob.connectionEnabled);
+    updateProgress();
+  }
+
+  private void notifyReadability() {
+    mSyncProgress.finishReadability();
+    updateProgress();
+  }
+
+  @Synthetic
+  void notifyArticle(int newProgress) {
+    mSyncProgress.updateArticle(newProgress, 100);
+    updateProgress();
+  }
+
+  private void updateProgress() {
+    if (mSyncProgress.getProgress() >= mSyncProgress.getMax()) { // TODO may never done
+      finish(); // TODO finish once only
+    } else if (mJob.notificationEnabled) {
+      showProgress();
+    }
+  }
+
+  private void showProgress() {
+    mNotificationManager.notify(
+        Integer.valueOf(mJob.id),
+        mNotificationBuilder
+            .setContentTitle(mSyncProgress.title)
+            .setContentText(mContext.getString(R.string.download_in_progress))
+            .setContentIntent(getItemActivity(mJob.id))
+            .setOnlyAlertOnce(true)
+            .setProgress(mSyncProgress.getMax(), mSyncProgress.getProgress(), false)
+            .setSortKey(mJob.id)
+            .build());
+  }
+
+  private void finish() {
+    if (mListener != null) {
+      mListener.onDone(mJob.id);
+      mListener = null;
+    }
+    stopSync();
+  }
+
+  void stopSync() {
+    // TODO
+    mJob.connectionEnabled = false;
+    int id = Integer.valueOf(mJob.id);
+    mNotificationManager.cancel(id);
+    mHandler.removeMessages(id);
+  }
+
+  private PendingIntent getItemActivity(String itemId) {
+    return PendingIntent.getActivity(
+        mContext,
+        0,
+        new Intent(Intent.ACTION_VIEW)
+            .setData(AppUtils.createItemUri(itemId))
+            .putExtra(ItemActivity.EXTRA_CACHE_MODE, ItemManager.MODE_CACHE)
+            .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+        PendingIntent.FLAG_ONE_SHOT | PendingIntent.FLAG_IMMUTABLE);
+  }
+
+  private static class SyncProgress {
+    private final String id;
+    private Boolean self;
+    private int totalKids, finishedKids, webProgress, maxWebProgress;
+    private Boolean readability;
+    String title;
+
+    @Synthetic
+    SyncProgress(Job job) {
+      this.id = job.id;
+      if (job.commentsEnabled) {
+        totalKids = 1;
+      }
+      if (job.articleEnabled) {
+        maxWebProgress = 100;
+      }
+      if (job.readabilityEnabled) {
+        readability = false;
+      }
     }
 
-    private void syncChildren(@NonNull HackerNewsItem item) {
-        if (mJob.commentsEnabled && item.getKids() != null) {
-            for (long id : item.getKids()) {
-                sync(String.valueOf(id));
-            }
-        }
+    int getMax() {
+      return 1 + totalKids + (readability != null ? 1 : 0) + maxWebProgress;
     }
 
-    private void defer(String itemId) {
-        mSharedPreferences.edit().putBoolean(itemId, true).apply();
-    }
-
-    private HackerNewsItem getFromCache(String itemId) {
-        try {
-            return mHnRestService.cachedItem(itemId).execute().body();
-        } catch (IOException e) {
-            return null;
-        }
+    int getProgress() {
+      return (self != null ? 1 : 0)
+          + finishedKids
+          + (readability != null && readability ? 1 : 0)
+          + webProgress;
     }
 
     @Synthetic
-    void notifyItem(@NonNull String id, @Nullable HackerNewsItem item) {
-        mSyncProgress.finishItem(id, item,
-                mJob.commentsEnabled && mJob.connectionEnabled,
-                mJob.readabilityEnabled && mJob.connectionEnabled);
-        updateProgress();
-    }
-
-    private void notifyReadability() {
-        mSyncProgress.finishReadability();
-        updateProgress();
+    void finishItem(
+        @NonNull String id,
+        @Nullable HackerNewsItem item,
+        boolean kidsEnabled,
+        boolean readabilityEnabled) {
+      if (TextUtils.equals(id, this.id)) {
+        finishSelf(item, kidsEnabled, readabilityEnabled);
+      } else {
+        finishKid();
+      }
     }
 
     @Synthetic
-    void notifyArticle(int newProgress) {
-        mSyncProgress.updateArticle(newProgress, 100);
-        updateProgress();
+    void finishReadability() {
+      readability = true;
     }
 
-    private void updateProgress() {
-        if (mSyncProgress.getProgress() >= mSyncProgress.getMax()) { // TODO may never done
-            finish(); // TODO finish once only
-        } else if (mJob.notificationEnabled) {
-            showProgress();
-        }
+    @Synthetic
+    void updateArticle(int webProgress, int maxWebProgress) {
+      this.webProgress = webProgress;
+      this.maxWebProgress = maxWebProgress;
     }
 
-    private void showProgress() {
-        mNotificationManager.notify(Integer.valueOf(mJob.id), mNotificationBuilder
-                .setContentTitle(mSyncProgress.title)
-                .setContentText(mContext.getString(R.string.download_in_progress))
-                .setContentIntent(getItemActivity(mJob.id))
-                .setOnlyAlertOnce(true)
-                .setProgress(mSyncProgress.getMax(), mSyncProgress.getProgress(), false)
-                .setSortKey(mJob.id)
-                .build());
+    private void finishSelf(
+        @Nullable HackerNewsItem item, boolean kidsEnabled, boolean readabilityEnabled) {
+      self = item != null;
+      title = item != null ? item.getTitle() : null;
+      if (kidsEnabled && item != null && item.getKids() != null) {
+        // fetch recursively but only notify for immediate children
+        totalKids = item.getKids().length;
+      } else {
+        totalKids = 0;
+      }
+      if (readabilityEnabled) {
+        readability = false;
+      }
     }
 
-    private void finish() {
-        if (mListener != null) {
-            mListener.onDone(mJob.id);
-            mListener = null;
-        }
-        stopSync();
+    private void finishKid() {
+      finishedKids++;
+    }
+  }
+
+  private static class BackgroundThreadExecutor implements Executor {
+
+    @Synthetic
+    BackgroundThreadExecutor() {}
+
+    @Override
+    public void execute(@NonNull Runnable r) {
+      Process.setThreadPriority(Process.THREAD_PRIORITY_BACKGROUND);
+      r.run();
+    }
+  }
+
+  interface ProgressListener {
+    void onDone(String token);
+  }
+
+  static class Job {
+    private static final String EXTRA_ID = "extra:id";
+    private static final String EXTRA_CONNECTION_ENABLED = "extra:connectionEnabled";
+    private static final String EXTRA_READABILITY_ENABLED = "extra:readabilityEnabled";
+    private static final String EXTRA_ARTICLE_ENABLED = "extra:articleEnabled";
+    private static final String EXTRA_COMMENTS_ENABLED = "extra:commentsEnabled";
+    private static final String EXTRA_NOTIFICATION_ENABLED = "extra:notificationEnabled";
+    final String id;
+    boolean connectionEnabled;
+    boolean readabilityEnabled;
+    boolean articleEnabled;
+    boolean commentsEnabled;
+    boolean notificationEnabled;
+
+    Job(String id) {
+      this.id = id;
     }
 
-    void stopSync() {
-        // TODO
-        mJob.connectionEnabled = false;
-        int id = Integer.valueOf(mJob.id);
-        mNotificationManager.cancel(id);
-        mHandler.removeMessages(id);
+    Job(PersistableBundle bundle) {
+      id = bundle.getString(EXTRA_ID);
+      connectionEnabled = bundle.getInt(EXTRA_CONNECTION_ENABLED) == 1;
+      readabilityEnabled = bundle.getInt(EXTRA_READABILITY_ENABLED) == 1;
+      articleEnabled = bundle.getInt(EXTRA_ARTICLE_ENABLED) == 1;
+      commentsEnabled = bundle.getInt(EXTRA_COMMENTS_ENABLED) == 1;
+      notificationEnabled = bundle.getInt(EXTRA_NOTIFICATION_ENABLED) == 1;
     }
 
-    private PendingIntent getItemActivity(String itemId) {
-        return PendingIntent.getActivity(mContext, 0,
-                new Intent(Intent.ACTION_VIEW)
-                        .setData(AppUtils.createItemUri(itemId))
-                        .putExtra(ItemActivity.EXTRA_CACHE_MODE, ItemManager.MODE_CACHE)
-                        .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
-                PendingIntent.FLAG_ONE_SHOT | PendingIntent.FLAG_IMMUTABLE);
+    Job(Bundle bundle) {
+      id = bundle.getString(EXTRA_ID);
+      connectionEnabled = bundle.getBoolean(EXTRA_CONNECTION_ENABLED);
+      readabilityEnabled = bundle.getBoolean(EXTRA_READABILITY_ENABLED);
+      articleEnabled = bundle.getBoolean(EXTRA_ARTICLE_ENABLED);
+      commentsEnabled = bundle.getBoolean(EXTRA_COMMENTS_ENABLED);
+      notificationEnabled = bundle.getBoolean(EXTRA_NOTIFICATION_ENABLED);
     }
 
-    private static class SyncProgress {
-        private final String id;
-        private Boolean self;
-        private int totalKids, finishedKids, webProgress, maxWebProgress;
-        private Boolean readability;
-        String title;
-
-        @Synthetic
-        SyncProgress(Job job) {
-            this.id = job.id;
-            if (job.commentsEnabled) {
-                totalKids = 1;
-            }
-            if (job.articleEnabled) {
-                maxWebProgress = 100;
-            }
-            if (job.readabilityEnabled) {
-                readability = false;
-            }
-        }
-
-        int getMax() {
-            return 1 + totalKids + (readability != null ? 1 : 0) + maxWebProgress;
-        }
-
-        int getProgress() {
-            return (self != null ? 1 : 0) + finishedKids + (readability != null && readability ? 1 : 0) + webProgress;
-        }
-
-        @Synthetic
-        void finishItem(@NonNull String id, @Nullable HackerNewsItem item,
-                boolean kidsEnabled, boolean readabilityEnabled) {
-            if (TextUtils.equals(id, this.id)) {
-                finishSelf(item, kidsEnabled, readabilityEnabled);
-            } else {
-                finishKid();
-            }
-        }
-
-        @Synthetic
-        void finishReadability() {
-            readability = true;
-        }
-
-        @Synthetic
-        void updateArticle(int webProgress, int maxWebProgress) {
-            this.webProgress = webProgress;
-            this.maxWebProgress = maxWebProgress;
-        }
-
-        private void finishSelf(@Nullable HackerNewsItem item, boolean kidsEnabled,
-                boolean readabilityEnabled) {
-            self = item != null;
-            title = item != null ? item.getTitle() : null;
-            if (kidsEnabled && item != null && item.getKids() != null) {
-                // fetch recursively but only notify for immediate children
-                totalKids = item.getKids().length;
-            } else {
-                totalKids = 0;
-            }
-            if (readabilityEnabled) {
-                readability = false;
-            }
-        }
-
-        private void finishKid() {
-            finishedKids++;
-        }
+    @Synthetic
+    PersistableBundle toPersistableBundle() {
+      PersistableBundle bundle = new PersistableBundle();
+      bundle.putString(EXTRA_ID, id);
+      bundle.putInt(EXTRA_CONNECTION_ENABLED, connectionEnabled ? 1 : 0);
+      bundle.putInt(EXTRA_READABILITY_ENABLED, readabilityEnabled ? 1 : 0);
+      bundle.putInt(EXTRA_ARTICLE_ENABLED, articleEnabled ? 1 : 0);
+      bundle.putInt(EXTRA_COMMENTS_ENABLED, commentsEnabled ? 1 : 0);
+      bundle.putInt(EXTRA_NOTIFICATION_ENABLED, notificationEnabled ? 1 : 0);
+      return bundle;
     }
 
-    private static class BackgroundThreadExecutor implements Executor {
+    @Synthetic
+    Bundle toBundle() {
+      Bundle bundle = new Bundle();
+      bundle.putString(EXTRA_ID, id);
+      bundle.putBoolean(EXTRA_CONNECTION_ENABLED, connectionEnabled);
+      bundle.putBoolean(EXTRA_READABILITY_ENABLED, readabilityEnabled);
+      bundle.putBoolean(EXTRA_ARTICLE_ENABLED, articleEnabled);
+      bundle.putBoolean(EXTRA_COMMENTS_ENABLED, commentsEnabled);
+      bundle.putBoolean(EXTRA_NOTIFICATION_ENABLED, notificationEnabled);
+      return bundle;
+    }
+  }
 
-        @Synthetic
-        BackgroundThreadExecutor() {
-        }
+  public static class JobBuilder {
+    private final Job job;
 
-        @Override
-        public void execute(@NonNull Runnable r) {
-            Process.setThreadPriority(Process.THREAD_PRIORITY_BACKGROUND);
-            r.run();
-        }
+    public JobBuilder(Context context, String id) {
+      job = new Job(id);
+      setConnectionEnabled(Preferences.Offline.currentConnectionEnabled(context));
+      setReadabilityEnabled(Preferences.Offline.isReadabilityEnabled(context));
+      setArticleEnabled(Preferences.Offline.isArticleEnabled(context));
+      setCommentsEnabled(Preferences.Offline.isCommentsEnabled(context));
+      setNotificationEnabled(Preferences.Offline.isNotificationEnabled(context));
     }
 
-    interface ProgressListener {
-        void onDone(String token);
+    JobBuilder setConnectionEnabled(boolean connectionEnabled) {
+      job.connectionEnabled = connectionEnabled;
+      return this;
     }
 
-    static class Job {
-        private static final String EXTRA_ID = "extra:id";
-        private static final String EXTRA_CONNECTION_ENABLED = "extra:connectionEnabled";
-        private static final String EXTRA_READABILITY_ENABLED = "extra:readabilityEnabled";
-        private static final String EXTRA_ARTICLE_ENABLED = "extra:articleEnabled";
-        private static final String EXTRA_COMMENTS_ENABLED = "extra:commentsEnabled";
-        private static final String EXTRA_NOTIFICATION_ENABLED = "extra:notificationEnabled";
-        final String id;
-        boolean connectionEnabled;
-        boolean readabilityEnabled;
-        boolean articleEnabled;
-        boolean commentsEnabled;
-        boolean notificationEnabled;
-
-        Job(String id) {
-            this.id = id;
-        }
-
-        Job(PersistableBundle bundle) {
-            id = bundle.getString(EXTRA_ID);
-            connectionEnabled = bundle.getInt(EXTRA_CONNECTION_ENABLED) == 1;
-            readabilityEnabled = bundle.getInt(EXTRA_READABILITY_ENABLED) == 1;
-            articleEnabled = bundle.getInt(EXTRA_ARTICLE_ENABLED) == 1;
-            commentsEnabled = bundle.getInt(EXTRA_COMMENTS_ENABLED) == 1;
-            notificationEnabled = bundle.getInt(EXTRA_NOTIFICATION_ENABLED) == 1;
-        }
-
-        Job(Bundle bundle) {
-            id = bundle.getString(EXTRA_ID);
-            connectionEnabled = bundle.getBoolean(EXTRA_CONNECTION_ENABLED);
-            readabilityEnabled = bundle.getBoolean(EXTRA_READABILITY_ENABLED);
-            articleEnabled = bundle.getBoolean(EXTRA_ARTICLE_ENABLED);
-            commentsEnabled = bundle.getBoolean(EXTRA_COMMENTS_ENABLED);
-            notificationEnabled = bundle.getBoolean(EXTRA_NOTIFICATION_ENABLED);
-        }
-
-        @Synthetic
-        PersistableBundle toPersistableBundle() {
-            PersistableBundle bundle = new PersistableBundle();
-            bundle.putString(EXTRA_ID, id);
-            bundle.putInt(EXTRA_CONNECTION_ENABLED, connectionEnabled ? 1 : 0);
-            bundle.putInt(EXTRA_READABILITY_ENABLED, readabilityEnabled ? 1 : 0);
-            bundle.putInt(EXTRA_ARTICLE_ENABLED, articleEnabled ? 1 : 0);
-            bundle.putInt(EXTRA_COMMENTS_ENABLED, commentsEnabled ? 1 : 0);
-            bundle.putInt(EXTRA_NOTIFICATION_ENABLED, notificationEnabled ? 1 : 0);
-            return bundle;
-        }
-
-        @Synthetic
-        Bundle toBundle() {
-            Bundle bundle = new Bundle();
-            bundle.putString(EXTRA_ID, id);
-            bundle.putBoolean(EXTRA_CONNECTION_ENABLED, connectionEnabled);
-            bundle.putBoolean(EXTRA_READABILITY_ENABLED, readabilityEnabled);
-            bundle.putBoolean(EXTRA_ARTICLE_ENABLED, articleEnabled);
-            bundle.putBoolean(EXTRA_COMMENTS_ENABLED, commentsEnabled);
-            bundle.putBoolean(EXTRA_NOTIFICATION_ENABLED, notificationEnabled);
-            return bundle;
-        }
+    JobBuilder setReadabilityEnabled(boolean readabilityEnabled) {
+      job.readabilityEnabled = readabilityEnabled;
+      return this;
     }
 
-    public static class JobBuilder {
-        private final Job job;
-
-        public JobBuilder(Context context, String id) {
-            job = new Job(id);
-            setConnectionEnabled(Preferences.Offline.currentConnectionEnabled(context));
-            setReadabilityEnabled(Preferences.Offline.isReadabilityEnabled(context));
-            setArticleEnabled(Preferences.Offline.isArticleEnabled(context));
-            setCommentsEnabled(Preferences.Offline.isCommentsEnabled(context));
-            setNotificationEnabled(Preferences.Offline.isNotificationEnabled(context));
-        }
-
-        JobBuilder setConnectionEnabled(boolean connectionEnabled) {
-            job.connectionEnabled = connectionEnabled;
-            return this;
-        }
-
-        JobBuilder setReadabilityEnabled(boolean readabilityEnabled) {
-            job.readabilityEnabled = readabilityEnabled;
-            return this;
-        }
-
-        JobBuilder setArticleEnabled(boolean articleEnabled) {
-            job.articleEnabled = articleEnabled;
-            return this;
-        }
-
-        JobBuilder setCommentsEnabled(boolean commentsEnabled) {
-            job.commentsEnabled = commentsEnabled;
-            return this;
-        }
-
-        public JobBuilder setNotificationEnabled(boolean notificationEnabled) {
-            job.notificationEnabled = notificationEnabled;
-            return this;
-        }
-
-        public Job build() {
-            return job;
-        }
+    JobBuilder setArticleEnabled(boolean articleEnabled) {
+      job.articleEnabled = articleEnabled;
+      return this;
     }
+
+    JobBuilder setCommentsEnabled(boolean commentsEnabled) {
+      job.commentsEnabled = commentsEnabled;
+      return this;
+    }
+
+    public JobBuilder setNotificationEnabled(boolean notificationEnabled) {
+      job.notificationEnabled = notificationEnabled;
+      return this;
+    }
+
+    public Job build() {
+      return job;
+    }
+  }
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/data/SyncDelegate.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/data/SyncDelegate.java
@@ -250,7 +250,7 @@ public class SyncDelegate {
 
     private void loadArticle(@NonNull final HackerNewsItem item) {
         mWebView = new CacheableWebView(mContext);
-        mWebView.setWebViewClient(new AdBlockWebViewClient(Preferences.adBlockEnabled(mContext)));
+        mWebView.setWebViewClient(new AdBlockWebViewClient(mContext, Preferences.adBlockEnabled(mContext)));
         mWebView.setWebChromeClient(new CacheableWebView.ArchiveClient() {
             @Override
             public void onProgressChanged(WebView view, int newProgress) {

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/data/SyncDelegate.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/data/SyncDelegate.java
@@ -39,8 +39,16 @@ import android.os.Process;
 import android.text.TextUtils;
 import android.text.format.DateUtils;
 import android.webkit.WebView;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.concurrent.Executor;
+
+import javax.inject.Inject;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 import androidx.annotation.UiThread;
 import androidx.annotation.VisibleForTesting;
 import androidx.core.app.NotificationCompat;
@@ -52,502 +60,478 @@ import io.github.sheepdestroyer.materialisheep.R;
 import io.github.sheepdestroyer.materialisheep.annotation.Synthetic;
 import io.github.sheepdestroyer.materialisheep.widget.AdBlockWebViewClient;
 import io.github.sheepdestroyer.materialisheep.widget.CacheableWebView;
-import java.io.IOException;
-import java.util.Set;
-import java.util.concurrent.Executor;
-import javax.inject.Inject;
 import retrofit2.Call;
 import retrofit2.Callback;
 
-/** A delegate for syncing data. */
+/**
+ * A delegate for syncing data.
+ */
 @SuppressWarnings("deprecation") // TODO: Uses deprecated NotificationCompat.Builder
 public class SyncDelegate {
-  static final String SYNC_PREFERENCES_FILE = "_syncpreferences";
-  private static final String NOTIFICATION_GROUP_KEY = "group";
-  private static final String SYNC_ACCOUNT_NAME = "Materialistic";
-  private static final long TIMEOUT_MILLIS = DateUtils.MINUTE_IN_MILLIS;
-  private static final String DOWNLOADS_CHANNEL_ID = "downloads";
+    static final String SYNC_PREFERENCES_FILE = "_syncpreferences";
+    private static final String NOTIFICATION_GROUP_KEY = "group";
+    private static final String SYNC_ACCOUNT_NAME = "Materialistic";
+    private static final long TIMEOUT_MILLIS = DateUtils.MINUTE_IN_MILLIS;
+    private static final String DOWNLOADS_CHANNEL_ID = "downloads";
 
-  private final HackerNewsClient.RestService mHnRestService;
-  private final ReadabilityClient mReadabilityClient;
-  private final SharedPreferences mSharedPreferences;
-  private final NotificationManager mNotificationManager;
-  private final NotificationCompat.Builder mNotificationBuilder;
-  private final Handler mHandler = new Handler(Looper.getMainLooper());
-  private SyncProgress mSyncProgress;
-  private final Context mContext;
-  private ProgressListener mListener;
-  private Job mJob;
-  @VisibleForTesting CacheableWebView mWebView;
+    private final HackerNewsClient.RestService mHnRestService;
+    private final ReadabilityClient mReadabilityClient;
+    private final SharedPreferences mSharedPreferences;
+    private final NotificationManager mNotificationManager;
+    private final NotificationCompat.Builder mNotificationBuilder;
+    private final Handler mHandler = new Handler(Looper.getMainLooper());
+    private SyncProgress mSyncProgress;
+    private final Context mContext;
+    private ProgressListener mListener;
+    private Job mJob;
+    @VisibleForTesting
+    CacheableWebView mWebView;
 
-  /**
-   * Constructs a new {@code SyncDelegate}.
-   *
-   * @param context the application context
-   * @param factory the {@link RestServiceFactory} to use for creating REST services
-   * @param readabilityClient the {@link ReadabilityClient} to use for fetching readable content
-   */
-  @Inject
-  SyncDelegate(Context context, RestServiceFactory factory, ReadabilityClient readabilityClient) {
-    mContext = context;
-    mSharedPreferences =
-        context.getSharedPreferences(
-            context.getPackageName() + SYNC_PREFERENCES_FILE, Context.MODE_PRIVATE);
-    mHnRestService =
-        factory.create(
-            HackerNewsClient.BASE_API_URL,
-            HackerNewsClient.RestService.class,
-            new BackgroundThreadExecutor());
-    mReadabilityClient = readabilityClient;
-    mNotificationManager =
-        (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-      NotificationChannel channel =
-          new NotificationChannel(
-              DOWNLOADS_CHANNEL_ID,
-              context.getString(R.string.notification_channel_downloads),
-              NotificationManager.IMPORTANCE_LOW);
-      mNotificationManager.createNotificationChannel(channel);
-      mNotificationBuilder = new NotificationCompat.Builder(context, DOWNLOADS_CHANNEL_ID);
-    } else {
-      // noinspection deprecation
-      mNotificationBuilder = new NotificationCompat.Builder(context);
+    /**
+     * Constructs a new {@code SyncDelegate}.
+     *
+     * @param context           the application context
+     * @param factory           the {@link RestServiceFactory} to use for creating
+     *                          REST services
+     * @param readabilityClient the {@link ReadabilityClient} to use for fetching
+     *                          readable content
+     */
+    @Inject
+    SyncDelegate(Context context, RestServiceFactory factory,
+            ReadabilityClient readabilityClient) {
+        mContext = context;
+        mSharedPreferences = context.getSharedPreferences(
+                context.getPackageName() + SYNC_PREFERENCES_FILE, Context.MODE_PRIVATE);
+        mHnRestService = factory.create(HackerNewsClient.BASE_API_URL,
+                HackerNewsClient.RestService.class, new BackgroundThreadExecutor());
+        mReadabilityClient = readabilityClient;
+        mNotificationManager = (NotificationManager) context
+                .getSystemService(Context.NOTIFICATION_SERVICE);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationChannel channel = new NotificationChannel(DOWNLOADS_CHANNEL_ID,
+                    context.getString(R.string.notification_channel_downloads),
+                    NotificationManager.IMPORTANCE_LOW);
+            mNotificationManager.createNotificationChannel(channel);
+            mNotificationBuilder = new NotificationCompat.Builder(context, DOWNLOADS_CHANNEL_ID);
+        } else {
+            // noinspection deprecation
+            mNotificationBuilder = new NotificationCompat.Builder(context);
+        }
+        mNotificationBuilder
+                .setLargeIcon(BitmapFactory.decodeResource(context.getResources(),
+                        R.mipmap.ic_launcher))
+                .setSmallIcon(R.drawable.ic_notification)
+                .setGroup(NOTIFICATION_GROUP_KEY)
+                .setOnlyAlertOnce(true)
+                .setCategory(NotificationCompat.CATEGORY_PROGRESS)
+                .setAutoCancel(true);
     }
-    mNotificationBuilder
-        .setLargeIcon(BitmapFactory.decodeResource(context.getResources(), R.mipmap.ic_launcher))
-        .setSmallIcon(R.drawable.ic_notification)
-        .setGroup(NOTIFICATION_GROUP_KEY)
-        .setOnlyAlertOnce(true)
-        .setCategory(NotificationCompat.CATEGORY_PROGRESS)
-        .setAutoCancel(true);
-  }
 
-  /**
-   * Schedules a sync job.
-   *
-   * @param context the application context
-   * @param job the job to schedule
-   */
-  @UiThread
-  static void scheduleSync(Context context, Job job) {
-    if (!Preferences.Offline.isEnabled(context)) {
-      return;
+    /**
+     * Schedules a sync job.
+     *
+     * @param context the application context
+     * @param job     the job to schedule
+     */
+    @UiThread
+    static void scheduleSync(Context context, Job job) {
+        if (!Preferences.Offline.isEnabled(context)) {
+            return;
+        }
+        if (!TextUtils.isEmpty(job.id)) {
+            JobInfo.Builder builder = new JobInfo.Builder(Long.valueOf(job.id).intValue(),
+                    new ComponentName(context.getPackageName(),
+                            ItemSyncJobService.class.getName()))
+                    .setRequiredNetworkType(Preferences.Offline.isWifiOnly(context) ? JobInfo.NETWORK_TYPE_UNMETERED
+                            : JobInfo.NETWORK_TYPE_ANY)
+                    .setExtras(job.toPersistableBundle());
+            if (Preferences.Offline.currentConnectionEnabled(context)) {
+                builder.setOverrideDeadline(0);
+            }
+            ((JobScheduler) context.getSystemService(Context.JOB_SCHEDULER_SERVICE))
+                    .schedule(builder.build());
+        } else {
+            Bundle extras = new Bundle(job.toBundle());
+            extras.putBoolean(ContentResolver.SYNC_EXTRAS_MANUAL, true);
+            Account syncAccount;
+            AccountManager accountManager = AccountManager.get(context);
+            Account[] accounts = accountManager.getAccountsByType(BuildConfig.APPLICATION_ID);
+            if (accounts.length == 0) {
+                syncAccount = new Account(SYNC_ACCOUNT_NAME, BuildConfig.APPLICATION_ID);
+                accountManager.addAccountExplicitly(syncAccount, null, null);
+            } else {
+                syncAccount = accounts[0];
+            }
+            ContentResolver.requestSync(syncAccount, SyncContentProvider.PROVIDER_AUTHORITY, extras);
+        }
     }
-    if (!TextUtils.isEmpty(job.id)) {
-      JobInfo.Builder builder =
-          new JobInfo.Builder(
-                  Long.valueOf(job.id).intValue(),
-                  new ComponentName(context.getPackageName(), ItemSyncJobService.class.getName()))
-              .setRequiredNetworkType(
-                  Preferences.Offline.isWifiOnly(context)
-                      ? JobInfo.NETWORK_TYPE_UNMETERED
-                      : JobInfo.NETWORK_TYPE_ANY)
-              .setExtras(job.toPersistableBundle());
-      if (Preferences.Offline.currentConnectionEnabled(context)) {
-        builder.setOverrideDeadline(0);
-      }
-      ((JobScheduler) context.getSystemService(Context.JOB_SCHEDULER_SERVICE))
-          .schedule(builder.build());
-    } else {
-      Bundle extras = new Bundle(job.toBundle());
-      extras.putBoolean(ContentResolver.SYNC_EXTRAS_MANUAL, true);
-      Account syncAccount;
-      AccountManager accountManager = AccountManager.get(context);
-      Account[] accounts = accountManager.getAccountsByType(BuildConfig.APPLICATION_ID);
-      if (accounts.length == 0) {
-        syncAccount = new Account(SYNC_ACCOUNT_NAME, BuildConfig.APPLICATION_ID);
-        accountManager.addAccountExplicitly(syncAccount, null, null);
-      } else {
-        syncAccount = accounts[0];
-      }
-      ContentResolver.requestSync(syncAccount, SyncContentProvider.PROVIDER_AUTHORITY, extras);
-    }
-  }
 
-  void subscribe(ProgressListener listener) {
-    mListener = listener;
-  }
-
-  void performSync(@NonNull Job job) {
-    // assume that connection wouldn't change until we finish syncing
-    mJob = job;
-    if (!TextUtils.isEmpty(mJob.id)) {
-      Message message = Message.obtain(mHandler, this::stopSync);
-      message.what = Integer.valueOf(mJob.id);
-      mHandler.sendMessageDelayed(message, TIMEOUT_MILLIS);
-      mSyncProgress = new SyncProgress(mJob);
-      sync(mJob.id);
-    } else {
-      syncDeferredItems();
+    void subscribe(ProgressListener listener) {
+        mListener = listener;
     }
-  }
 
-  private void syncDeferredItems() {
-    Set<String> itemIds = mSharedPreferences.getAll().keySet();
-    for (String itemId : itemIds) {
-      scheduleSync(
-          mContext, new JobBuilder(mContext, itemId).setNotificationEnabled(false).build());
+    void performSync(@NonNull Job job) {
+        // assume that connection wouldn't change until we finish syncing
+        mJob = job;
+        if (!TextUtils.isEmpty(mJob.id)) {
+            Message message = Message.obtain(mHandler, this::stopSync);
+            message.what = Integer.valueOf(mJob.id);
+            mHandler.sendMessageDelayed(message, TIMEOUT_MILLIS);
+            mSyncProgress = new SyncProgress(mJob);
+            sync(mJob.id);
+        } else {
+            syncDeferredItems();
+        }
     }
-  }
 
-  private void sync(String itemId) {
-    if (!mJob.connectionEnabled) {
-      defer(itemId);
-      return;
+    private void syncDeferredItems() {
+        Set<String> itemIds = mSharedPreferences.getAll().keySet();
+        for (String itemId : itemIds) {
+            scheduleSync(mContext, new JobBuilder(mContext, itemId).setNotificationEnabled(false).build());
+        }
     }
-    HackerNewsItem cachedItem;
-    if ((cachedItem = getFromCache(itemId)) != null) {
-      sync(cachedItem);
-    } else {
-      updateProgress();
-      // TODO defer on low battery as well?
-      mHnRestService
-          .networkItem(itemId)
-          .enqueue(
-              new Callback<HackerNewsItem>() {
+
+    private void sync(String itemId) {
+        if (!mJob.connectionEnabled) {
+            defer(itemId);
+            return;
+        }
+        HackerNewsItem cachedItem;
+        if ((cachedItem = getFromCache(itemId)) != null) {
+            sync(cachedItem);
+        } else {
+            updateProgress();
+            // TODO defer on low battery as well?
+            mHnRestService.networkItem(itemId).enqueue(new Callback<HackerNewsItem>() {
                 @Override
-                public void onResponse(
-                    Call<HackerNewsItem> call, retrofit2.Response<HackerNewsItem> response) {
-                  HackerNewsItem item;
-                  if ((item = response.body()) != null) {
-                    sync(item);
-                  }
+                public void onResponse(Call<HackerNewsItem> call,
+                        retrofit2.Response<HackerNewsItem> response) {
+                    HackerNewsItem item;
+                    if ((item = response.body()) != null) {
+                        sync(item);
+                    }
                 }
 
                 @Override
                 public void onFailure(Call<HackerNewsItem> call, Throwable t) {
-                  notifyItem(itemId, null);
+                    notifyItem(itemId, null);
                 }
-              });
+            });
+        }
     }
-  }
 
-  @Synthetic
-  void sync(@NonNull HackerNewsItem item) {
-    mSharedPreferences.edit().remove(item.getId()).apply();
-    notifyItem(item.getId(), item);
-    syncReadability(item);
-    syncArticle(item);
-    syncChildren(item);
-  }
-
-  private void syncReadability(@NonNull HackerNewsItem item) {
-    if (mJob.readabilityEnabled && item.isStoryType()) {
-      final String itemId = item.getId();
-      mReadabilityClient.parse(itemId, item.getRawUrl(), content -> notifyReadability());
+    @Synthetic
+    void sync(@NonNull HackerNewsItem item) {
+        mSharedPreferences.edit().remove(item.getId()).apply();
+        notifyItem(item.getId(), item);
+        syncReadability(item);
+        syncArticle(item);
+        syncChildren(item);
     }
-  }
 
-  private void syncArticle(@NonNull HackerNewsItem item) {
-    if (mJob.articleEnabled && item.isStoryType() && !TextUtils.isEmpty(item.getUrl())) {
-      if (Looper.myLooper() == Looper.getMainLooper()) {
-        loadArticle(item);
-      } else {
-        mContext.startService(
-            new Intent(mContext, WebCacheService.class)
-                .putExtra(WebCacheService.EXTRA_URL, item.getUrl()));
-        notifyArticle(100);
-      }
+    private void syncReadability(@NonNull HackerNewsItem item) {
+        if (mJob.readabilityEnabled && item.isStoryType()) {
+            final String itemId = item.getId();
+            mReadabilityClient.parse(itemId, item.getRawUrl(), content -> notifyReadability());
+        }
     }
-  }
 
-  private void loadArticle(@NonNull final HackerNewsItem item) {
-    mWebView = new CacheableWebView(mContext);
-    mWebView.setWebViewClient(
-        new AdBlockWebViewClient(mContext, Preferences.adBlockEnabled(mContext)));
-    mWebView.setWebChromeClient(
-        new CacheableWebView.ArchiveClient() {
-          @Override
-          public void onProgressChanged(WebView view, int newProgress) {
-            super.onProgressChanged(view, newProgress);
-            notifyArticle(newProgress);
-          }
+    private void syncArticle(@NonNull HackerNewsItem item) {
+        if (mJob.articleEnabled && item.isStoryType() && !TextUtils.isEmpty(item.getUrl())) {
+            if (Looper.myLooper() == Looper.getMainLooper()) {
+                loadArticle(item);
+            } else {
+                mContext.startService(new Intent(mContext, WebCacheService.class)
+                        .putExtra(WebCacheService.EXTRA_URL, item.getUrl()));
+                notifyArticle(100);
+            }
+        }
+    }
+
+    private void loadArticle(@NonNull final HackerNewsItem item) {
+        mWebView = new CacheableWebView(mContext);
+        mWebView.setWebViewClient(new AdBlockWebViewClient(mContext, Preferences.adBlockEnabled(mContext)));
+        mWebView.setWebChromeClient(new CacheableWebView.ArchiveClient() {
+            @Override
+            public void onProgressChanged(WebView view, int newProgress) {
+                super.onProgressChanged(view, newProgress);
+                notifyArticle(newProgress);
+            }
         });
-    notifyArticle(0);
-    mWebView.loadUrl(item.getUrl());
-  }
-
-  private void syncChildren(@NonNull HackerNewsItem item) {
-    if (mJob.commentsEnabled && item.getKids() != null) {
-      for (long id : item.getKids()) {
-        sync(String.valueOf(id));
-      }
-    }
-  }
-
-  private void defer(String itemId) {
-    mSharedPreferences.edit().putBoolean(itemId, true).apply();
-  }
-
-  private HackerNewsItem getFromCache(String itemId) {
-    try {
-      return mHnRestService.cachedItem(itemId).execute().body();
-    } catch (IOException e) {
-      return null;
-    }
-  }
-
-  @Synthetic
-  void notifyItem(@NonNull String id, @Nullable HackerNewsItem item) {
-    mSyncProgress.finishItem(
-        id,
-        item,
-        mJob.commentsEnabled && mJob.connectionEnabled,
-        mJob.readabilityEnabled && mJob.connectionEnabled);
-    updateProgress();
-  }
-
-  private void notifyReadability() {
-    mSyncProgress.finishReadability();
-    updateProgress();
-  }
-
-  @Synthetic
-  void notifyArticle(int newProgress) {
-    mSyncProgress.updateArticle(newProgress, 100);
-    updateProgress();
-  }
-
-  private void updateProgress() {
-    if (mSyncProgress.getProgress() >= mSyncProgress.getMax()) { // TODO may never done
-      finish(); // TODO finish once only
-    } else if (mJob.notificationEnabled) {
-      showProgress();
-    }
-  }
-
-  private void showProgress() {
-    mNotificationManager.notify(
-        Integer.valueOf(mJob.id),
-        mNotificationBuilder
-            .setContentTitle(mSyncProgress.title)
-            .setContentText(mContext.getString(R.string.download_in_progress))
-            .setContentIntent(getItemActivity(mJob.id))
-            .setOnlyAlertOnce(true)
-            .setProgress(mSyncProgress.getMax(), mSyncProgress.getProgress(), false)
-            .setSortKey(mJob.id)
-            .build());
-  }
-
-  private void finish() {
-    if (mListener != null) {
-      mListener.onDone(mJob.id);
-      mListener = null;
-    }
-    stopSync();
-  }
-
-  void stopSync() {
-    // TODO
-    mJob.connectionEnabled = false;
-    int id = Integer.valueOf(mJob.id);
-    mNotificationManager.cancel(id);
-    mHandler.removeMessages(id);
-  }
-
-  private PendingIntent getItemActivity(String itemId) {
-    return PendingIntent.getActivity(
-        mContext,
-        0,
-        new Intent(Intent.ACTION_VIEW)
-            .setData(AppUtils.createItemUri(itemId))
-            .putExtra(ItemActivity.EXTRA_CACHE_MODE, ItemManager.MODE_CACHE)
-            .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
-        PendingIntent.FLAG_ONE_SHOT | PendingIntent.FLAG_IMMUTABLE);
-  }
-
-  private static class SyncProgress {
-    private final String id;
-    private Boolean self;
-    private int totalKids, finishedKids, webProgress, maxWebProgress;
-    private Boolean readability;
-    String title;
-
-    @Synthetic
-    SyncProgress(Job job) {
-      this.id = job.id;
-      if (job.commentsEnabled) {
-        totalKids = 1;
-      }
-      if (job.articleEnabled) {
-        maxWebProgress = 100;
-      }
-      if (job.readabilityEnabled) {
-        readability = false;
-      }
+        notifyArticle(0);
+        mWebView.loadUrl(item.getUrl());
     }
 
-    int getMax() {
-      return 1 + totalKids + (readability != null ? 1 : 0) + maxWebProgress;
+    private void syncChildren(@NonNull HackerNewsItem item) {
+        if (mJob.commentsEnabled && item.getKids() != null) {
+            for (long id : item.getKids()) {
+                sync(String.valueOf(id));
+            }
+        }
     }
 
-    int getProgress() {
-      return (self != null ? 1 : 0)
-          + finishedKids
-          + (readability != null && readability ? 1 : 0)
-          + webProgress;
+    private void defer(String itemId) {
+        mSharedPreferences.edit().putBoolean(itemId, true).apply();
+    }
+
+    private HackerNewsItem getFromCache(String itemId) {
+        try {
+            return mHnRestService.cachedItem(itemId).execute().body();
+        } catch (IOException e) {
+            return null;
+        }
     }
 
     @Synthetic
-    void finishItem(
-        @NonNull String id,
-        @Nullable HackerNewsItem item,
-        boolean kidsEnabled,
-        boolean readabilityEnabled) {
-      if (TextUtils.equals(id, this.id)) {
-        finishSelf(item, kidsEnabled, readabilityEnabled);
-      } else {
-        finishKid();
-      }
+    void notifyItem(@NonNull String id, @Nullable HackerNewsItem item) {
+        mSyncProgress.finishItem(id, item,
+                mJob.commentsEnabled && mJob.connectionEnabled,
+                mJob.readabilityEnabled && mJob.connectionEnabled);
+        updateProgress();
+    }
+
+    private void notifyReadability() {
+        mSyncProgress.finishReadability();
+        updateProgress();
     }
 
     @Synthetic
-    void finishReadability() {
-      readability = true;
+    void notifyArticle(int newProgress) {
+        mSyncProgress.updateArticle(newProgress, 100);
+        updateProgress();
     }
 
-    @Synthetic
-    void updateArticle(int webProgress, int maxWebProgress) {
-      this.webProgress = webProgress;
-      this.maxWebProgress = maxWebProgress;
+    private void updateProgress() {
+        if (mSyncProgress.getProgress() >= mSyncProgress.getMax()) { // TODO may never done
+            finish(); // TODO finish once only
+        } else if (mJob.notificationEnabled) {
+            showProgress();
+        }
     }
 
-    private void finishSelf(
-        @Nullable HackerNewsItem item, boolean kidsEnabled, boolean readabilityEnabled) {
-      self = item != null;
-      title = item != null ? item.getTitle() : null;
-      if (kidsEnabled && item != null && item.getKids() != null) {
-        // fetch recursively but only notify for immediate children
-        totalKids = item.getKids().length;
-      } else {
-        totalKids = 0;
-      }
-      if (readabilityEnabled) {
-        readability = false;
-      }
+    private void showProgress() {
+        mNotificationManager.notify(Integer.valueOf(mJob.id), mNotificationBuilder
+                .setContentTitle(mSyncProgress.title)
+                .setContentText(mContext.getString(R.string.download_in_progress))
+                .setContentIntent(getItemActivity(mJob.id))
+                .setOnlyAlertOnce(true)
+                .setProgress(mSyncProgress.getMax(), mSyncProgress.getProgress(), false)
+                .setSortKey(mJob.id)
+                .build());
     }
 
-    private void finishKid() {
-      finishedKids++;
-    }
-  }
-
-  private static class BackgroundThreadExecutor implements Executor {
-
-    @Synthetic
-    BackgroundThreadExecutor() {}
-
-    @Override
-    public void execute(@NonNull Runnable r) {
-      Process.setThreadPriority(Process.THREAD_PRIORITY_BACKGROUND);
-      r.run();
-    }
-  }
-
-  interface ProgressListener {
-    void onDone(String token);
-  }
-
-  static class Job {
-    private static final String EXTRA_ID = "extra:id";
-    private static final String EXTRA_CONNECTION_ENABLED = "extra:connectionEnabled";
-    private static final String EXTRA_READABILITY_ENABLED = "extra:readabilityEnabled";
-    private static final String EXTRA_ARTICLE_ENABLED = "extra:articleEnabled";
-    private static final String EXTRA_COMMENTS_ENABLED = "extra:commentsEnabled";
-    private static final String EXTRA_NOTIFICATION_ENABLED = "extra:notificationEnabled";
-    final String id;
-    boolean connectionEnabled;
-    boolean readabilityEnabled;
-    boolean articleEnabled;
-    boolean commentsEnabled;
-    boolean notificationEnabled;
-
-    Job(String id) {
-      this.id = id;
+    private void finish() {
+        if (mListener != null) {
+            mListener.onDone(mJob.id);
+            mListener = null;
+        }
+        stopSync();
     }
 
-    Job(PersistableBundle bundle) {
-      id = bundle.getString(EXTRA_ID);
-      connectionEnabled = bundle.getInt(EXTRA_CONNECTION_ENABLED) == 1;
-      readabilityEnabled = bundle.getInt(EXTRA_READABILITY_ENABLED) == 1;
-      articleEnabled = bundle.getInt(EXTRA_ARTICLE_ENABLED) == 1;
-      commentsEnabled = bundle.getInt(EXTRA_COMMENTS_ENABLED) == 1;
-      notificationEnabled = bundle.getInt(EXTRA_NOTIFICATION_ENABLED) == 1;
+    void stopSync() {
+        // TODO
+        mJob.connectionEnabled = false;
+        int id = Integer.valueOf(mJob.id);
+        mNotificationManager.cancel(id);
+        mHandler.removeMessages(id);
     }
 
-    Job(Bundle bundle) {
-      id = bundle.getString(EXTRA_ID);
-      connectionEnabled = bundle.getBoolean(EXTRA_CONNECTION_ENABLED);
-      readabilityEnabled = bundle.getBoolean(EXTRA_READABILITY_ENABLED);
-      articleEnabled = bundle.getBoolean(EXTRA_ARTICLE_ENABLED);
-      commentsEnabled = bundle.getBoolean(EXTRA_COMMENTS_ENABLED);
-      notificationEnabled = bundle.getBoolean(EXTRA_NOTIFICATION_ENABLED);
+    private PendingIntent getItemActivity(String itemId) {
+        return PendingIntent.getActivity(mContext, 0,
+                new Intent(Intent.ACTION_VIEW)
+                        .setData(AppUtils.createItemUri(itemId))
+                        .putExtra(ItemActivity.EXTRA_CACHE_MODE, ItemManager.MODE_CACHE)
+                        .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+                PendingIntent.FLAG_ONE_SHOT | PendingIntent.FLAG_IMMUTABLE);
     }
 
-    @Synthetic
-    PersistableBundle toPersistableBundle() {
-      PersistableBundle bundle = new PersistableBundle();
-      bundle.putString(EXTRA_ID, id);
-      bundle.putInt(EXTRA_CONNECTION_ENABLED, connectionEnabled ? 1 : 0);
-      bundle.putInt(EXTRA_READABILITY_ENABLED, readabilityEnabled ? 1 : 0);
-      bundle.putInt(EXTRA_ARTICLE_ENABLED, articleEnabled ? 1 : 0);
-      bundle.putInt(EXTRA_COMMENTS_ENABLED, commentsEnabled ? 1 : 0);
-      bundle.putInt(EXTRA_NOTIFICATION_ENABLED, notificationEnabled ? 1 : 0);
-      return bundle;
+    private static class SyncProgress {
+        private final String id;
+        private Boolean self;
+        private int totalKids, finishedKids, webProgress, maxWebProgress;
+        private Boolean readability;
+        String title;
+
+        @Synthetic
+        SyncProgress(Job job) {
+            this.id = job.id;
+            if (job.commentsEnabled) {
+                totalKids = 1;
+            }
+            if (job.articleEnabled) {
+                maxWebProgress = 100;
+            }
+            if (job.readabilityEnabled) {
+                readability = false;
+            }
+        }
+
+        int getMax() {
+            return 1 + totalKids + (readability != null ? 1 : 0) + maxWebProgress;
+        }
+
+        int getProgress() {
+            return (self != null ? 1 : 0) + finishedKids + (readability != null && readability ? 1 : 0) + webProgress;
+        }
+
+        @Synthetic
+        void finishItem(@NonNull String id, @Nullable HackerNewsItem item,
+                boolean kidsEnabled, boolean readabilityEnabled) {
+            if (TextUtils.equals(id, this.id)) {
+                finishSelf(item, kidsEnabled, readabilityEnabled);
+            } else {
+                finishKid();
+            }
+        }
+
+        @Synthetic
+        void finishReadability() {
+            readability = true;
+        }
+
+        @Synthetic
+        void updateArticle(int webProgress, int maxWebProgress) {
+            this.webProgress = webProgress;
+            this.maxWebProgress = maxWebProgress;
+        }
+
+        private void finishSelf(@Nullable HackerNewsItem item, boolean kidsEnabled,
+                boolean readabilityEnabled) {
+            self = item != null;
+            title = item != null ? item.getTitle() : null;
+            if (kidsEnabled && item != null && item.getKids() != null) {
+                // fetch recursively but only notify for immediate children
+                totalKids = item.getKids().length;
+            } else {
+                totalKids = 0;
+            }
+            if (readabilityEnabled) {
+                readability = false;
+            }
+        }
+
+        private void finishKid() {
+            finishedKids++;
+        }
     }
 
-    @Synthetic
-    Bundle toBundle() {
-      Bundle bundle = new Bundle();
-      bundle.putString(EXTRA_ID, id);
-      bundle.putBoolean(EXTRA_CONNECTION_ENABLED, connectionEnabled);
-      bundle.putBoolean(EXTRA_READABILITY_ENABLED, readabilityEnabled);
-      bundle.putBoolean(EXTRA_ARTICLE_ENABLED, articleEnabled);
-      bundle.putBoolean(EXTRA_COMMENTS_ENABLED, commentsEnabled);
-      bundle.putBoolean(EXTRA_NOTIFICATION_ENABLED, notificationEnabled);
-      return bundle;
-    }
-  }
+    private static class BackgroundThreadExecutor implements Executor {
 
-  public static class JobBuilder {
-    private final Job job;
+        @Synthetic
+        BackgroundThreadExecutor() {
+        }
 
-    public JobBuilder(Context context, String id) {
-      job = new Job(id);
-      setConnectionEnabled(Preferences.Offline.currentConnectionEnabled(context));
-      setReadabilityEnabled(Preferences.Offline.isReadabilityEnabled(context));
-      setArticleEnabled(Preferences.Offline.isArticleEnabled(context));
-      setCommentsEnabled(Preferences.Offline.isCommentsEnabled(context));
-      setNotificationEnabled(Preferences.Offline.isNotificationEnabled(context));
+        @Override
+        public void execute(@NonNull Runnable r) {
+            Process.setThreadPriority(Process.THREAD_PRIORITY_BACKGROUND);
+            r.run();
+        }
     }
 
-    JobBuilder setConnectionEnabled(boolean connectionEnabled) {
-      job.connectionEnabled = connectionEnabled;
-      return this;
+    interface ProgressListener {
+        void onDone(String token);
     }
 
-    JobBuilder setReadabilityEnabled(boolean readabilityEnabled) {
-      job.readabilityEnabled = readabilityEnabled;
-      return this;
+    static class Job {
+        private static final String EXTRA_ID = "extra:id";
+        private static final String EXTRA_CONNECTION_ENABLED = "extra:connectionEnabled";
+        private static final String EXTRA_READABILITY_ENABLED = "extra:readabilityEnabled";
+        private static final String EXTRA_ARTICLE_ENABLED = "extra:articleEnabled";
+        private static final String EXTRA_COMMENTS_ENABLED = "extra:commentsEnabled";
+        private static final String EXTRA_NOTIFICATION_ENABLED = "extra:notificationEnabled";
+        final String id;
+        boolean connectionEnabled;
+        boolean readabilityEnabled;
+        boolean articleEnabled;
+        boolean commentsEnabled;
+        boolean notificationEnabled;
+
+        Job(String id) {
+            this.id = id;
+        }
+
+        Job(PersistableBundle bundle) {
+            id = bundle.getString(EXTRA_ID);
+            connectionEnabled = bundle.getInt(EXTRA_CONNECTION_ENABLED) == 1;
+            readabilityEnabled = bundle.getInt(EXTRA_READABILITY_ENABLED) == 1;
+            articleEnabled = bundle.getInt(EXTRA_ARTICLE_ENABLED) == 1;
+            commentsEnabled = bundle.getInt(EXTRA_COMMENTS_ENABLED) == 1;
+            notificationEnabled = bundle.getInt(EXTRA_NOTIFICATION_ENABLED) == 1;
+        }
+
+        Job(Bundle bundle) {
+            id = bundle.getString(EXTRA_ID);
+            connectionEnabled = bundle.getBoolean(EXTRA_CONNECTION_ENABLED);
+            readabilityEnabled = bundle.getBoolean(EXTRA_READABILITY_ENABLED);
+            articleEnabled = bundle.getBoolean(EXTRA_ARTICLE_ENABLED);
+            commentsEnabled = bundle.getBoolean(EXTRA_COMMENTS_ENABLED);
+            notificationEnabled = bundle.getBoolean(EXTRA_NOTIFICATION_ENABLED);
+        }
+
+        @Synthetic
+        PersistableBundle toPersistableBundle() {
+            PersistableBundle bundle = new PersistableBundle();
+            bundle.putString(EXTRA_ID, id);
+            bundle.putInt(EXTRA_CONNECTION_ENABLED, connectionEnabled ? 1 : 0);
+            bundle.putInt(EXTRA_READABILITY_ENABLED, readabilityEnabled ? 1 : 0);
+            bundle.putInt(EXTRA_ARTICLE_ENABLED, articleEnabled ? 1 : 0);
+            bundle.putInt(EXTRA_COMMENTS_ENABLED, commentsEnabled ? 1 : 0);
+            bundle.putInt(EXTRA_NOTIFICATION_ENABLED, notificationEnabled ? 1 : 0);
+            return bundle;
+        }
+
+        @Synthetic
+        Bundle toBundle() {
+            Bundle bundle = new Bundle();
+            bundle.putString(EXTRA_ID, id);
+            bundle.putBoolean(EXTRA_CONNECTION_ENABLED, connectionEnabled);
+            bundle.putBoolean(EXTRA_READABILITY_ENABLED, readabilityEnabled);
+            bundle.putBoolean(EXTRA_ARTICLE_ENABLED, articleEnabled);
+            bundle.putBoolean(EXTRA_COMMENTS_ENABLED, commentsEnabled);
+            bundle.putBoolean(EXTRA_NOTIFICATION_ENABLED, notificationEnabled);
+            return bundle;
+        }
     }
 
-    JobBuilder setArticleEnabled(boolean articleEnabled) {
-      job.articleEnabled = articleEnabled;
-      return this;
-    }
+    public static class JobBuilder {
+        private final Job job;
 
-    JobBuilder setCommentsEnabled(boolean commentsEnabled) {
-      job.commentsEnabled = commentsEnabled;
-      return this;
-    }
+        public JobBuilder(Context context, String id) {
+            job = new Job(id);
+            setConnectionEnabled(Preferences.Offline.currentConnectionEnabled(context));
+            setReadabilityEnabled(Preferences.Offline.isReadabilityEnabled(context));
+            setArticleEnabled(Preferences.Offline.isArticleEnabled(context));
+            setCommentsEnabled(Preferences.Offline.isCommentsEnabled(context));
+            setNotificationEnabled(Preferences.Offline.isNotificationEnabled(context));
+        }
 
-    public JobBuilder setNotificationEnabled(boolean notificationEnabled) {
-      job.notificationEnabled = notificationEnabled;
-      return this;
-    }
+        JobBuilder setConnectionEnabled(boolean connectionEnabled) {
+            job.connectionEnabled = connectionEnabled;
+            return this;
+        }
 
-    public Job build() {
-      return job;
+        JobBuilder setReadabilityEnabled(boolean readabilityEnabled) {
+            job.readabilityEnabled = readabilityEnabled;
+            return this;
+        }
+
+        JobBuilder setArticleEnabled(boolean articleEnabled) {
+            job.articleEnabled = articleEnabled;
+            return this;
+        }
+
+        JobBuilder setCommentsEnabled(boolean commentsEnabled) {
+            job.commentsEnabled = commentsEnabled;
+            return this;
+        }
+
+        public JobBuilder setNotificationEnabled(boolean notificationEnabled) {
+            job.notificationEnabled = notificationEnabled;
+            return this;
+        }
+
+        public Job build() {
+            return job;
+        }
     }
-  }
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/data/WebCacheService.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/data/WebCacheService.java
@@ -48,7 +48,7 @@ public class WebCacheService extends Service {
             return START_STICKY;
         }
         CacheableWebView webView = new CacheableWebView(this);
-        webView.setWebViewClient(new AdBlockWebViewClient(Preferences.adBlockEnabled(this)));
+        webView.setWebViewClient(new AdBlockWebViewClient(this, Preferences.adBlockEnabled(this)));
         webView.setWebChromeClient(new CacheableWebView.ArchiveClient() {
             @Override
             public void onProgressChanged(WebView view, int newProgress) {

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/data/WebCacheService.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/data/WebCacheService.java
@@ -19,42 +19,46 @@ package io.github.sheepdestroyer.materialisheep.data;
 import android.app.Service;
 import android.content.Intent;
 import android.os.IBinder;
-import android.webkit.WebView;
 import androidx.annotation.Nullable;
+import android.webkit.WebView;
+
 import io.github.sheepdestroyer.materialisheep.Preferences;
 import io.github.sheepdestroyer.materialisheep.widget.AdBlockWebViewClient;
 import io.github.sheepdestroyer.materialisheep.widget.CacheableWebView;
 
-/** A {@link Service} that caches web pages for offline viewing. */
+/**
+ * A {@link Service} that caches web pages for offline viewing.
+ */
 public class WebCacheService extends Service {
-  /** An extra that contains the URL of the web page to cache. */
-  static final String EXTRA_URL = "extra:url";
+    /**
+     * An extra that contains the URL of the web page to cache.
+     */
+    static final String EXTRA_URL = "extra:url";
 
-  @Nullable
-  @Override
-  public IBinder onBind(Intent intent) {
-    return null;
-  }
-
-  @Override
-  public int onStartCommand(Intent intent, int flags, int startId) {
-    if (intent == null) { // restarted
-      stopSelf(startId);
-      return START_STICKY;
+    @Nullable
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
     }
-    CacheableWebView webView = new CacheableWebView(this);
-    webView.setWebViewClient(new AdBlockWebViewClient(this, Preferences.adBlockEnabled(this)));
-    webView.setWebChromeClient(
-        new CacheableWebView.ArchiveClient() {
-          @Override
-          public void onProgressChanged(WebView view, int newProgress) {
-            super.onProgressChanged(view, newProgress);
-            if (newProgress == 100) {
-              stopSelf(startId);
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        if (intent == null) { // restarted
+            stopSelf(startId);
+            return START_STICKY;
+        }
+        CacheableWebView webView = new CacheableWebView(this);
+        webView.setWebViewClient(new AdBlockWebViewClient(this, Preferences.adBlockEnabled(this)));
+        webView.setWebChromeClient(new CacheableWebView.ArchiveClient() {
+            @Override
+            public void onProgressChanged(WebView view, int newProgress) {
+                super.onProgressChanged(view, newProgress);
+                if (newProgress == 100) {
+                    stopSelf(startId);
+                }
             }
-          }
         });
-    webView.loadUrl(intent.getStringExtra(EXTRA_URL));
-    return START_STICKY;
-  }
+        webView.loadUrl(intent.getStringExtra(EXTRA_URL));
+        return START_STICKY;
+    }
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/data/WebCacheService.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/data/WebCacheService.java
@@ -19,46 +19,42 @@ package io.github.sheepdestroyer.materialisheep.data;
 import android.app.Service;
 import android.content.Intent;
 import android.os.IBinder;
-import androidx.annotation.Nullable;
 import android.webkit.WebView;
-
+import androidx.annotation.Nullable;
 import io.github.sheepdestroyer.materialisheep.Preferences;
 import io.github.sheepdestroyer.materialisheep.widget.AdBlockWebViewClient;
 import io.github.sheepdestroyer.materialisheep.widget.CacheableWebView;
 
-/**
- * A {@link Service} that caches web pages for offline viewing.
- */
+/** A {@link Service} that caches web pages for offline viewing. */
 public class WebCacheService extends Service {
-    /**
-     * An extra that contains the URL of the web page to cache.
-     */
-    static final String EXTRA_URL = "extra:url";
+  /** An extra that contains the URL of the web page to cache. */
+  static final String EXTRA_URL = "extra:url";
 
-    @Nullable
-    @Override
-    public IBinder onBind(Intent intent) {
-        return null;
+  @Nullable
+  @Override
+  public IBinder onBind(Intent intent) {
+    return null;
+  }
+
+  @Override
+  public int onStartCommand(Intent intent, int flags, int startId) {
+    if (intent == null) { // restarted
+      stopSelf(startId);
+      return START_STICKY;
     }
-
-    @Override
-    public int onStartCommand(Intent intent, int flags, int startId) {
-        if (intent == null) { // restarted
-            stopSelf(startId);
-            return START_STICKY;
-        }
-        CacheableWebView webView = new CacheableWebView(this);
-        webView.setWebViewClient(new AdBlockWebViewClient(this, Preferences.adBlockEnabled(this)));
-        webView.setWebChromeClient(new CacheableWebView.ArchiveClient() {
-            @Override
-            public void onProgressChanged(WebView view, int newProgress) {
-                super.onProgressChanged(view, newProgress);
-                if (newProgress == 100) {
-                    stopSelf(startId);
-                }
+    CacheableWebView webView = new CacheableWebView(this);
+    webView.setWebViewClient(new AdBlockWebViewClient(this, Preferences.adBlockEnabled(this)));
+    webView.setWebChromeClient(
+        new CacheableWebView.ArchiveClient() {
+          @Override
+          public void onProgressChanged(WebView view, int newProgress) {
+            super.onProgressChanged(view, newProgress);
+            if (newProgress == 100) {
+              stopSelf(startId);
             }
+          }
         });
-        webView.loadUrl(intent.getStringExtra(EXTRA_URL));
-        return START_STICKY;
-    }
+    webView.loadUrl(intent.getStringExtra(EXTRA_URL));
+    return START_STICKY;
+  }
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
@@ -17,14 +17,17 @@
 package io.github.sheepdestroyer.materialisheep.widget;
 
 import android.annotation.TargetApi;
+import android.content.Context;
 import android.os.Build;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
-import java.util.HashMap;
+import java.io.File;
+import java.io.IOException;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import androidx.annotation.Nullable;
 import io.github.sheepdestroyer.materialisheep.AdBlocker;
@@ -32,16 +35,29 @@ import io.github.sheepdestroyer.materialisheep.AdBlocker;
 @SuppressWarnings("deprecation") // TODO: Uses deprecated WebResourceRequest API
 public class AdBlockWebViewClient extends WebViewClient {
     private final boolean mAdBlockEnabled;
-    private final Map<String, Boolean> mLoadedUrls = new HashMap<>();
+    private final Map<String, Boolean> mLoadedUrls = new ConcurrentHashMap<>();
+    private final File mCacheDir;
+    private final String mCacheDirPath;
 
-    public AdBlockWebViewClient(boolean adBlockEnabled) {
+    public AdBlockWebViewClient(Context context, boolean adBlockEnabled) {
         mAdBlockEnabled = adBlockEnabled;
+        mCacheDir = context.getApplicationContext().getCacheDir();
+        String path;
+        try {
+            path = mCacheDir.getCanonicalPath();
+        } catch (IOException e) {
+            path = mCacheDir.getAbsolutePath();
+        }
+        mCacheDirPath = path;
     }
 
     @Override
     public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
         if (!mAdBlockEnabled) {
             return super.shouldInterceptRequest(view, url);
+        }
+        if (isUnsafeFileUrl(url)) {
+            return AdBlocker.createEmptyResource();
         }
         boolean ad;
         if (!mLoadedUrls.containsKey(url)) {
@@ -59,8 +75,11 @@ public class AdBlockWebViewClient extends WebViewClient {
         if (!mAdBlockEnabled) {
             return super.shouldInterceptRequest(view, request);
         }
-        boolean ad;
         String url = request.getUrl().toString();
+        if (isUnsafeFileUrl(url)) {
+            return AdBlocker.createEmptyResource();
+        }
+        boolean ad;
         if (!mLoadedUrls.containsKey(url)) {
             ad = AdBlocker.isAd(url);
             mLoadedUrls.put(url, ad);
@@ -68,5 +87,27 @@ public class AdBlockWebViewClient extends WebViewClient {
             ad = mLoadedUrls.get(url);
         }
         return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, request);
+    }
+
+    private boolean isUnsafeFileUrl(String url) {
+        if (url.startsWith("file://")) {
+            if (url.startsWith("file:///android_asset/")) {
+                return false;
+            }
+            try {
+                // file:///path -> /path
+                String path = url.substring(7);
+                File file = new File(path);
+                String canonicalPath = file.getCanonicalPath();
+                if (canonicalPath.startsWith(mCacheDirPath)) {
+                    return false;
+                }
+            } catch (IOException e) {
+                // If we can't determine canonical path, treat as unsafe
+                return true;
+            }
+            return true;
+        }
+        return false;
     }
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
@@ -16,98 +16,94 @@
 
 package io.github.sheepdestroyer.materialisheep.widget;
 
-import android.annotation.TargetApi;
 import android.content.Context;
-import android.os.Build;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
-
+import androidx.annotation.Nullable;
+import io.github.sheepdestroyer.materialisheep.AdBlocker;
 import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import androidx.annotation.Nullable;
-import io.github.sheepdestroyer.materialisheep.AdBlocker;
-
 @SuppressWarnings("deprecation") // TODO: Uses deprecated WebResourceRequest API
 public class AdBlockWebViewClient extends WebViewClient {
-    private final boolean mAdBlockEnabled;
-    private final Map<String, Boolean> mLoadedUrls = new ConcurrentHashMap<>();
-    private final File mCacheDir;
-    private final String mCacheDirPath;
+  private final boolean mAdBlockEnabled;
+  private final Map<String, Boolean> mLoadedUrls = new ConcurrentHashMap<>();
+  private final File mCacheDir;
+  private final String mCacheDirPath;
 
-    public AdBlockWebViewClient(Context context, boolean adBlockEnabled) {
-        mAdBlockEnabled = adBlockEnabled;
-        mCacheDir = context.getApplicationContext().getCacheDir();
-        String path;
-        try {
-            path = mCacheDir.getCanonicalPath();
-        } catch (IOException e) {
-            path = mCacheDir.getAbsolutePath();
-        }
-        mCacheDirPath = path;
+  public AdBlockWebViewClient(Context context, boolean adBlockEnabled) {
+    mAdBlockEnabled = adBlockEnabled;
+    mCacheDir = context.getApplicationContext().getCacheDir();
+    String path;
+    try {
+      path = mCacheDir.getCanonicalPath();
+    } catch (IOException e) {
+      path = mCacheDir.getAbsolutePath();
     }
+    mCacheDirPath = path;
+  }
 
-    @Override
-    public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
-        if (!mAdBlockEnabled) {
-            return super.shouldInterceptRequest(view, url);
-        }
-        if (isUnsafeFileUrl(url)) {
-            return AdBlocker.createEmptyResource();
-        }
-        boolean ad;
-        if (!mLoadedUrls.containsKey(url)) {
-            ad = AdBlocker.isAd(url);
-            mLoadedUrls.put(url, ad);
-        } else {
-            ad = mLoadedUrls.get(url);
-        }
-        return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, url);
+  @Override
+  public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
+    if (!mAdBlockEnabled) {
+      return super.shouldInterceptRequest(view, url);
     }
-
-    @Nullable
-    @Override
-    public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
-        if (!mAdBlockEnabled) {
-            return super.shouldInterceptRequest(view, request);
-        }
-        String url = request.getUrl().toString();
-        if (isUnsafeFileUrl(url)) {
-            return AdBlocker.createEmptyResource();
-        }
-        boolean ad;
-        if (!mLoadedUrls.containsKey(url)) {
-            ad = AdBlocker.isAd(url);
-            mLoadedUrls.put(url, ad);
-        } else {
-            ad = mLoadedUrls.get(url);
-        }
-        return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, request);
+    if (isUnsafeFileUrl(url)) {
+      return AdBlocker.createEmptyResource();
     }
+    boolean ad;
+    if (!mLoadedUrls.containsKey(url)) {
+      ad = AdBlocker.isAd(url);
+      mLoadedUrls.put(url, ad);
+    } else {
+      ad = mLoadedUrls.get(url);
+    }
+    return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, url);
+  }
 
-    private boolean isUnsafeFileUrl(String url) {
-        if (url.startsWith("file://")) {
-            if (url.startsWith("file:///android_asset/")) {
-                return false;
-            }
-            try {
-                // file:///path -> /path
-                String path = url.substring(7);
-                File file = new File(path);
-                String canonicalPath = file.getCanonicalPath();
-                if (canonicalPath.startsWith(mCacheDirPath)) {
-                    return false;
-                }
-            } catch (IOException e) {
-                // If we can't determine canonical path, treat as unsafe
-                return true;
-            }
-            return true;
-        }
+  @Nullable
+  @Override
+  public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+    if (!mAdBlockEnabled) {
+      return super.shouldInterceptRequest(view, request);
+    }
+    String url = request.getUrl().toString();
+    if (isUnsafeFileUrl(url)) {
+      return AdBlocker.createEmptyResource();
+    }
+    boolean ad;
+    if (!mLoadedUrls.containsKey(url)) {
+      ad = AdBlocker.isAd(url);
+      mLoadedUrls.put(url, ad);
+    } else {
+      ad = mLoadedUrls.get(url);
+    }
+    return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, request);
+  }
+
+  private boolean isUnsafeFileUrl(String url) {
+    if (url.startsWith("file://")) {
+      if (url.startsWith("file:///android_asset/")) {
         return false;
+      }
+      try {
+        // file:///path -> /path
+        String path = url.substring(7);
+        File file = new File(path);
+        String canonicalPath = file.getCanonicalPath();
+        if (canonicalPath.startsWith(mCacheDirPath)) {
+          return false;
+        }
+      } catch (IOException e) {
+        // If we can't determine canonical path, treat as unsafe
+        return true;
+      }
+      return true;
     }
+    return false;
+  }
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
@@ -16,94 +16,98 @@
 
 package io.github.sheepdestroyer.materialisheep.widget;
 
+import android.annotation.TargetApi;
 import android.content.Context;
+import android.os.Build;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
-import androidx.annotation.Nullable;
-import io.github.sheepdestroyer.materialisheep.AdBlocker;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import androidx.annotation.Nullable;
+import io.github.sheepdestroyer.materialisheep.AdBlocker;
+
 @SuppressWarnings("deprecation") // TODO: Uses deprecated WebResourceRequest API
 public class AdBlockWebViewClient extends WebViewClient {
-  private final boolean mAdBlockEnabled;
-  private final Map<String, Boolean> mLoadedUrls = new ConcurrentHashMap<>();
-  private final File mCacheDir;
-  private final String mCacheDirPath;
+    private final boolean mAdBlockEnabled;
+    private final Map<String, Boolean> mLoadedUrls = new ConcurrentHashMap<>();
+    private final File mCacheDir;
+    private final String mCacheDirPath;
 
-  public AdBlockWebViewClient(Context context, boolean adBlockEnabled) {
-    mAdBlockEnabled = adBlockEnabled;
-    mCacheDir = context.getApplicationContext().getCacheDir();
-    String path;
-    try {
-      path = mCacheDir.getCanonicalPath();
-    } catch (IOException e) {
-      path = mCacheDir.getAbsolutePath();
-    }
-    mCacheDirPath = path;
-  }
-
-  @Override
-  public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
-    if (!mAdBlockEnabled) {
-      return super.shouldInterceptRequest(view, url);
-    }
-    if (isUnsafeFileUrl(url)) {
-      return AdBlocker.createEmptyResource();
-    }
-    boolean ad;
-    if (!mLoadedUrls.containsKey(url)) {
-      ad = AdBlocker.isAd(url);
-      mLoadedUrls.put(url, ad);
-    } else {
-      ad = mLoadedUrls.get(url);
-    }
-    return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, url);
-  }
-
-  @Nullable
-  @Override
-  public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
-    if (!mAdBlockEnabled) {
-      return super.shouldInterceptRequest(view, request);
-    }
-    String url = request.getUrl().toString();
-    if (isUnsafeFileUrl(url)) {
-      return AdBlocker.createEmptyResource();
-    }
-    boolean ad;
-    if (!mLoadedUrls.containsKey(url)) {
-      ad = AdBlocker.isAd(url);
-      mLoadedUrls.put(url, ad);
-    } else {
-      ad = mLoadedUrls.get(url);
-    }
-    return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, request);
-  }
-
-  private boolean isUnsafeFileUrl(String url) {
-    if (url.startsWith("file://")) {
-      if (url.startsWith("file:///android_asset/")) {
-        return false;
-      }
-      try {
-        // file:///path -> /path
-        String path = url.substring(7);
-        File file = new File(path);
-        String canonicalPath = file.getCanonicalPath();
-        if (canonicalPath.startsWith(mCacheDirPath)) {
-          return false;
+    public AdBlockWebViewClient(Context context, boolean adBlockEnabled) {
+        mAdBlockEnabled = adBlockEnabled;
+        mCacheDir = context.getApplicationContext().getCacheDir();
+        String path;
+        try {
+            path = mCacheDir.getCanonicalPath();
+        } catch (IOException e) {
+            path = mCacheDir.getAbsolutePath();
         }
-      } catch (IOException e) {
-        // If we can't determine canonical path, treat as unsafe
-        return true;
-      }
-      return true;
+        mCacheDirPath = path;
     }
-    return false;
-  }
+
+    @Override
+    public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
+        if (!mAdBlockEnabled) {
+            return super.shouldInterceptRequest(view, url);
+        }
+        if (isUnsafeFileUrl(url)) {
+            return AdBlocker.createEmptyResource();
+        }
+        boolean ad;
+        if (!mLoadedUrls.containsKey(url)) {
+            ad = AdBlocker.isAd(url);
+            mLoadedUrls.put(url, ad);
+        } else {
+            ad = mLoadedUrls.get(url);
+        }
+        return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, url);
+    }
+
+    @Nullable
+    @Override
+    public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+        if (!mAdBlockEnabled) {
+            return super.shouldInterceptRequest(view, request);
+        }
+        String url = request.getUrl().toString();
+        if (isUnsafeFileUrl(url)) {
+            return AdBlocker.createEmptyResource();
+        }
+        boolean ad;
+        if (!mLoadedUrls.containsKey(url)) {
+            ad = AdBlocker.isAd(url);
+            mLoadedUrls.put(url, ad);
+        } else {
+            ad = mLoadedUrls.get(url);
+        }
+        return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, request);
+    }
+
+    private boolean isUnsafeFileUrl(String url) {
+        if (url.startsWith("file://")) {
+            if (url.startsWith("file:///android_asset/")) {
+                return false;
+            }
+            try {
+                // file:///path -> /path
+                String path = url.substring(7);
+                File file = new File(path);
+                String canonicalPath = file.getCanonicalPath();
+                if (canonicalPath.startsWith(mCacheDirPath)) {
+                    return false;
+                }
+            } catch (IOException e) {
+                // If we can't determine canonical path, treat as unsafe
+                return true;
+            }
+            return true;
+        }
+        return false;
+    }
 }

--- a/app/src/test/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClientTest.java
+++ b/app/src/test/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClientTest.java
@@ -1,11 +1,15 @@
 package io.github.sheepdestroyer.materialisheep.widget;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.when;
+
 import android.content.Context;
 import android.net.Uri;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
-
+import java.io.File;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -14,74 +18,62 @@ import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 
-import java.io.File;
-import java.io.IOException;
-
-import io.github.sheepdestroyer.materialisheep.AdBlocker;
-
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 @RunWith(RobolectricTestRunner.class)
 public class AdBlockWebViewClientTest {
-    @Mock
-    private WebView webView;
-    @Mock
-    private WebResourceRequest request;
+  @Mock private WebView webView;
+  @Mock private WebResourceRequest request;
 
-    private Context context;
-    private AdBlockWebViewClient client;
+  private Context context;
+  private AdBlockWebViewClient client;
 
-    @Before
-    public void setUp() {
-        MockitoAnnotations.openMocks(this);
-        context = RuntimeEnvironment.getApplication();
-    }
+  @Before
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+    context = RuntimeEnvironment.getApplication();
+  }
 
-    @Test
-    public void testBlockFileUrl() {
-        client = new AdBlockWebViewClient(context, true);
+  @Test
+  public void testBlockFileUrl() {
+    client = new AdBlockWebViewClient(context, true);
 
-        String unsafeUrl = "file:///etc/hosts";
-        when(request.getUrl()).thenReturn(Uri.parse(unsafeUrl));
+    String unsafeUrl = "file:///etc/hosts";
+    when(request.getUrl()).thenReturn(Uri.parse(unsafeUrl));
 
-        WebResourceResponse response = client.shouldInterceptRequest(webView, request);
-        assertNotNull("Should block unsafe file URL", response);
-    }
+    WebResourceResponse response = client.shouldInterceptRequest(webView, request);
+    assertNotNull("Should block unsafe file URL", response);
+  }
 
-    @Test
-    public void testAllowAssetUrl() {
-        client = new AdBlockWebViewClient(context, true);
+  @Test
+  public void testAllowAssetUrl() {
+    client = new AdBlockWebViewClient(context, true);
 
-        String safeUrl = "file:///android_asset/pdf/index.html";
-        when(request.getUrl()).thenReturn(Uri.parse(safeUrl));
+    String safeUrl = "file:///android_asset/pdf/index.html";
+    when(request.getUrl()).thenReturn(Uri.parse(safeUrl));
 
-        WebResourceResponse response = client.shouldInterceptRequest(webView, request);
-        assertNull("Should allow safe asset URL", response);
-    }
+    WebResourceResponse response = client.shouldInterceptRequest(webView, request);
+    assertNull("Should allow safe asset URL", response);
+  }
 
-    @Test
-    public void testAllowCacheUrl() {
-        client = new AdBlockWebViewClient(context, true);
-        File cacheDir = context.getCacheDir();
-        String safeUrl = "file://" + cacheDir.getAbsolutePath() + "/test.html";
-        when(request.getUrl()).thenReturn(Uri.parse(safeUrl));
+  @Test
+  public void testAllowCacheUrl() {
+    client = new AdBlockWebViewClient(context, true);
+    File cacheDir = context.getCacheDir();
+    String safeUrl = "file://" + cacheDir.getAbsolutePath() + "/test.html";
+    when(request.getUrl()).thenReturn(Uri.parse(safeUrl));
 
-        WebResourceResponse response = client.shouldInterceptRequest(webView, request);
-        assertNull("Should allow safe cache URL", response);
-    }
+    WebResourceResponse response = client.shouldInterceptRequest(webView, request);
+    assertNull("Should allow safe cache URL", response);
+  }
 
-    @Test
-    public void testBlockPathTraversalUrl() {
-        client = new AdBlockWebViewClient(context, true);
-        File cacheDir = context.getCacheDir();
-        // Construct a path that looks like it's inside cacheDir but traverses out
-        String unsafeUrl = "file://" + cacheDir.getAbsolutePath() + "/../secret.db";
-        when(request.getUrl()).thenReturn(Uri.parse(unsafeUrl));
+  @Test
+  public void testBlockPathTraversalUrl() {
+    client = new AdBlockWebViewClient(context, true);
+    File cacheDir = context.getCacheDir();
+    // Construct a path that looks like it's inside cacheDir but traverses out
+    String unsafeUrl = "file://" + cacheDir.getAbsolutePath() + "/../secret.db";
+    when(request.getUrl()).thenReturn(Uri.parse(unsafeUrl));
 
-        WebResourceResponse response = client.shouldInterceptRequest(webView, request);
-        assertNotNull("Should block path traversal URL", response);
-    }
+    WebResourceResponse response = client.shouldInterceptRequest(webView, request);
+    assertNotNull("Should block path traversal URL", response);
+  }
 }

--- a/app/src/test/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClientTest.java
+++ b/app/src/test/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClientTest.java
@@ -1,79 +1,87 @@
 package io.github.sheepdestroyer.materialisheep.widget;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.mockito.Mockito.when;
-
 import android.content.Context;
 import android.net.Uri;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
-import java.io.File;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
+import androidx.test.core.app.ApplicationProvider;
+
+import java.io.File;
+import java.io.IOException;
+
+import io.github.sheepdestroyer.materialisheep.AdBlocker;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
 public class AdBlockWebViewClientTest {
-  @Mock private WebView webView;
-  @Mock private WebResourceRequest request;
+    @Mock
+    private WebView webView;
+    @Mock
+    private WebResourceRequest request;
 
-  private Context context;
-  private AdBlockWebViewClient client;
+    private Context context;
+    private AdBlockWebViewClient client;
 
-  @Before
-  public void setUp() {
-    MockitoAnnotations.openMocks(this);
-    context = RuntimeEnvironment.getApplication();
-  }
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        context = ApplicationProvider.getApplicationContext();
+    }
 
-  @Test
-  public void testBlockFileUrl() {
-    client = new AdBlockWebViewClient(context, true);
+    @Test
+    public void testBlockFileUrl() {
+        client = new AdBlockWebViewClient(context, true);
 
-    String unsafeUrl = "file:///etc/hosts";
-    when(request.getUrl()).thenReturn(Uri.parse(unsafeUrl));
+        String unsafeUrl = "file:///etc/hosts";
+        when(request.getUrl()).thenReturn(Uri.parse(unsafeUrl));
 
-    WebResourceResponse response = client.shouldInterceptRequest(webView, request);
-    assertNotNull("Should block unsafe file URL", response);
-  }
+        WebResourceResponse response = client.shouldInterceptRequest(webView, request);
+        assertNotNull("Should block unsafe file URL", response);
+    }
 
-  @Test
-  public void testAllowAssetUrl() {
-    client = new AdBlockWebViewClient(context, true);
+    @Test
+    public void testAllowAssetUrl() {
+        client = new AdBlockWebViewClient(context, true);
 
-    String safeUrl = "file:///android_asset/pdf/index.html";
-    when(request.getUrl()).thenReturn(Uri.parse(safeUrl));
+        String safeUrl = "file:///android_asset/pdf/index.html";
+        when(request.getUrl()).thenReturn(Uri.parse(safeUrl));
 
-    WebResourceResponse response = client.shouldInterceptRequest(webView, request);
-    assertNull("Should allow safe asset URL", response);
-  }
+        WebResourceResponse response = client.shouldInterceptRequest(webView, request);
+        assertNull("Should allow safe asset URL", response);
+    }
 
-  @Test
-  public void testAllowCacheUrl() {
-    client = new AdBlockWebViewClient(context, true);
-    File cacheDir = context.getCacheDir();
-    String safeUrl = "file://" + cacheDir.getAbsolutePath() + "/test.html";
-    when(request.getUrl()).thenReturn(Uri.parse(safeUrl));
+    @Test
+    public void testAllowCacheUrl() {
+        client = new AdBlockWebViewClient(context, true);
+        File cacheDir = context.getCacheDir();
+        String safeUrl = "file://" + cacheDir.getAbsolutePath() + "/test.html";
+        when(request.getUrl()).thenReturn(Uri.parse(safeUrl));
 
-    WebResourceResponse response = client.shouldInterceptRequest(webView, request);
-    assertNull("Should allow safe cache URL", response);
-  }
+        WebResourceResponse response = client.shouldInterceptRequest(webView, request);
+        assertNull("Should allow safe cache URL", response);
+    }
 
-  @Test
-  public void testBlockPathTraversalUrl() {
-    client = new AdBlockWebViewClient(context, true);
-    File cacheDir = context.getCacheDir();
-    // Construct a path that looks like it's inside cacheDir but traverses out
-    String unsafeUrl = "file://" + cacheDir.getAbsolutePath() + "/../secret.db";
-    when(request.getUrl()).thenReturn(Uri.parse(unsafeUrl));
+    @Test
+    public void testBlockPathTraversalUrl() {
+        client = new AdBlockWebViewClient(context, true);
+        File cacheDir = context.getCacheDir();
+        // Construct a path that looks like it's inside cacheDir but traverses out
+        String unsafeUrl = "file://" + cacheDir.getAbsolutePath() + "/../secret.db";
+        when(request.getUrl()).thenReturn(Uri.parse(unsafeUrl));
 
-    WebResourceResponse response = client.shouldInterceptRequest(webView, request);
-    assertNotNull("Should block path traversal URL", response);
-  }
+        WebResourceResponse response = client.shouldInterceptRequest(webView, request);
+        assertNotNull("Should block path traversal URL", response);
+    }
 }

--- a/app/src/test/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClientTest.java
+++ b/app/src/test/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClientTest.java
@@ -1,0 +1,87 @@
+package io.github.sheepdestroyer.materialisheep.widget;
+
+import android.content.Context;
+import android.net.Uri;
+import android.webkit.WebResourceRequest;
+import android.webkit.WebResourceResponse;
+import android.webkit.WebView;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+
+import java.io.File;
+import java.io.IOException;
+
+import io.github.sheepdestroyer.materialisheep.AdBlocker;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(RobolectricTestRunner.class)
+public class AdBlockWebViewClientTest {
+    @Mock
+    private WebView webView;
+    @Mock
+    private WebResourceRequest request;
+
+    private Context context;
+    private AdBlockWebViewClient client;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        context = RuntimeEnvironment.getApplication();
+    }
+
+    @Test
+    public void testBlockFileUrl() {
+        client = new AdBlockWebViewClient(context, true);
+
+        String unsafeUrl = "file:///etc/hosts";
+        when(request.getUrl()).thenReturn(Uri.parse(unsafeUrl));
+
+        WebResourceResponse response = client.shouldInterceptRequest(webView, request);
+        assertNotNull("Should block unsafe file URL", response);
+    }
+
+    @Test
+    public void testAllowAssetUrl() {
+        client = new AdBlockWebViewClient(context, true);
+
+        String safeUrl = "file:///android_asset/pdf/index.html";
+        when(request.getUrl()).thenReturn(Uri.parse(safeUrl));
+
+        WebResourceResponse response = client.shouldInterceptRequest(webView, request);
+        assertNull("Should allow safe asset URL", response);
+    }
+
+    @Test
+    public void testAllowCacheUrl() {
+        client = new AdBlockWebViewClient(context, true);
+        File cacheDir = context.getCacheDir();
+        String safeUrl = "file://" + cacheDir.getAbsolutePath() + "/test.html";
+        when(request.getUrl()).thenReturn(Uri.parse(safeUrl));
+
+        WebResourceResponse response = client.shouldInterceptRequest(webView, request);
+        assertNull("Should allow safe cache URL", response);
+    }
+
+    @Test
+    public void testBlockPathTraversalUrl() {
+        client = new AdBlockWebViewClient(context, true);
+        File cacheDir = context.getCacheDir();
+        // Construct a path that looks like it's inside cacheDir but traverses out
+        String unsafeUrl = "file://" + cacheDir.getAbsolutePath() + "/../secret.db";
+        when(request.getUrl()).thenReturn(Uri.parse(unsafeUrl));
+
+        WebResourceResponse response = client.shouldInterceptRequest(webView, request);
+        assertNotNull("Should block path traversal URL", response);
+    }
+}

--- a/app/src/test/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClientTest.java
+++ b/app/src/test/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClientTest.java
@@ -1,87 +1,79 @@
 package io.github.sheepdestroyer.materialisheep.widget;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.when;
+
 import android.content.Context;
 import android.net.Uri;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
-
+import androidx.test.core.app.ApplicationProvider;
+import java.io.File;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
-import androidx.test.core.app.ApplicationProvider;
-
-import java.io.File;
-import java.io.IOException;
-
-import io.github.sheepdestroyer.materialisheep.AdBlocker;
-
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
 public class AdBlockWebViewClientTest {
-    @Mock
-    private WebView webView;
-    @Mock
-    private WebResourceRequest request;
+  @Mock private WebView webView;
+  @Mock private WebResourceRequest request;
 
-    private Context context;
-    private AdBlockWebViewClient client;
+  private Context context;
+  private AdBlockWebViewClient client;
 
-    @Before
-    public void setUp() {
-        MockitoAnnotations.openMocks(this);
-        context = ApplicationProvider.getApplicationContext();
-    }
+  @Before
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+    context = ApplicationProvider.getApplicationContext();
+  }
 
-    @Test
-    public void testBlockFileUrl() {
-        client = new AdBlockWebViewClient(context, true);
+  @Test
+  public void testBlockFileUrl() {
+    client = new AdBlockWebViewClient(context, true);
 
-        String unsafeUrl = "file:///etc/hosts";
-        when(request.getUrl()).thenReturn(Uri.parse(unsafeUrl));
+    String unsafeUrl = "file:///etc/hosts";
+    when(request.getUrl()).thenReturn(Uri.parse(unsafeUrl));
 
-        WebResourceResponse response = client.shouldInterceptRequest(webView, request);
-        assertNotNull("Should block unsafe file URL", response);
-    }
+    WebResourceResponse response = client.shouldInterceptRequest(webView, request);
+    assertNotNull("Should block unsafe file URL", response);
+  }
 
-    @Test
-    public void testAllowAssetUrl() {
-        client = new AdBlockWebViewClient(context, true);
+  @Test
+  public void testAllowAssetUrl() {
+    client = new AdBlockWebViewClient(context, true);
 
-        String safeUrl = "file:///android_asset/pdf/index.html";
-        when(request.getUrl()).thenReturn(Uri.parse(safeUrl));
+    String safeUrl = "file:///android_asset/pdf/index.html";
+    when(request.getUrl()).thenReturn(Uri.parse(safeUrl));
 
-        WebResourceResponse response = client.shouldInterceptRequest(webView, request);
-        assertNull("Should allow safe asset URL", response);
-    }
+    WebResourceResponse response = client.shouldInterceptRequest(webView, request);
+    assertNull("Should allow safe asset URL", response);
+  }
 
-    @Test
-    public void testAllowCacheUrl() {
-        client = new AdBlockWebViewClient(context, true);
-        File cacheDir = context.getCacheDir();
-        String safeUrl = "file://" + cacheDir.getAbsolutePath() + "/test.html";
-        when(request.getUrl()).thenReturn(Uri.parse(safeUrl));
+  @Test
+  public void testAllowCacheUrl() {
+    client = new AdBlockWebViewClient(context, true);
+    File cacheDir = context.getCacheDir();
+    String safeUrl = "file://" + cacheDir.getAbsolutePath() + "/test.html";
+    when(request.getUrl()).thenReturn(Uri.parse(safeUrl));
 
-        WebResourceResponse response = client.shouldInterceptRequest(webView, request);
-        assertNull("Should allow safe cache URL", response);
-    }
+    WebResourceResponse response = client.shouldInterceptRequest(webView, request);
+    assertNull("Should allow safe cache URL", response);
+  }
 
-    @Test
-    public void testBlockPathTraversalUrl() {
-        client = new AdBlockWebViewClient(context, true);
-        File cacheDir = context.getCacheDir();
-        // Construct a path that looks like it's inside cacheDir but traverses out
-        String unsafeUrl = "file://" + cacheDir.getAbsolutePath() + "/../secret.db";
-        when(request.getUrl()).thenReturn(Uri.parse(unsafeUrl));
+  @Test
+  public void testBlockPathTraversalUrl() {
+    client = new AdBlockWebViewClient(context, true);
+    File cacheDir = context.getCacheDir();
+    // Construct a path that looks like it's inside cacheDir but traverses out
+    String unsafeUrl = "file://" + cacheDir.getAbsolutePath() + "/../secret.db";
+    when(request.getUrl()).thenReturn(Uri.parse(unsafeUrl));
 
-        WebResourceResponse response = client.shouldInterceptRequest(webView, request);
-        assertNotNull("Should block path traversal URL", response);
-    }
+    WebResourceResponse response = client.shouldInterceptRequest(webView, request);
+    assertNotNull("Should block path traversal URL", response);
+  }
 }


### PR DESCRIPTION
This PR addresses a critical security vulnerability in `CacheableWebView`, which enables `setAllowFileAccess(true)` to support offline reading. Previously, `AdBlockWebViewClient` did not filter `file://` URLs, potentially allowing malicious links to access arbitrary files within the application's sandbox.

Changes:
- Modified `AdBlockWebViewClient` to strictly filter `file://` URLs in `shouldInterceptRequest`.
- Allowed access only to `file:///android_asset/` (for PDF viewer) and the application's cache directory (for offline archives).
- Implemented `getCanonicalPath()` checks to prevent directory traversal attacks.
- Replaced `HashMap` with `ConcurrentHashMap` in `AdBlockWebViewClient` to ensure thread safety during concurrent resource loading.
- Added `AdBlockWebViewClientTest` to verify the security logic.

Testing:
- Verified that `file:///etc/hosts` and traversal attempts like `.../cache/../secret.db` are blocked.
- Verified that valid asset and cache URLs are allowed.
- Ran full unit test suite.

---
*PR created automatically by Jules for task [11550112720629876168](https://jules.google.com/task/11550112720629876168) started by @sheepdestroyer*

## Summary by Sourcery

Harden WebView file URL handling in AdBlockWebViewClient to prevent unsafe local file access while preserving offline and asset loading.

Bug Fixes:
- Block unsafe file:// URLs in AdBlockWebViewClient, allowing only Android asset files and files within the app cache directory using canonical path checks to prevent traversal attacks.

Enhancements:
- Make AdBlockWebViewClient thread-safe by using a ConcurrentHashMap for tracked URLs and passing Context to initialize cache directory metadata.

Documentation:
- Add a Sentinel security incident note describing the WebView file access vulnerability, its root cause, and prevention guidelines.

Tests:
- Add Robolectric tests for AdBlockWebViewClient to verify allowed asset/cache file URLs and blocked unsafe or path-traversal file URLs.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes critical WebView file access vulnerability by filtering `file://` URLs in `AdBlockWebViewClient` and ensuring thread safety.
> 
>   - **Security Fix**:
>     - `AdBlockWebViewClient` now filters `file://` URLs in `shouldInterceptRequest` to prevent unauthorized file access.
>     - Allows only `file:///android_asset/` and cache directory paths.
>     - Uses `getCanonicalPath()` to prevent directory traversal attacks.
>   - **Thread Safety**:
>     - Replaces `HashMap` with `ConcurrentHashMap` in `AdBlockWebViewClient` for thread-safe URL loading.
>   - **Testing**:
>     - Adds `AdBlockWebViewClientTest` to verify blocking of unsafe URLs and allowing of safe ones.
>     - Tests include blocking `file:///etc/hosts` and traversal attempts, and allowing valid asset and cache URLs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sheepdestroyer%2Fmaterialisheep&utm_source=github&utm_medium=referral)<sup> for 890a48967daa64a21823a6a2515405b860d9f7c1. You can [customize](https://app.ellipsis.dev/sheepdestroyer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Blocked unsafe file:// access in WebView and prevented path traversal to local files.

* **New Features**
  * Improved in-app web view scrolling and back-navigation behavior.
  * Added a JobBuilder-style API for more flexible sync job configuration.

* **Tests**
  * Added unit tests validating WebView file URL safety checks.

* **Documentation**
  * Added guidance on secure WebView file access and path validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->