### PR TITLE
⚡ Bolt: Optimize AdBlocker isAdHost to use iteration instead of recursion

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2023-10-27 - [Iterative AdBlocker Subdomain Matching]
+**Learning:** The `AdBlocker` domain matching logic should use an iterative approach (checking subdomains) rather than recursion to avoid stack frame instantiation overhead. Note that `substring()` still creates strings in both versions, but iteration removes stack growth.
+**Action:** Use an iterative while loop for string tokenization or substring checks on domain names.

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/AdBlocker.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/AdBlocker.java
@@ -92,15 +92,25 @@ public class AdBlocker {
     }
 
     /**
-     * Recursively walking up sub domain chain until we exhaust or find a match,
-     * effectively doing a longest substring matching here
+     * Iteratively walking up sub domain chain until we exhaust or find a match,
+     * effectively doing a longest substring matching here without recursion overhead.
      */
     private static boolean isAdHost(String host) {
         if (TextUtils.isEmpty(host)) {
             return false;
         }
         int index = host.indexOf(".");
-        return index >= 0 && (AD_HOSTS.contains(host) ||
-                index + 1 < host.length() && isAdHost(host.substring(index + 1)));
+        while (index >= 0) {
+            if (AD_HOSTS.contains(host)) {
+                return true;
+            }
+            if (index + 1 < host.length()) {
+                host = host.substring(index + 1);
+                index = host.indexOf(".");
+            } else {
+                break;
+            }
+        }
+        return false;
     }
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/AdBlocker.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/AdBlocker.java
@@ -17,100 +17,94 @@
 package io.github.sheepdestroyer.materialisheep;
 
 import android.annotation.SuppressLint;
-import android.annotation.TargetApi;
 import android.content.Context;
-import android.os.Build;
-import androidx.annotation.WorkerThread;
 import android.text.TextUtils;
 import android.webkit.WebResourceResponse;
-
+import androidx.annotation.WorkerThread;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Scheduler;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashSet;
 import java.util.Set;
-
 import okhttp3.HttpUrl;
 import okio.BufferedSource;
 import okio.Okio;
-import io.reactivex.rxjava3.core.Observable;
-import io.reactivex.rxjava3.core.Scheduler;
 
-/**
- * A simple ad blocker that blocks network requests to hosts listed in the ad
- * hosts file.
- */
+/** A simple ad blocker that blocks network requests to hosts listed in the ad hosts file. */
 public class AdBlocker {
-    private static final String AD_HOSTS_FILE = "pgl.yoyo.org.txt";
-    private static final Set<String> AD_HOSTS = java.util.Collections.synchronizedSet(new HashSet<>());
+  private static final String AD_HOSTS_FILE = "pgl.yoyo.org.txt";
+  private static final Set<String> AD_HOSTS =
+      java.util.Collections.synchronizedSet(new HashSet<>());
 
-    /**
-     * Initializes the ad blocker by loading the ad hosts from the assets file.
-     *
-     * @param context   The application context.
-     * @param scheduler The RxJava scheduler to perform the operation on.
-     */
-    @SuppressLint("CheckResult")
-    public static void init(Context context, Scheduler scheduler) {
-        Observable.fromCallable(() -> loadFromAssets(context))
-                .subscribeOn(scheduler)
-                .subscribe(result -> {
-                },
-                        t -> android.util.Log.e(AdBlocker.class.getSimpleName(), "Error loading ad hosts", t));
+  /**
+   * Initializes the ad blocker by loading the ad hosts from the assets file.
+   *
+   * @param context The application context.
+   * @param scheduler The RxJava scheduler to perform the operation on.
+   */
+  @SuppressLint("CheckResult")
+  public static void init(Context context, Scheduler scheduler) {
+    Observable.fromCallable(() -> loadFromAssets(context))
+        .subscribeOn(scheduler)
+        .subscribe(
+            result -> {},
+            t -> android.util.Log.e(AdBlocker.class.getSimpleName(), "Error loading ad hosts", t));
+  }
+
+  /**
+   * Checks if a given URL is an ad.
+   *
+   * @param url The URL to check.
+   * @return True if the URL is an ad, false otherwise.
+   */
+  public static boolean isAd(String url) {
+    HttpUrl httpUrl = HttpUrl.parse(url);
+    return isAdHost(httpUrl != null ? httpUrl.host() : "");
+  }
+
+  /**
+   * Creates an empty WebResourceResponse to block a network request.
+   *
+   * @return An empty WebResourceResponse.
+   */
+  public static WebResourceResponse createEmptyResource() {
+    return new WebResourceResponse("text/plain", "utf-8", new ByteArrayInputStream("".getBytes()));
+  }
+
+  @WorkerThread
+  private static Boolean loadFromAssets(Context context) throws IOException {
+    try (InputStream stream = context.getAssets().open(AD_HOSTS_FILE);
+        BufferedSource buffer = Okio.buffer(Okio.source(stream))) {
+      String line;
+      while ((line = buffer.readUtf8Line()) != null) {
+        AD_HOSTS.add(line);
+      }
     }
+    return true;
+  }
 
-    /**
-     * Checks if a given URL is an ad.
-     *
-     * @param url The URL to check.
-     * @return True if the URL is an ad, false otherwise.
-     */
-    public static boolean isAd(String url) {
-        HttpUrl httpUrl = HttpUrl.parse(url);
-        return isAdHost(httpUrl != null ? httpUrl.host() : "");
+  /**
+   * Iteratively walking up sub domain chain until we exhaust or find a match, effectively doing a
+   * longest substring matching here without recursion overhead.
+   */
+  private static boolean isAdHost(String host) {
+    if (TextUtils.isEmpty(host)) {
+      return false;
     }
-
-    /**
-     * Creates an empty WebResourceResponse to block a network request.
-     *
-     * @return An empty WebResourceResponse.
-     */
-    public static WebResourceResponse createEmptyResource() {
-        return new WebResourceResponse("text/plain", "utf-8", new ByteArrayInputStream("".getBytes()));
-    }
-
-    @WorkerThread
-    private static Boolean loadFromAssets(Context context) throws IOException {
-        try (InputStream stream = context.getAssets().open(AD_HOSTS_FILE);
-                BufferedSource buffer = Okio.buffer(Okio.source(stream))) {
-            String line;
-            while ((line = buffer.readUtf8Line()) != null) {
-                AD_HOSTS.add(line);
-            }
-        }
+    int index = host.indexOf(".");
+    while (index >= 0) {
+      if (AD_HOSTS.contains(host)) {
         return true;
+      }
+      if (index + 1 < host.length()) {
+        host = host.substring(index + 1);
+        index = host.indexOf(".");
+      } else {
+        break;
+      }
     }
-
-    /**
-     * Iteratively walking up sub domain chain until we exhaust or find a match,
-     * effectively doing a longest substring matching here without recursion overhead.
-     */
-    private static boolean isAdHost(String host) {
-        if (TextUtils.isEmpty(host)) {
-            return false;
-        }
-        int index = host.indexOf(".");
-        while (index >= 0) {
-            if (AD_HOSTS.contains(host)) {
-                return true;
-            }
-            if (index + 1 < host.length()) {
-                host = host.substring(index + 1);
-                index = host.indexOf(".");
-            } else {
-                break;
-            }
-        }
-        return false;
-    }
+    return false;
+  }
 }


### PR DESCRIPTION
💡 What: Replaced the recursive `isAdHost` matching in `AdBlocker.java` with an iterative `while` loop that sequentially truncates subdomains.
🎯 Why: Subdomain matching checks previously relied on recursion which adds overhead from instantiating new call stack frames on each subdomain block match.
📊 Impact: Decreases JVM stack-growth overhead during URL evaluations. Reduces method-call overhead. 
🔬 Measurement: Run unit tests/Robolectric tests for `AdBlocker` components or benchmark recursive versus iterative string parsing loops in JVM (the behavior logic is identical). Tested via `./gradlew testDebugUnitTest` ensuring bounds matching constraints on ad blocking logic remain unchanged.

---
*PR created automatically by Jules for task [3028186141488567354](https://jules.google.com/task/3028186141488567354) started by @sheepdestroyer*

## Summary by Sourcery

Optimize ad host detection by replacing recursive subdomain matching with an iterative approach.

Enhancements:
- Replace recursive ad host subdomain matching with an iterative loop to reduce stack and call overhead while preserving behavior.

Documentation:
- Add an internal Bolt note documenting the decision to use iterative subdomain matching instead of recursion for AdBlocker domain checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation describing iterative subdomain matching approach for ad blocking.

* **Refactor**
  * Optimized subdomain matching in ad blocker to use iteration instead of recursion, reducing stack overhead while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->