### PR TITLE
🛡️ Sentinel: [HIGH] Fix directory traversal and secure file:// access in WebView

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-03-13 - Fix directory traversal and secure file:// access in WebView
+**Vulnerability:** WebView allowed loading `file://` URLs which exposed local file system due to `setAllowFileAccess(true)` in `CacheableWebView`, creating a directory traversal vulnerability because of insufficient validation in `AdBlockWebViewClient`.
+**Learning:** Canonical paths must be checked rigorously when intercepting local file accesses in WebViews. `getCanonicalPath()` checks alone are insufficient if they do not append a `File.separator` to the base directory path, as this could allow partial directory name bypasses.
+**Prevention:** Always append `File.separator` to the base directory's canonical path before using `startsWith()` for validation to ensure the file is strictly within the intended directory.

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
@@ -23,26 +23,70 @@ import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
-import java.util.HashMap;
+import java.io.File;
+import java.io.IOException;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
+import android.net.Uri;
 import androidx.annotation.Nullable;
 import io.github.sheepdestroyer.materialisheep.AdBlocker;
 
-@SuppressWarnings("deprecation") // TODO: Uses deprecated WebResourceRequest API
+@SuppressWarnings("deprecation")
 public class AdBlockWebViewClient extends WebViewClient {
     private final boolean mAdBlockEnabled;
-    private final Map<String, Boolean> mLoadedUrls = new HashMap<>();
+    private final Map<String, Boolean> mLoadedUrls = new ConcurrentHashMap<>();
 
     public AdBlockWebViewClient(boolean adBlockEnabled) {
         mAdBlockEnabled = adBlockEnabled;
     }
 
+    private WebResourceResponse handleFileRequest(WebView view, String url) {
+        Uri uri = Uri.parse(url);
+        if ("file".equals(uri.getScheme())) {
+            try {
+                String path = uri.getPath();
+                if (path == null) {
+                    return AdBlocker.createEmptyResource();
+                }
+
+                // Allow android_asset
+                if (path.startsWith("/android_asset/")) {
+                    return null;
+                }
+
+                File cacheFile = new File(path);
+                String canonicalCacheDir = view.getContext().getApplicationContext().getCacheDir().getCanonicalPath() + File.separator;
+
+                if (cacheFile.getCanonicalPath().startsWith(canonicalCacheDir)
+                        && cacheFile.exists() && cacheFile.getName().startsWith(CacheableWebView.CACHE_PREFIX)
+                        && cacheFile.getName().endsWith(CacheableWebView.CACHE_EXTENSION)) {
+                    return null; // Valid cache file, let WebView load it natively
+                } else {
+                    return AdBlocker.createEmptyResource(); // Block any unauthorized file access
+                }
+            } catch (IOException e) {
+                return AdBlocker.createEmptyResource();
+            }
+        }
+        return null; // Not a file request, continue normal processing
+    }
+
     @Override
     public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
+        if (url == null) {
+            return super.shouldInterceptRequest(view, url);
+        }
+
+        WebResourceResponse fileResponse = handleFileRequest(view, url);
+        if (fileResponse != null) {
+            return fileResponse;
+        }
+
         if (!mAdBlockEnabled) {
             return super.shouldInterceptRequest(view, url);
         }
+
         boolean ad;
         if (!mLoadedUrls.containsKey(url)) {
             ad = AdBlocker.isAd(url);
@@ -56,11 +100,22 @@ public class AdBlockWebViewClient extends WebViewClient {
     @Nullable
     @Override
     public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+        if (request == null || request.getUrl() == null) {
+            return super.shouldInterceptRequest(view, request);
+        }
+
+        String url = request.getUrl().toString();
+
+        WebResourceResponse fileResponse = handleFileRequest(view, url);
+        if (fileResponse != null) {
+            return fileResponse;
+        }
+
         if (!mAdBlockEnabled) {
             return super.shouldInterceptRequest(view, request);
         }
+
         boolean ad;
-        String url = request.getUrl().toString();
         if (!mLoadedUrls.containsKey(url)) {
             ad = AdBlocker.isAd(url);
             mLoadedUrls.put(url, ad);

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
@@ -16,112 +16,111 @@
 
 package io.github.sheepdestroyer.materialisheep.widget;
 
-import android.annotation.TargetApi;
-import android.os.Build;
+import android.net.Uri;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
-
+import androidx.annotation.Nullable;
+import io.github.sheepdestroyer.materialisheep.AdBlocker;
 import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import android.net.Uri;
-import androidx.annotation.Nullable;
-import io.github.sheepdestroyer.materialisheep.AdBlocker;
-
 @SuppressWarnings("deprecation")
 public class AdBlockWebViewClient extends WebViewClient {
-    private final boolean mAdBlockEnabled;
-    private final Map<String, Boolean> mLoadedUrls = new ConcurrentHashMap<>();
+  private final boolean mAdBlockEnabled;
+  private final Map<String, Boolean> mLoadedUrls = new ConcurrentHashMap<>();
 
-    public AdBlockWebViewClient(boolean adBlockEnabled) {
-        mAdBlockEnabled = adBlockEnabled;
-    }
+  public AdBlockWebViewClient(boolean adBlockEnabled) {
+    mAdBlockEnabled = adBlockEnabled;
+  }
 
-    private WebResourceResponse handleFileRequest(WebView view, String url) {
-        Uri uri = Uri.parse(url);
-        if ("file".equals(uri.getScheme())) {
-            try {
-                String path = uri.getPath();
-                if (path == null) {
-                    return AdBlocker.createEmptyResource();
-                }
-
-                // Allow android_asset
-                if (path.startsWith("/android_asset/")) {
-                    return null;
-                }
-
-                File cacheFile = new File(path);
-                String canonicalCacheDir = view.getContext().getApplicationContext().getCacheDir().getCanonicalPath() + File.separator;
-
-                if (cacheFile.getCanonicalPath().startsWith(canonicalCacheDir)
-                        && cacheFile.exists() && cacheFile.getName().startsWith(CacheableWebView.CACHE_PREFIX)
-                        && cacheFile.getName().endsWith(CacheableWebView.CACHE_EXTENSION)) {
-                    return null; // Valid cache file, let WebView load it natively
-                } else {
-                    return AdBlocker.createEmptyResource(); // Block any unauthorized file access
-                }
-            } catch (IOException e) {
-                return AdBlocker.createEmptyResource();
-            }
-        }
-        return null; // Not a file request, continue normal processing
-    }
-
-    @Override
-    public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
-        if (url == null) {
-            return super.shouldInterceptRequest(view, url);
+  private WebResourceResponse handleFileRequest(WebView view, String url) {
+    Uri uri = Uri.parse(url);
+    if ("file".equals(uri.getScheme())) {
+      try {
+        String path = uri.getPath();
+        if (path == null) {
+          return AdBlocker.createEmptyResource();
         }
 
-        WebResourceResponse fileResponse = handleFileRequest(view, url);
-        if (fileResponse != null) {
-            return fileResponse;
+        // Allow android_asset
+        if (path.startsWith("/android_asset/")) {
+          return null;
         }
 
-        if (!mAdBlockEnabled) {
-            return super.shouldInterceptRequest(view, url);
-        }
+        File cacheFile = new File(path);
+        String canonicalCacheDir =
+            view.getContext().getApplicationContext().getCacheDir().getCanonicalPath()
+                + File.separator;
 
-        boolean ad;
-        if (!mLoadedUrls.containsKey(url)) {
-            ad = AdBlocker.isAd(url);
-            mLoadedUrls.put(url, ad);
+        if (cacheFile.getCanonicalPath().startsWith(canonicalCacheDir)
+            && cacheFile.exists()
+            && cacheFile.getName().startsWith(CacheableWebView.CACHE_PREFIX)
+            && cacheFile.getName().endsWith(CacheableWebView.CACHE_EXTENSION)) {
+          return null; // Valid cache file, let WebView load it natively
         } else {
-            ad = mLoadedUrls.get(url);
+          return AdBlocker.createEmptyResource(); // Block any unauthorized file access
         }
-        return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, url);
+      } catch (IOException e) {
+        return AdBlocker.createEmptyResource();
+      }
+    }
+    return null; // Not a file request, continue normal processing
+  }
+
+  @Override
+  public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
+    if (url == null) {
+      return super.shouldInterceptRequest(view, url);
     }
 
-    @Nullable
-    @Override
-    public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
-        if (request == null || request.getUrl() == null) {
-            return super.shouldInterceptRequest(view, request);
-        }
-
-        String url = request.getUrl().toString();
-
-        WebResourceResponse fileResponse = handleFileRequest(view, url);
-        if (fileResponse != null) {
-            return fileResponse;
-        }
-
-        if (!mAdBlockEnabled) {
-            return super.shouldInterceptRequest(view, request);
-        }
-
-        boolean ad;
-        if (!mLoadedUrls.containsKey(url)) {
-            ad = AdBlocker.isAd(url);
-            mLoadedUrls.put(url, ad);
-        } else {
-            ad = mLoadedUrls.get(url);
-        }
-        return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, request);
+    WebResourceResponse fileResponse = handleFileRequest(view, url);
+    if (fileResponse != null) {
+      return fileResponse;
     }
+
+    if (!mAdBlockEnabled) {
+      return super.shouldInterceptRequest(view, url);
+    }
+
+    boolean ad;
+    if (!mLoadedUrls.containsKey(url)) {
+      ad = AdBlocker.isAd(url);
+      mLoadedUrls.put(url, ad);
+    } else {
+      ad = mLoadedUrls.get(url);
+    }
+    return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, url);
+  }
+
+  @Nullable
+  @Override
+  public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+    if (request == null || request.getUrl() == null) {
+      return super.shouldInterceptRequest(view, request);
+    }
+
+    String url = request.getUrl().toString();
+
+    WebResourceResponse fileResponse = handleFileRequest(view, url);
+    if (fileResponse != null) {
+      return fileResponse;
+    }
+
+    if (!mAdBlockEnabled) {
+      return super.shouldInterceptRequest(view, request);
+    }
+
+    boolean ad;
+    if (!mLoadedUrls.containsKey(url)) {
+      ad = AdBlocker.isAd(url);
+      mLoadedUrls.put(url, ad);
+    } else {
+      ad = mLoadedUrls.get(url);
+    }
+    return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, request);
+  }
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/CacheableWebView.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/CacheableWebView.java
@@ -33,8 +33,8 @@ import java.util.Map;
 import io.github.sheepdestroyer.materialisheep.AppUtils;
 
 public class CacheableWebView extends WebView {
-    private static final String CACHE_PREFIX = "webarchive-";
-    private static final String CACHE_EXTENSION = ".mht";
+    static final String CACHE_PREFIX = "webarchive-";
+    static final String CACHE_EXTENSION = ".mht";
     private ArchiveClient mArchiveClient = new ArchiveClient();
 
     public CacheableWebView(Context context) {

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/CacheableWebView.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/CacheableWebView.java
@@ -19,149 +19,145 @@ package io.github.sheepdestroyer.materialisheep.widget;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.net.Uri;
-
-import androidx.annotation.CallSuper;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
 import android.webkit.WebViewClient;
-
+import androidx.annotation.CallSuper;
+import io.github.sheepdestroyer.materialisheep.AppUtils;
 import java.io.File;
 import java.util.Map;
 
-import io.github.sheepdestroyer.materialisheep.AppUtils;
-
 public class CacheableWebView extends WebView {
-    static final String CACHE_PREFIX = "webarchive-";
-    static final String CACHE_EXTENSION = ".mht";
-    private ArchiveClient mArchiveClient = new ArchiveClient();
+  static final String CACHE_PREFIX = "webarchive-";
+  static final String CACHE_EXTENSION = ".mht";
+  private ArchiveClient mArchiveClient = new ArchiveClient();
 
-    public CacheableWebView(Context context) {
-        this(context, null);
+  public CacheableWebView(Context context) {
+    this(context, null);
+  }
+
+  public CacheableWebView(Context context, AttributeSet attrs) {
+    this(context, attrs, 0);
+  }
+
+  public CacheableWebView(Context context, AttributeSet attrs, int defStyleAttr) {
+    super(context, attrs, defStyleAttr);
+    init();
+  }
+
+  @Override
+  public void reloadUrl(String url) {
+    super.reloadUrl(getCacheableUrl(url));
+  }
+
+  @Override
+  public void loadUrl(String url) {
+    if (TextUtils.isEmpty(url)) {
+      return;
     }
+    mArchiveClient.lastProgress = 0;
+    super.loadUrl(getCacheableUrl(url));
+  }
 
-    public CacheableWebView(Context context, AttributeSet attrs) {
-        this(context, attrs, 0);
+  @Override
+  public void loadUrl(String url, Map<String, String> additionalHttpHeaders) {
+    if (TextUtils.isEmpty(url)) {
+      return;
     }
+    mArchiveClient.lastProgress = 0;
+    super.loadUrl(getCacheableUrl(url), additionalHttpHeaders);
+  }
 
-    public CacheableWebView(Context context, AttributeSet attrs, int defStyleAttr) {
-        super(context, attrs, defStyleAttr);
-        init();
+  @Override
+  public void setWebChromeClient(WebChromeClient client) {
+    if (!(client instanceof ArchiveClient)) {
+      throw new IllegalArgumentException(
+          "client should be an instance of " + ArchiveClient.class.getName());
     }
+    mArchiveClient = (ArchiveClient) client;
+    super.setWebChromeClient(mArchiveClient);
+  }
 
+  private void init() {
+    enableCache();
+    setLoadSettings();
+    setWebViewClient(new WebViewClient());
+    setWebChromeClient(mArchiveClient);
+  }
+
+  private void enableCache() {
+    WebSettings webSettings = getSettings();
+    webSettings.setAllowFileAccess(true);
+    setCacheModeInternal();
+  }
+
+  private void setCacheModeInternal() {
+    getSettings().setCacheMode(WebSettings.LOAD_CACHE_ELSE_NETWORK);
+  }
+
+  @SuppressLint("SetJavaScriptEnabled")
+  private void setLoadSettings() {
+    WebSettings webSettings = getSettings();
+    webSettings.setLoadWithOverviewMode(true);
+    webSettings.setUseWideViewPort(true);
+    webSettings.setJavaScriptEnabled(true);
+  }
+
+  private String getCacheableUrl(String url) {
+    if (TextUtils.equals(url, BLANK) || TextUtils.equals(url, FILE)) {
+      mArchiveClient.cacheFileName = null;
+      return url;
+    }
+    mArchiveClient.cacheFileName = generateCacheFilename(url);
+    setCacheModeInternal();
+    File cacheFile = new File(mArchiveClient.cacheFileName);
+    if (cacheFile.exists() && !AppUtils.hasConnection(getContext())) {
+      getSettings().setCacheMode(WebSettings.LOAD_CACHE_ONLY);
+      return Uri.fromFile(cacheFile).toString();
+    }
+    return url;
+  }
+
+  private String generateCacheFilename(String url) {
+    String name;
+    try {
+      java.security.MessageDigest digest = java.security.MessageDigest.getInstance("SHA-256");
+      byte[] hash = digest.digest(url.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+      StringBuilder hexString = new StringBuilder();
+      for (byte b : hash) {
+        String hex = Integer.toHexString(0xff & b);
+        if (hex.length() == 1) {
+          hexString.append('0');
+        }
+        hexString.append(hex);
+      }
+      name = hexString.toString();
+    } catch (java.security.NoSuchAlgorithmException e) {
+      name = String.valueOf(url.hashCode());
+    }
+    return getContext().getApplicationContext().getCacheDir().getAbsolutePath()
+        + File.separator
+        + CACHE_PREFIX
+        + name
+        + CACHE_EXTENSION;
+  }
+
+  public static class ArchiveClient extends WebChromeClient {
+    int lastProgress = 0;
+    String cacheFileName = null;
+
+    @CallSuper
     @Override
-    public void reloadUrl(String url) {
-        super.reloadUrl(getCacheableUrl(url));
+    public void onProgressChanged(android.webkit.WebView view, int newProgress) {
+      if (view.getSettings().getCacheMode() == WebSettings.LOAD_CACHE_ONLY) {
+        return;
+      }
+      if (cacheFileName != null && lastProgress != 100 && newProgress == 100) {
+        lastProgress = newProgress;
+        view.saveWebArchive(cacheFileName);
+      }
     }
-
-    @Override
-    public void loadUrl(String url) {
-        if (TextUtils.isEmpty(url)) {
-            return;
-        }
-        mArchiveClient.lastProgress = 0;
-        super.loadUrl(getCacheableUrl(url));
-    }
-
-    @Override
-    public void loadUrl(String url, Map<String, String> additionalHttpHeaders) {
-        if (TextUtils.isEmpty(url)) {
-            return;
-        }
-        mArchiveClient.lastProgress = 0;
-        super.loadUrl(getCacheableUrl(url), additionalHttpHeaders);
-    }
-
-    @Override
-    public void setWebChromeClient(WebChromeClient client) {
-        if (!(client instanceof ArchiveClient)) {
-            throw new IllegalArgumentException("client should be an instance of " +
-                    ArchiveClient.class.getName());
-        }
-        mArchiveClient = (ArchiveClient) client;
-        super.setWebChromeClient(mArchiveClient);
-    }
-
-    private void init() {
-        enableCache();
-        setLoadSettings();
-        setWebViewClient(new WebViewClient());
-        setWebChromeClient(mArchiveClient);
-    }
-
-    private void enableCache() {
-        WebSettings webSettings = getSettings();
-        webSettings.setAllowFileAccess(true);
-        setCacheModeInternal();
-    }
-
-    private void setCacheModeInternal() {
-        getSettings().setCacheMode(WebSettings.LOAD_CACHE_ELSE_NETWORK);
-    }
-
-    @SuppressLint("SetJavaScriptEnabled")
-    private void setLoadSettings() {
-        WebSettings webSettings = getSettings();
-        webSettings.setLoadWithOverviewMode(true);
-        webSettings.setUseWideViewPort(true);
-        webSettings.setJavaScriptEnabled(true);
-    }
-
-    private String getCacheableUrl(String url) {
-        if (TextUtils.equals(url, BLANK) || TextUtils.equals(url, FILE)) {
-            mArchiveClient.cacheFileName = null;
-            return url;
-        }
-        mArchiveClient.cacheFileName = generateCacheFilename(url);
-        setCacheModeInternal();
-        File cacheFile = new File(mArchiveClient.cacheFileName);
-        if (cacheFile.exists() && !AppUtils.hasConnection(getContext())) {
-            getSettings().setCacheMode(WebSettings.LOAD_CACHE_ONLY);
-            return Uri.fromFile(cacheFile).toString();
-        }
-        return url;
-    }
-
-    private String generateCacheFilename(String url) {
-        String name;
-        try {
-            java.security.MessageDigest digest = java.security.MessageDigest.getInstance("SHA-256");
-            byte[] hash = digest.digest(url.getBytes(java.nio.charset.StandardCharsets.UTF_8));
-            StringBuilder hexString = new StringBuilder();
-            for (byte b : hash) {
-                String hex = Integer.toHexString(0xff & b);
-                if (hex.length() == 1) {
-                    hexString.append('0');
-                }
-                hexString.append(hex);
-            }
-            name = hexString.toString();
-        } catch (java.security.NoSuchAlgorithmException e) {
-            name = String.valueOf(url.hashCode());
-        }
-        return getContext().getApplicationContext().getCacheDir().getAbsolutePath() +
-                File.separator +
-                CACHE_PREFIX +
-                name +
-                CACHE_EXTENSION;
-    }
-
-    public static class ArchiveClient extends WebChromeClient {
-        int lastProgress = 0;
-        String cacheFileName = null;
-
-        @CallSuper
-        @Override
-        public void onProgressChanged(android.webkit.WebView view, int newProgress) {
-            if (view.getSettings().getCacheMode() == WebSettings.LOAD_CACHE_ONLY) {
-                return;
-            }
-            if (cacheFileName != null && lastProgress != 100 && newProgress == 100) {
-                lastProgress = newProgress;
-                view.saveWebArchive(cacheFileName);
-            }
-        }
-
-    }
+  }
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/WebView.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/WebView.java
@@ -16,116 +16,115 @@
 
 package io.github.sheepdestroyer.materialisheep.widget;
 
-import android.annotation.TargetApi;
 import android.content.Context;
 import android.graphics.Bitmap;
-import android.os.Build;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebViewClient;
-
 import io.github.sheepdestroyer.materialisheep.AppUtils;
 import io.github.sheepdestroyer.materialisheep.annotation.Synthetic;
 
 public class WebView extends android.webkit.WebView {
-    static final String BLANK = "about:blank";
-    public static final String FILE = "file:///";
-    private final HistoryWebViewClient mClient = new HistoryWebViewClient();
+  static final String BLANK = "about:blank";
+  public static final String FILE = "file:///";
+  private final HistoryWebViewClient mClient = new HistoryWebViewClient();
+  @Synthetic String mPendingUrl, mPendingHtml;
+
+  public WebView(Context context) {
+    this(context, null);
+  }
+
+  public WebView(Context context, AttributeSet attrs) {
+    this(context, attrs, 0);
+  }
+
+  public WebView(Context context, AttributeSet attrs, int defStyleAttr) {
+    super(context, attrs, defStyleAttr);
+    super.setWebViewClient(mClient);
+  }
+
+  @Override
+  public void setWebViewClient(WebViewClient client) {
+    mClient.wrap(client);
+  }
+
+  @Override
+  public boolean canGoBack() {
+    return TextUtils.isEmpty(mPendingUrl) && super.canGoBack();
+  }
+
+  public void reloadUrl(String url) {
+    if (getProgress() < 100) {
+      stopLoading(); // this will fire onPageFinished for current URL
+    }
+    mPendingUrl = url;
+    loadUrl(BLANK); // clear current web resources, load pending URL upon onPageFinished
+  }
+
+  public void reloadHtml(String html) {
+    mPendingHtml = html;
+    reloadUrl(FILE);
+  }
+
+  static class HistoryWebViewClient extends WebViewClient {
+    private WebViewClient mClient;
+
+    @Override
+    public void onPageStarted(android.webkit.WebView view, String url, Bitmap favicon) {
+      super.onPageStarted(view, url, favicon);
+      view.pageUp(true);
+      WebView webView = (WebView) view;
+      if (AppUtils.urlEquals(url, webView.mPendingUrl)) {
+        view.setVisibility(VISIBLE);
+      }
+      if (mClient != null) {
+        mClient.onPageStarted(view, url, favicon);
+      }
+    }
+
+    @Override
+    public void onPageFinished(android.webkit.WebView view, String url) {
+      super.onPageFinished(view, url);
+      WebView webView = (WebView) view;
+      if (TextUtils.equals(url, BLANK)) { // has pending reload, open corresponding URL
+        if (!TextUtils.isEmpty(webView.mPendingHtml)) {
+          view.loadDataWithBaseURL(
+              webView.mPendingUrl, webView.mPendingHtml, "text/html", "UTF-8", webView.mPendingUrl);
+        } else {
+          view.loadUrl(webView.mPendingUrl);
+        }
+      } else if (!TextUtils.isEmpty(webView.mPendingUrl)
+          && TextUtils.equals(url, webView.mPendingUrl)) { // reload done, clear history
+        webView.mPendingUrl = null;
+        webView.mPendingHtml = null;
+        view.clearHistory();
+      }
+      if (mClient != null) {
+        mClient.onPageFinished(view, url);
+      }
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public WebResourceResponse shouldInterceptRequest(android.webkit.WebView view, String url) {
+      return mClient != null
+          ? mClient.shouldInterceptRequest(view, url)
+          : super.shouldInterceptRequest(view, url);
+    }
+
+    @Override
+    public WebResourceResponse shouldInterceptRequest(
+        android.webkit.WebView view, WebResourceRequest request) {
+      return mClient != null
+          ? mClient.shouldInterceptRequest(view, request)
+          : super.shouldInterceptRequest(view, request);
+    }
+
     @Synthetic
-    String mPendingUrl, mPendingHtml;
-
-    public WebView(Context context) {
-        this(context, null);
+    void wrap(WebViewClient client) {
+      mClient = client;
     }
-
-    public WebView(Context context, AttributeSet attrs) {
-        this(context, attrs, 0);
-    }
-
-    public WebView(Context context, AttributeSet attrs, int defStyleAttr) {
-        super(context, attrs, defStyleAttr);
-        super.setWebViewClient(mClient);
-    }
-
-    @Override
-    public void setWebViewClient(WebViewClient client) {
-        mClient.wrap(client);
-    }
-
-    @Override
-    public boolean canGoBack() {
-        return TextUtils.isEmpty(mPendingUrl) && super.canGoBack();
-    }
-
-    public void reloadUrl(String url) {
-        if (getProgress() < 100) {
-            stopLoading(); // this will fire onPageFinished for current URL
-        }
-        mPendingUrl = url;
-        loadUrl(BLANK); // clear current web resources, load pending URL upon onPageFinished
-    }
-
-    public void reloadHtml(String html) {
-        mPendingHtml = html;
-        reloadUrl(FILE);
-    }
-
-    static class HistoryWebViewClient extends WebViewClient {
-        private WebViewClient mClient;
-
-        @Override
-        public void onPageStarted(android.webkit.WebView view, String url, Bitmap favicon) {
-            super.onPageStarted(view, url, favicon);
-            view.pageUp(true);
-            WebView webView = (WebView) view;
-            if (AppUtils.urlEquals(url, webView.mPendingUrl)) {
-                view.setVisibility(VISIBLE);
-            }
-            if (mClient != null) {
-                mClient.onPageStarted(view, url, favicon);
-            }
-        }
-
-        @Override
-        public void onPageFinished(android.webkit.WebView view, String url) {
-            super.onPageFinished(view, url);
-            WebView webView = (WebView) view;
-            if (TextUtils.equals(url, BLANK)) { // has pending reload, open corresponding URL
-                if (!TextUtils.isEmpty(webView.mPendingHtml)) {
-                    view.loadDataWithBaseURL(webView.mPendingUrl, webView.mPendingHtml,
-                            "text/html", "UTF-8", webView.mPendingUrl);
-                } else {
-                    view.loadUrl(webView.mPendingUrl);
-                }
-            } else if (!TextUtils.isEmpty(webView.mPendingUrl) &&
-                    TextUtils.equals(url, webView.mPendingUrl)) { // reload done, clear history
-                webView.mPendingUrl = null;
-                webView.mPendingHtml = null;
-                view.clearHistory();
-            }
-            if (mClient != null) {
-                mClient.onPageFinished(view, url);
-            }
-        }
-
-        @SuppressWarnings("deprecation")
-        @Override
-        public WebResourceResponse shouldInterceptRequest(android.webkit.WebView view, String url) {
-            return mClient != null ? mClient.shouldInterceptRequest(view, url)
-                    : super.shouldInterceptRequest(view, url);
-        }
-
-        @Override
-        public WebResourceResponse shouldInterceptRequest(android.webkit.WebView view, WebResourceRequest request) {
-            return mClient != null ? mClient.shouldInterceptRequest(view, request)
-                    : super.shouldInterceptRequest(view, request);
-        }
-
-        @Synthetic
-        void wrap(WebViewClient client) {
-            mClient = client;
-        }
-    }
+  }
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/WebView.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/WebView.java
@@ -31,7 +31,7 @@ import io.github.sheepdestroyer.materialisheep.annotation.Synthetic;
 
 public class WebView extends android.webkit.WebView {
     static final String BLANK = "about:blank";
-    static final String FILE = "file:///";
+    public static final String FILE = "file:///";
     private final HistoryWebViewClient mClient = new HistoryWebViewClient();
     @Synthetic
     String mPendingUrl, mPendingHtml;


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** `AdBlockWebViewClient` did not properly validate `file://` URL schemes during request interception, allowing a directory traversal attack. Furthermore, the `WebView` could natively load and exfiltrate unintended arbitrary files.
🎯 **Impact:** An attacker could exploit the `setAllowFileAccess(true)` configuration via a crafted URL parameter to navigate out of the cache directory and read sensitive application files or `/sdcard/` data.
🔧 **Fix:** Intercepts `file://` URIs and ensures that the requested path's canonical path strictly starts with the canonical path of the cache directory (with `File.separator` appended) or explicitly matches `/android_asset/`. Allowed resources let the WebView proceed naturally (returning `null`), while out-of-bounds file accesses are forcibly blocked with an empty `WebResourceResponse`. Also upgraded `mLoadedUrls` to `ConcurrentHashMap` for thread-safe access.
✅ **Verification:** Ran `./gradlew clean lint testDebugUnitTest`. All tests pass. Verified the logic returns `null` for `.mht` files to maintain web archive viewing capabilities without regression. Added `.jules/sentinel.md` entry.

---
*PR created automatically by Jules for task [3676770936342731641](https://jules.google.com/task/3676770936342731641) started by @sheepdestroyer*

## Summary by Sourcery

Harden WebView file loading to prevent directory traversal and unauthorized local file access while keeping ad blocking and web archive behavior intact.

Bug Fixes:
- Validate intercepted file:// requests against the app cache directory and android_asset path to prevent directory traversal and arbitrary local file reads.
- Ensure null or invalid WebView requests fall back to default handling instead of being processed by ad blocking logic.

Enhancements:
- Make the loaded-URL tracking map concurrent for thread-safe access in the WebView client.
- Expose cache file naming constants from CacheableWebView and the file:// prefix constant from WebView for reuse in request handling logic.

Documentation:
- Add a Sentinel security note documenting the WebView file:// vulnerability, fix, and prevention guidance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed security vulnerability related to improper file:// URL validation in WebView, preventing unauthorized file access.

* **New Features**
  * Added ability to reload URLs and HTML content directly.
  * Enhanced offline support with improved file caching for web content.

* **Improvements**
  * Strengthened file access validation mechanisms.
  * Enhanced thread-safety in resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->