### PR TITLE
⚡ Bolt: [performance improvement] Optimize AdBlocker operations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+
+## 2024-05-28 - Optimize AdBlocker operations
+**Learning:** Initializing synchronized collections (like `Collections.synchronizedSet` or `ConcurrentHashMap` sets) item-by-item causes significant lock contention. Furthermore, using recursive functions for domain matching adds unnecessary stack frame instantiation overhead.
+**Action:** Populate a local collection first and use `addAll` for bulk initialization to minimize lock contention. For read-heavy static sets, use `Collections.newSetFromMap(new ConcurrentHashMap<>())` instead of `Collections.synchronizedSet`. Lastly, convert recursive operations to iterative loops when possible to avoid stack growth.

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/AdBlocker.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/AdBlocker.java
@@ -17,13 +17,12 @@
 package io.github.sheepdestroyer.materialisheep;
 
 import android.annotation.SuppressLint;
-import android.annotation.TargetApi;
 import android.content.Context;
-import android.os.Build;
-import androidx.annotation.WorkerThread;
 import android.text.TextUtils;
 import android.webkit.WebResourceResponse;
-
+import androidx.annotation.WorkerThread;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Scheduler;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -31,92 +30,87 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-
 import okhttp3.HttpUrl;
 import okio.BufferedSource;
 import okio.Okio;
-import io.reactivex.rxjava3.core.Observable;
-import io.reactivex.rxjava3.core.Scheduler;
 
-/**
- * A simple ad blocker that blocks network requests to hosts listed in the ad
- * hosts file.
- */
+/** A simple ad blocker that blocks network requests to hosts listed in the ad hosts file. */
 public class AdBlocker {
-    private static final String AD_HOSTS_FILE = "pgl.yoyo.org.txt";
-    private static final Set<String> AD_HOSTS = Collections.newSetFromMap(new ConcurrentHashMap<>());
-    private static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
+  private static final String AD_HOSTS_FILE = "pgl.yoyo.org.txt";
+  private static final Set<String> AD_HOSTS = Collections.newSetFromMap(new ConcurrentHashMap<>());
+  private static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
 
-    /**
-     * Initializes the ad blocker by loading the ad hosts from the assets file.
-     *
-     * @param context   The application context.
-     * @param scheduler The RxJava scheduler to perform the operation on.
-     */
-    @SuppressLint("CheckResult")
-    public static void init(Context context, Scheduler scheduler) {
-        Observable.fromCallable(() -> loadFromAssets(context))
-                .subscribeOn(scheduler)
-                .subscribe(result -> {
-                },
-                        t -> android.util.Log.e(AdBlocker.class.getSimpleName(), "Error loading ad hosts", t));
+  /**
+   * Initializes the ad blocker by loading the ad hosts from the assets file.
+   *
+   * @param context The application context.
+   * @param scheduler The RxJava scheduler to perform the operation on.
+   */
+  @SuppressLint("CheckResult")
+  public static void init(Context context, Scheduler scheduler) {
+    Observable.fromCallable(() -> loadFromAssets(context))
+        .subscribeOn(scheduler)
+        .subscribe(
+            result -> {},
+            t -> android.util.Log.e(AdBlocker.class.getSimpleName(), "Error loading ad hosts", t));
+  }
+
+  /**
+   * Checks if a given URL is an ad.
+   *
+   * @param url The URL to check.
+   * @return True if the URL is an ad, false otherwise.
+   */
+  public static boolean isAd(String url) {
+    HttpUrl httpUrl = HttpUrl.parse(url);
+    return isAdHost(httpUrl != null ? httpUrl.host() : "");
+  }
+
+  /**
+   * Creates an empty WebResourceResponse to block a network request.
+   *
+   * @return An empty WebResourceResponse.
+   */
+  public static WebResourceResponse createEmptyResource() {
+    return new WebResourceResponse(
+        "text/plain", "utf-8", new ByteArrayInputStream(EMPTY_BYTE_ARRAY));
+  }
+
+  @WorkerThread
+  private static Boolean loadFromAssets(Context context) throws IOException {
+    try (InputStream stream = context.getAssets().open(AD_HOSTS_FILE);
+        BufferedSource buffer = Okio.buffer(Okio.source(stream))) {
+      String line;
+      Set<String> localHosts = new HashSet<>();
+      while ((line = buffer.readUtf8Line()) != null) {
+        localHosts.add(line);
+      }
+      AD_HOSTS.addAll(localHosts);
+    }
+    return true;
+  }
+
+  /**
+   * Iteratively walking up sub domain chain until we exhaust or find a match, effectively doing a
+   * longest substring matching here
+   */
+  private static boolean isAdHost(String host) {
+    if (TextUtils.isEmpty(host)) {
+      return false;
     }
 
-    /**
-     * Checks if a given URL is an ad.
-     *
-     * @param url The URL to check.
-     * @return True if the URL is an ad, false otherwise.
-     */
-    public static boolean isAd(String url) {
-        HttpUrl httpUrl = HttpUrl.parse(url);
-        return isAdHost(httpUrl != null ? httpUrl.host() : "");
-    }
-
-    /**
-     * Creates an empty WebResourceResponse to block a network request.
-     *
-     * @return An empty WebResourceResponse.
-     */
-    public static WebResourceResponse createEmptyResource() {
-        return new WebResourceResponse("text/plain", "utf-8", new ByteArrayInputStream(EMPTY_BYTE_ARRAY));
-    }
-
-    @WorkerThread
-    private static Boolean loadFromAssets(Context context) throws IOException {
-        try (InputStream stream = context.getAssets().open(AD_HOSTS_FILE);
-                BufferedSource buffer = Okio.buffer(Okio.source(stream))) {
-            String line;
-            Set<String> localHosts = new HashSet<>();
-            while ((line = buffer.readUtf8Line()) != null) {
-                localHosts.add(line);
-            }
-            AD_HOSTS.addAll(localHosts);
-        }
+    String currentHost = host;
+    while (!TextUtils.isEmpty(currentHost)) {
+      if (AD_HOSTS.contains(currentHost)) {
         return true;
+      }
+      int index = currentHost.indexOf(".");
+      if (index >= 0 && index + 1 < currentHost.length()) {
+        currentHost = currentHost.substring(index + 1);
+      } else {
+        break;
+      }
     }
-
-    /**
-     * Iteratively walking up sub domain chain until we exhaust or find a match,
-     * effectively doing a longest substring matching here
-     */
-    private static boolean isAdHost(String host) {
-        if (TextUtils.isEmpty(host)) {
-            return false;
-        }
-
-        String currentHost = host;
-        while (!TextUtils.isEmpty(currentHost)) {
-            if (AD_HOSTS.contains(currentHost)) {
-                return true;
-            }
-            int index = currentHost.indexOf(".");
-            if (index >= 0 && index + 1 < currentHost.length()) {
-                currentHost = currentHost.substring(index + 1);
-            } else {
-                break;
-            }
-        }
-        return false;
-    }
+    return false;
+  }
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/AdBlocker.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/AdBlocker.java
@@ -27,8 +27,10 @@ import android.webkit.WebResourceResponse;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import okhttp3.HttpUrl;
 import okio.BufferedSource;
@@ -42,7 +44,8 @@ import io.reactivex.rxjava3.core.Scheduler;
  */
 public class AdBlocker {
     private static final String AD_HOSTS_FILE = "pgl.yoyo.org.txt";
-    private static final Set<String> AD_HOSTS = java.util.Collections.synchronizedSet(new HashSet<>());
+    private static final Set<String> AD_HOSTS = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    private static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
 
     /**
      * Initializes the ad blocker by loading the ad hosts from the assets file.
@@ -76,7 +79,7 @@ public class AdBlocker {
      * @return An empty WebResourceResponse.
      */
     public static WebResourceResponse createEmptyResource() {
-        return new WebResourceResponse("text/plain", "utf-8", new ByteArrayInputStream("".getBytes()));
+        return new WebResourceResponse("text/plain", "utf-8", new ByteArrayInputStream(EMPTY_BYTE_ARRAY));
     }
 
     @WorkerThread
@@ -84,23 +87,36 @@ public class AdBlocker {
         try (InputStream stream = context.getAssets().open(AD_HOSTS_FILE);
                 BufferedSource buffer = Okio.buffer(Okio.source(stream))) {
             String line;
+            Set<String> localHosts = new HashSet<>();
             while ((line = buffer.readUtf8Line()) != null) {
-                AD_HOSTS.add(line);
+                localHosts.add(line);
             }
+            AD_HOSTS.addAll(localHosts);
         }
         return true;
     }
 
     /**
-     * Recursively walking up sub domain chain until we exhaust or find a match,
+     * Iteratively walking up sub domain chain until we exhaust or find a match,
      * effectively doing a longest substring matching here
      */
     private static boolean isAdHost(String host) {
         if (TextUtils.isEmpty(host)) {
             return false;
         }
-        int index = host.indexOf(".");
-        return index >= 0 && (AD_HOSTS.contains(host) ||
-                index + 1 < host.length() && isAdHost(host.substring(index + 1)));
+
+        String currentHost = host;
+        while (!TextUtils.isEmpty(currentHost)) {
+            if (AD_HOSTS.contains(currentHost)) {
+                return true;
+            }
+            int index = currentHost.indexOf(".");
+            if (index >= 0 && index + 1 < currentHost.length()) {
+                currentHost = currentHost.substring(index + 1);
+            } else {
+                break;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
💡 **What:** 
- Modified `AD_HOSTS` to use a `ConcurrentHashMap`-backed Set instead of `Collections.synchronizedSet`.
- Updated `loadFromAssets` to populate a local `HashSet` before bulk adding to `AD_HOSTS`.
- Cached a static `EMPTY_BYTE_ARRAY` for `createEmptyResource`.
- Refactored `isAdHost` to use an iterative loop instead of a recursive method.
- Documented these optimizations in `.jules/bolt.md`.

🎯 **Why:**
- `synchronizedSet` uses coarse-grained locks on every read (like `.contains()`), which are frequent in ad-blockers. `ConcurrentHashMap` enables concurrent lock-free reads.
- Initializing synchronized collections item-by-item causes severe lock contention. Populating a local collection first and using `addAll` is much faster.
- Allocating a new `byte[0]` and running UTF-8 string encoding on every blocked request creates unnecessary garbage collection pressure.
- Recursive algorithms create stack frames for each call, creating unnecessary overhead compared to iterative loops.

📊 **Impact:** 
- Significantly reduces lock contention during AdBlocker initialization.
- Reduces memory allocations and GC pressure for every blocked network request.
- Eliminates stack frame instantiation overhead during domain matching.
- Enables concurrent lock-free reading for ad host verification.

🔬 **Measurement:** 
- Run tests (`./gradlew clean testDebugUnitTest`) to verify no regressions were introduced.
- Review memory profiling during initialization and heavy ad-blocking scenarios to see reduced allocation rates and lock wait times.

---
*PR created automatically by Jules for task [13952415159026487943](https://jules.google.com/task/13952415159026487943) started by @sheepdestroyer*

## Summary by Sourcery

Optimize AdBlocker performance and memory usage during host loading and request handling.

Enhancements:
- Use a ConcurrentHashMap-backed set for ad host storage to improve concurrent read performance.
- Bulk-load ad host entries via a local HashSet before adding them to the shared set to reduce lock contention.
- Reuse a cached empty byte array when creating empty WebResourceResponse instances to reduce allocations and GC pressure.
- Replace recursive ad host matching with an iterative loop to avoid stack overhead and improve efficiency.

Documentation:
- Document the AdBlocker performance optimizations and related learnings in .jules/bolt.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored and optimized internal ad-blocking operations with concurrent data structures and improved algorithms for enhanced performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->