### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in WebView file access

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,8 @@
+# Sentinel Journal
+
+## Security Learnings
+
+## 2024-05-21 - [WebView Path Traversal Vulnerability]
+**Vulnerability:** `setAllowFileAccess(true)` in `CacheableWebView` enables file access in `WebView`, allowing potentially malicious websites or XSS payloads to access local files via `file://` URLs.
+**Learning:** Even if `setAllowFileAccess` is necessary for specific functionality (like loading cached web archives), it exposes the entire filesystem to the `WebView` context.
+**Prevention:** Implement strict URL interception in `WebViewClient.shouldInterceptRequest` to validate and restrict all `file://` scheme requests. Only allow access to explicitly required directories, such as `android_asset/` and the application's specific cache directory. Use `getCanonicalPath()` to resolve paths and prevent directory traversal attacks (e.g., `file:///data/data/com.example/cache/../../shared_prefs/prefs.xml`). Always perform security checks before application logic (like ad blocking) to ensure protections are not bypassed by feature flags.

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
@@ -23,8 +23,10 @@ import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
-import java.util.HashMap;
+import java.io.File;
+import java.io.IOException;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import androidx.annotation.Nullable;
 import io.github.sheepdestroyer.materialisheep.AdBlocker;
@@ -32,15 +34,53 @@ import io.github.sheepdestroyer.materialisheep.AdBlocker;
 @SuppressWarnings("deprecation") // TODO: Uses deprecated WebResourceRequest API
 public class AdBlockWebViewClient extends WebViewClient {
     private final boolean mAdBlockEnabled;
-    private final Map<String, Boolean> mLoadedUrls = new HashMap<>();
+    private final Map<String, Boolean> mLoadedUrls = new ConcurrentHashMap<>();
 
     public AdBlockWebViewClient(boolean adBlockEnabled) {
         mAdBlockEnabled = adBlockEnabled;
     }
 
+    private boolean isSafeFileUrl(WebView view, String url) {
+        if (url == null || !url.startsWith("file://")) {
+            return true;
+        }
+        try {
+            String filePath = url.substring("file://".length());
+            if (filePath.startsWith("/android_asset/")) {
+                // Remove /android_asset/ prefix to canonicalize the relative path
+                // to make sure no directory traversal bypasses the asset folder
+                String relativePath = filePath.substring("/android_asset/".length());
+                File baseDir = new File("/android_asset/");
+                File assetFile = new File(baseDir, relativePath);
+                if (assetFile.getCanonicalPath().startsWith(baseDir.getCanonicalPath() + File.separator)) {
+                    return true;
+                }
+            }
+
+            File file = new File(filePath);
+            String canonicalPath = file.getCanonicalPath();
+            File cacheDir = view.getContext().getApplicationContext().getCacheDir();
+            if (cacheDir != null) {
+                String canonicalCacheDir = cacheDir.getCanonicalPath();
+                if (canonicalPath.startsWith(canonicalCacheDir + File.separator)) {
+                    return true;
+                }
+            }
+        } catch (IOException e) {
+            // Fallthrough to block
+        }
+        return false;
+    }
+
     @Override
     public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
+        if (!isSafeFileUrl(view, url)) {
+            return AdBlocker.createEmptyResource();
+        }
         if (!mAdBlockEnabled) {
+            return super.shouldInterceptRequest(view, url);
+        }
+        if (url == null) {
             return super.shouldInterceptRequest(view, url);
         }
         boolean ad;
@@ -56,11 +96,17 @@ public class AdBlockWebViewClient extends WebViewClient {
     @Nullable
     @Override
     public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+        String url = request.getUrl() != null ? request.getUrl().toString() : null;
+        if (!isSafeFileUrl(view, url)) {
+            return AdBlocker.createEmptyResource();
+        }
         if (!mAdBlockEnabled) {
             return super.shouldInterceptRequest(view, request);
         }
+        if (url == null) {
+            return super.shouldInterceptRequest(view, request);
+        }
         boolean ad;
-        String url = request.getUrl().toString();
         if (!mLoadedUrls.containsKey(url)) {
             ad = AdBlocker.isAd(url);
             mLoadedUrls.put(url, ad);

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
@@ -16,103 +16,99 @@
 
 package io.github.sheepdestroyer.materialisheep.widget;
 
-import android.annotation.TargetApi;
-import android.os.Build;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
-
+import androidx.annotation.Nullable;
+import io.github.sheepdestroyer.materialisheep.AdBlocker;
 import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import androidx.annotation.Nullable;
-import io.github.sheepdestroyer.materialisheep.AdBlocker;
-
 @SuppressWarnings("deprecation") // TODO: Uses deprecated WebResourceRequest API
 public class AdBlockWebViewClient extends WebViewClient {
-    private final boolean mAdBlockEnabled;
-    private final Map<String, Boolean> mLoadedUrls = new ConcurrentHashMap<>();
+  private final boolean mAdBlockEnabled;
+  private final Map<String, Boolean> mLoadedUrls = new ConcurrentHashMap<>();
 
-    public AdBlockWebViewClient(boolean adBlockEnabled) {
-        mAdBlockEnabled = adBlockEnabled;
+  public AdBlockWebViewClient(boolean adBlockEnabled) {
+    mAdBlockEnabled = adBlockEnabled;
+  }
+
+  private boolean isSafeFileUrl(WebView view, String url) {
+    if (url == null || !url.startsWith("file://")) {
+      return true;
     }
-
-    private boolean isSafeFileUrl(WebView view, String url) {
-        if (url == null || !url.startsWith("file://")) {
-            return true;
+    try {
+      String filePath = url.substring("file://".length());
+      if (filePath.startsWith("/android_asset/")) {
+        // Remove /android_asset/ prefix to canonicalize the relative path
+        // to make sure no directory traversal bypasses the asset folder
+        String relativePath = filePath.substring("/android_asset/".length());
+        File baseDir = new File("/android_asset/");
+        File assetFile = new File(baseDir, relativePath);
+        if (assetFile.getCanonicalPath().startsWith(baseDir.getCanonicalPath() + File.separator)) {
+          return true;
         }
-        try {
-            String filePath = url.substring("file://".length());
-            if (filePath.startsWith("/android_asset/")) {
-                // Remove /android_asset/ prefix to canonicalize the relative path
-                // to make sure no directory traversal bypasses the asset folder
-                String relativePath = filePath.substring("/android_asset/".length());
-                File baseDir = new File("/android_asset/");
-                File assetFile = new File(baseDir, relativePath);
-                if (assetFile.getCanonicalPath().startsWith(baseDir.getCanonicalPath() + File.separator)) {
-                    return true;
-                }
-            }
+      }
 
-            File file = new File(filePath);
-            String canonicalPath = file.getCanonicalPath();
-            File cacheDir = view.getContext().getApplicationContext().getCacheDir();
-            if (cacheDir != null) {
-                String canonicalCacheDir = cacheDir.getCanonicalPath();
-                if (canonicalPath.startsWith(canonicalCacheDir + File.separator)) {
-                    return true;
-                }
-            }
-        } catch (IOException e) {
-            // Fallthrough to block
+      File file = new File(filePath);
+      String canonicalPath = file.getCanonicalPath();
+      File cacheDir = view.getContext().getApplicationContext().getCacheDir();
+      if (cacheDir != null) {
+        String canonicalCacheDir = cacheDir.getCanonicalPath();
+        if (canonicalPath.startsWith(canonicalCacheDir + File.separator)) {
+          return true;
         }
-        return false;
+      }
+    } catch (IOException e) {
+      // Fallthrough to block
     }
+    return false;
+  }
 
-    @Override
-    public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
-        if (!isSafeFileUrl(view, url)) {
-            return AdBlocker.createEmptyResource();
-        }
-        if (!mAdBlockEnabled) {
-            return super.shouldInterceptRequest(view, url);
-        }
-        if (url == null) {
-            return super.shouldInterceptRequest(view, url);
-        }
-        boolean ad;
-        if (!mLoadedUrls.containsKey(url)) {
-            ad = AdBlocker.isAd(url);
-            mLoadedUrls.put(url, ad);
-        } else {
-            ad = mLoadedUrls.get(url);
-        }
-        return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, url);
+  @Override
+  public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
+    if (!isSafeFileUrl(view, url)) {
+      return AdBlocker.createEmptyResource();
     }
+    if (!mAdBlockEnabled) {
+      return super.shouldInterceptRequest(view, url);
+    }
+    if (url == null) {
+      return super.shouldInterceptRequest(view, url);
+    }
+    boolean ad;
+    if (!mLoadedUrls.containsKey(url)) {
+      ad = AdBlocker.isAd(url);
+      mLoadedUrls.put(url, ad);
+    } else {
+      ad = mLoadedUrls.get(url);
+    }
+    return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, url);
+  }
 
-    @Nullable
-    @Override
-    public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
-        String url = request.getUrl() != null ? request.getUrl().toString() : null;
-        if (!isSafeFileUrl(view, url)) {
-            return AdBlocker.createEmptyResource();
-        }
-        if (!mAdBlockEnabled) {
-            return super.shouldInterceptRequest(view, request);
-        }
-        if (url == null) {
-            return super.shouldInterceptRequest(view, request);
-        }
-        boolean ad;
-        if (!mLoadedUrls.containsKey(url)) {
-            ad = AdBlocker.isAd(url);
-            mLoadedUrls.put(url, ad);
-        } else {
-            ad = mLoadedUrls.get(url);
-        }
-        return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, request);
+  @Nullable
+  @Override
+  public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+    String url = request.getUrl() != null ? request.getUrl().toString() : null;
+    if (!isSafeFileUrl(view, url)) {
+      return AdBlocker.createEmptyResource();
     }
+    if (!mAdBlockEnabled) {
+      return super.shouldInterceptRequest(view, request);
+    }
+    if (url == null) {
+      return super.shouldInterceptRequest(view, request);
+    }
+    boolean ad;
+    if (!mLoadedUrls.containsKey(url)) {
+      ad = AdBlocker.isAd(url);
+      mLoadedUrls.put(url, ad);
+    } else {
+      ad = mLoadedUrls.get(url);
+    }
+    return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, request);
+  }
 }


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Path traversal vulnerability due to `setAllowFileAccess(true)` in `CacheableWebView`, exposing local files via `file://` scheme in `WebView`.
🎯 **Impact:** Malicious websites or XSS payloads could bypass protections and read sensitive local files, such as shared preferences, databases, or cached credentials.
🔧 **Fix:** Added `isSafeFileUrl` to `AdBlockWebViewClient` to strictly intercept and validate all `file://` URLs. The function uses `getCanonicalPath()` to ensure files are confined to safe directories (`android_asset` and the app cache directory), preventing `../` traversal attempts. Thread safety fixes for `mLoadedUrls` are also included.
✅ **Verification:** Ran `gradlew lint` and `gradlew test` to ensure stability and correctness. Code review issues resolved.

---
*PR created automatically by Jules for task [7911264786085500617](https://jules.google.com/task/7911264786085500617) started by @sheepdestroyer*

## Summary by Sourcery

Harden WebView file URL handling to prevent path traversal while keeping ad blocking behavior and thread safety intact.

Bug Fixes:
- Block unsafe file:// requests in WebView by validating paths and restricting access to android_asset and the app cache directory using canonical paths to prevent traversal outside allowed locations.

Enhancements:
- Make WebView URL tracking map thread-safe by switching to a concurrent implementation and add null-safety checks around intercepted request URLs.

Documentation:
- Add a Sentinel security journal entry documenting the WebView path traversal vulnerability, its root cause, and the adopted mitigation strategy.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes critical path traversal vulnerability in `CacheableWebView` by validating `file://` URLs in `AdBlockWebViewClient`.
> 
>   - **Security Fix**:
>     - Adds `isSafeFileUrl` in `AdBlockWebViewClient` to validate `file://` URLs, ensuring access is restricted to `android_asset` and app cache directories.
>     - Uses `getCanonicalPath()` to prevent directory traversal attacks.
>   - **Thread Safety**:
>     - Changes `mLoadedUrls` to `ConcurrentHashMap` in `AdBlockWebViewClient` for thread safety.
>   - **Misc**:
>     - Updates `shouldInterceptRequest` methods to use `isSafeFileUrl` for URL validation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=sheepdestroyer%2Fmaterialisheep&utm_source=github&utm_medium=referral)<sup> for 912c6cc2ea4cef6a7108ea4b2a9ac14e59bd16f1. You can [customize](https://app.ellipsis.dev/sheepdestroyer/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced WebView security with stricter file URL validation to prevent unauthorized file system access attempts
* Improved thread-safety of internal caching mechanisms for concurrent access scenarios
* Maintained ad-blocking functionality while strengthening overall security protections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->