### PR TITLE
🛡️ Sentinel: [HIGH] Fix Javascript Interface Data Leak in WebFragment

### DIFF
--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/WebFragment.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/WebFragment.java
@@ -462,6 +462,11 @@ public class WebFragment extends LazyLoadFragment
                 if (getActivity() != null) {
                     getActivity().invalidateOptionsMenu();
                 }
+                if (mPdfAndroidJavascriptBridge != null && !TextUtils.equals(PDF_LOADER_URL, url)) {
+                    mPdfAndroidJavascriptBridge.cleanUp();
+                    mWebView.removeJavascriptInterface("PdfAndroidJavascriptBridge");
+                    mPdfAndroidJavascriptBridge = null;
+                }
             }
 
             @Override

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/WebFragment.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/WebFragment.java
@@ -16,12 +16,15 @@
 
 package io.github.sheepdestroyer.materialisheep;
 
+import static android.view.View.GONE;
+import static android.view.View.VISIBLE;
+import static io.github.sheepdestroyer.materialisheep.DataModule.HN;
+
 import android.annotation.SuppressLint;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import androidx.core.os.BundleCompat;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.net.Uri;
@@ -45,21 +48,10 @@ import android.widget.ImageButton;
 import android.widget.ProgressBar;
 import android.widget.Toast;
 import android.widget.ViewSwitcher;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.RandomAccessFile;
-import java.lang.ref.WeakReference;
-
-import javax.inject.Inject;
-import javax.inject.Named;
-
-import static io.github.sheepdestroyer.materialisheep.DataModule.HN;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.os.BundleCompat;
 import androidx.core.widget.NestedScrollView;
-import androidx.fragment.app.DialogFragment;
-import androidx.fragment.app.Fragment;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import io.github.sheepdestroyer.materialisheep.annotation.Synthetic;
 import io.github.sheepdestroyer.materialisheep.data.FileDownloader;
@@ -72,698 +64,723 @@ import io.github.sheepdestroyer.materialisheep.widget.AdBlockWebViewClient;
 import io.github.sheepdestroyer.materialisheep.widget.CacheableWebView;
 import io.github.sheepdestroyer.materialisheep.widget.PopupMenu;
 import io.github.sheepdestroyer.materialisheep.widget.WebView;
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.lang.ref.WeakReference;
+import javax.inject.Inject;
+import javax.inject.Named;
 import okhttp3.Call;
 
-import static android.view.View.GONE;
-import static android.view.View.VISIBLE;
-
-/**
- * A fragment that displays a web page.
- */
+/** A fragment that displays a web page. */
 @SuppressWarnings("deprecation") // TODO: Uses deprecated LocalBroadcastManager/Fragment APIs
 public class WebFragment extends LazyLoadFragment
-        implements Scrollable, KeyDelegate.BackInterceptor {
-    public static final String EXTRA_ITEM = WebFragment.class.getName() + ".EXTRA_ITEM";
-    private static final String STATE_EMPTY = "state:empty";
-    private static final String STATE_READABILITY = "state:readability";
-    static final String ACTION_FULLSCREEN = WebFragment.class.getName() + ".ACTION_FULLSCREEN";
-    static final String EXTRA_FULLSCREEN = WebFragment.class.getName() + ".EXTRA_FULLSCREEN";
-    private static final String STATE_FULLSCREEN = "state:fullscreen";
-    private static final String STATE_CONTENT = "state:content";
-    private static final int DEFAULT_PROGRESS = 20;
-    public static final String PDF_LOADER_URL = "file:///android_asset/pdf/index.html";
-    private static final String PDF_MIME_TYPE = "application/pdf";
-    @Synthetic
-    WebView mWebView;
-    private NestedScrollView mScrollView;
-    @Synthetic
-    boolean mExternalRequired = false;
-    @Inject
-    @Named(HN)
-    ItemManager mItemManager;
-    @Inject
-    PopupMenu mPopupMenu;
-    private KeyDelegate.NestedScrollViewHelper mScrollableHelper;
-    private final Preferences.Observable mPreferenceObservable = new Preferences.Observable();
-    private final BroadcastReceiver mReceiver = new BroadcastReceiver() {
+    implements Scrollable, KeyDelegate.BackInterceptor {
+  public static final String EXTRA_ITEM = WebFragment.class.getName() + ".EXTRA_ITEM";
+  private static final String STATE_EMPTY = "state:empty";
+  private static final String STATE_READABILITY = "state:readability";
+  static final String ACTION_FULLSCREEN = WebFragment.class.getName() + ".ACTION_FULLSCREEN";
+  static final String EXTRA_FULLSCREEN = WebFragment.class.getName() + ".EXTRA_FULLSCREEN";
+  private static final String STATE_FULLSCREEN = "state:fullscreen";
+  private static final String STATE_CONTENT = "state:content";
+  private static final int DEFAULT_PROGRESS = 20;
+  public static final String PDF_LOADER_URL = "file:///android_asset/pdf/index.html";
+  private static final String PDF_MIME_TYPE = "application/pdf";
+  @Synthetic WebView mWebView;
+  private NestedScrollView mScrollView;
+  @Synthetic boolean mExternalRequired = false;
+
+  @Inject
+  @Named(HN)
+  ItemManager mItemManager;
+
+  @Inject PopupMenu mPopupMenu;
+  private KeyDelegate.NestedScrollViewHelper mScrollableHelper;
+  private final Preferences.Observable mPreferenceObservable = new Preferences.Observable();
+  private final BroadcastReceiver mReceiver =
+      new BroadcastReceiver() {
         @Override
         public void onReceive(Context context, Intent intent) {
-            setFullscreen(intent.getBooleanExtra(WebFragment.EXTRA_FULLSCREEN, false));
+          setFullscreen(intent.getBooleanExtra(WebFragment.EXTRA_FULLSCREEN, false));
         }
-    };
-    private ViewGroup mFullscreenView;
-    private ViewGroup mScrollViewContent;
-    @Synthetic
-    ImageButton mButtonRefresh;
-    private ViewSwitcher mControls;
-    private EditText mEditText;
-    private View mButtonMore;
-    private View mButtonNext;
-    protected ProgressBar mProgressBar;
-    private boolean mFullscreen;
-    private boolean mIsPdf;
-    protected String mContent;
-    private AppUtils.SystemUiHelper mSystemUiHelper;
-    private View mFragmentView;
-    @Inject
-    ReadabilityClient mReadabilityClient;
-    @Inject
-    FileDownloader mFileDownloader;
-    private WebItem mItem;
-    private boolean mIsHackerNewsUrl, mEmpty, mReadability;
-    private PdfAndroidJavascriptBridge mPdfAndroidJavascriptBridge;
+      };
+  private ViewGroup mFullscreenView;
+  private ViewGroup mScrollViewContent;
+  @Synthetic ImageButton mButtonRefresh;
+  private ViewSwitcher mControls;
+  private EditText mEditText;
+  private View mButtonMore;
+  private View mButtonNext;
+  protected ProgressBar mProgressBar;
+  private boolean mFullscreen;
+  private boolean mIsPdf;
+  protected String mContent;
+  private AppUtils.SystemUiHelper mSystemUiHelper;
+  private View mFragmentView;
+  @Inject ReadabilityClient mReadabilityClient;
+  @Inject FileDownloader mFileDownloader;
+  private WebItem mItem;
+  private boolean mIsHackerNewsUrl, mEmpty, mReadability;
+  private PdfAndroidJavascriptBridge mPdfAndroidJavascriptBridge;
 
-    @SuppressWarnings("deprecation") // Using deprecated LocalBroadcastManager; migration to LiveData/Flow requires
-                                     // architectural changes
-    @Override
-    public void onAttach(Context context) {
-        super.onAttach(context);
-        ((MaterialisticApplication) getActivity().getApplication()).applicationComponent.inject(this);
-        mPreferenceObservable.subscribe(context, this::onPreferenceChanged,
-                R.string.pref_readability_font,
-                R.string.pref_readability_line_height,
-                R.string.pref_readability_text_size);
-        LocalBroadcastManager.getInstance(context).registerReceiver(mReceiver,
-                new IntentFilter(ACTION_FULLSCREEN));
+  @SuppressWarnings(
+      "deprecation") // Using deprecated LocalBroadcastManager; migration to LiveData/Flow requires
+  // architectural changes
+  @Override
+  public void onAttach(Context context) {
+    super.onAttach(context);
+    ((MaterialisticApplication) getActivity().getApplication()).applicationComponent.inject(this);
+    mPreferenceObservable.subscribe(
+        context,
+        this::onPreferenceChanged,
+        R.string.pref_readability_font,
+        R.string.pref_readability_line_height,
+        R.string.pref_readability_text_size);
+    LocalBroadcastManager.getInstance(context)
+        .registerReceiver(mReceiver, new IntentFilter(ACTION_FULLSCREEN));
+  }
+
+  @Override
+  public void onCreate(@Nullable Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    if (savedInstanceState != null) {
+      mFullscreen = savedInstanceState.getBoolean(STATE_FULLSCREEN, false);
+      mContent = savedInstanceState.getString(STATE_CONTENT);
+      mEmpty = savedInstanceState.getBoolean(STATE_EMPTY, false);
+      mReadability = savedInstanceState.getBoolean(STATE_READABILITY, false);
+      mItem = BundleCompat.getParcelable(savedInstanceState, EXTRA_ITEM, WebItem.class);
+    } else {
+      mReadability =
+          Preferences.getDefaultStoryView(getActivity()) == Preferences.StoryViewMode.Readability;
+      mItem = BundleCompat.getParcelable(getArguments(), EXTRA_ITEM, WebItem.class);
     }
+    mIsHackerNewsUrl = AppUtils.isHackerNewsUrl(mItem);
+  }
 
-    @Override
-    public void onCreate(@Nullable Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        if (savedInstanceState != null) {
-            mFullscreen = savedInstanceState.getBoolean(STATE_FULLSCREEN, false);
-            mContent = savedInstanceState.getString(STATE_CONTENT);
-            mEmpty = savedInstanceState.getBoolean(STATE_EMPTY, false);
-            mReadability = savedInstanceState.getBoolean(STATE_READABILITY, false);
-            mItem = BundleCompat.getParcelable(savedInstanceState, EXTRA_ITEM, WebItem.class);
-        } else {
-            mReadability = Preferences.getDefaultStoryView(getActivity()) == Preferences.StoryViewMode.Readability;
-            mItem = BundleCompat.getParcelable(getArguments(), EXTRA_ITEM, WebItem.class);
-        }
-        mIsHackerNewsUrl = AppUtils.isHackerNewsUrl(mItem);
+  @Override
+  public View onCreateView(
+      LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+
+    mFragmentView = inflater.inflate(R.layout.fragment_web, container, false);
+    mFullscreenView = (ViewGroup) mFragmentView.findViewById(R.id.fullscreen);
+    mScrollViewContent = (ViewGroup) mFragmentView.findViewById(R.id.scroll_view_content);
+    mScrollView = (NestedScrollView) mFragmentView.findViewById(R.id.nested_scroll_view);
+    mControls = (ViewSwitcher) mFragmentView.findViewById(R.id.control_switcher);
+    mWebView = (WebView) mFragmentView.findViewById(R.id.web_view);
+    mButtonRefresh = (ImageButton) mFragmentView.findViewById(R.id.button_refresh);
+    mButtonMore = mFragmentView.findViewById(R.id.button_more);
+    mButtonNext = mFragmentView.findViewById(R.id.button_next);
+    mButtonNext.setEnabled(false);
+    mEditText = (EditText) mFragmentView.findViewById(R.id.edittext);
+    setUpWebControls(mFragmentView);
+    setUpWebView(mFragmentView);
+
+    return mFragmentView;
+  }
+
+  @SuppressWarnings(
+      "deprecation") // Using deprecated Fragment menu API; migration to MenuProvider requires
+  // Activity cooperation
+  @Override
+  public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+    super.onViewCreated(view, savedInstanceState);
+
+    mScrollableHelper = new KeyDelegate.NestedScrollViewHelper(mScrollView);
+    mSystemUiHelper = new AppUtils.SystemUiHelper(getActivity().getWindow());
+    mSystemUiHelper.setEnabled(!getResources().getBoolean(R.bool.multi_pane));
+    if (mFullscreen) {
+      setFullscreen(true);
     }
+  }
 
-    @Override
-    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container,
-            @Nullable Bundle savedInstanceState) {
+  @Override
+  protected void createOptionsMenu(Menu menu, MenuInflater inflater) {
+    inflater.inflate(R.menu.menu_article, menu);
+  }
 
-        mFragmentView = inflater.inflate(R.layout.fragment_web, container, false);
-        mFullscreenView = (ViewGroup) mFragmentView.findViewById(R.id.fullscreen);
-        mScrollViewContent = (ViewGroup) mFragmentView.findViewById(R.id.scroll_view_content);
-        mScrollView = (NestedScrollView) mFragmentView.findViewById(R.id.nested_scroll_view);
-        mControls = (ViewSwitcher) mFragmentView.findViewById(R.id.control_switcher);
-        mWebView = (WebView) mFragmentView.findViewById(R.id.web_view);
-        mButtonRefresh = (ImageButton) mFragmentView.findViewById(R.id.button_refresh);
-        mButtonMore = mFragmentView.findViewById(R.id.button_more);
-        mButtonNext = mFragmentView.findViewById(R.id.button_next);
-        mButtonNext.setEnabled(false);
-        mEditText = (EditText) mFragmentView.findViewById(R.id.edittext);
-        setUpWebControls(mFragmentView);
-        setUpWebView(mFragmentView);
+  @Override
+  protected void prepareOptionsMenu(Menu menu) {
+    MenuItem menuReadability = menu.findItem(R.id.menu_readability);
+    menuReadability.setVisible(modeToggleEnabled());
+    mMenuTintDelegate.setIcon(
+        menuReadability,
+        mReadability ? R.drawable.ic_web_black_24dp : R.drawable.ic_chrome_reader_mode_black_24dp);
+    menuReadability.setTitle(mReadability ? R.string.article : R.string.readability);
+    menu.findItem(R.id.menu_font_options).setVisible(fontEnabled());
+  }
 
-        return mFragmentView;
+  @SuppressWarnings(
+      "deprecation") // Using deprecated Fragment menu API; migration to MenuProvider requires
+  // Activity cooperation
+  @Override
+  public boolean onOptionsItemSelected(MenuItem item) {
+    if (item.getItemId() == R.id.menu_font_options) {
+      showPreferences();
+      return true;
     }
-
-    @SuppressWarnings("deprecation") // Using deprecated Fragment menu API; migration to MenuProvider requires
-                                     // Activity cooperation
-    @Override
-    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
-        super.onViewCreated(view, savedInstanceState);
-
-        mScrollableHelper = new KeyDelegate.NestedScrollViewHelper(mScrollView);
-        mSystemUiHelper = new AppUtils.SystemUiHelper(getActivity().getWindow());
-        mSystemUiHelper.setEnabled(!getResources().getBoolean(R.bool.multi_pane));
-        if (mFullscreen) {
-            setFullscreen(true);
-        }
-
+    if (item.getItemId() == R.id.menu_readability) {
+      mReadability = !mReadability;
+      load();
+      return true;
     }
+    return super.onOptionsItemSelected(item);
+  }
 
-    @Override
-    protected void createOptionsMenu(Menu menu, MenuInflater inflater) {
-        inflater.inflate(R.menu.menu_article, menu);
+  @Override
+  public void onResume() {
+    super.onResume();
+    mWebView.onResume();
+    mWebView.resumeTimers();
+  }
+
+  @Override
+  public void onStop() {
+    super.onStop();
+    pauseWebView();
+  }
+
+  @Override
+  public void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    outState.putBoolean(STATE_FULLSCREEN, mFullscreen);
+    outState.putString(STATE_CONTENT, mContent);
+    outState.putParcelable(EXTRA_ITEM, mItem);
+    outState.putBoolean(STATE_EMPTY, mEmpty);
+    outState.putBoolean(STATE_READABILITY, mReadability);
+  }
+
+  @Override
+  public void onDestroy() {
+    super.onDestroy();
+    if (mPdfAndroidJavascriptBridge != null) {
+      mPdfAndroidJavascriptBridge.cleanUp();
     }
+    mWebView.destroy();
+    // Note: mReadabilityClient is a singleton, do not call destroy() here.
+    // Subscriptions are fire-and-forget and managed internally.
+  }
 
-    @Override
-    protected void prepareOptionsMenu(Menu menu) {
-        MenuItem menuReadability = menu.findItem(R.id.menu_readability);
-        menuReadability.setVisible(modeToggleEnabled());
-        mMenuTintDelegate.setIcon(menuReadability,
-                mReadability ? R.drawable.ic_web_black_24dp : R.drawable.ic_chrome_reader_mode_black_24dp);
-        menuReadability.setTitle(mReadability ? R.string.article : R.string.readability);
-        menu.findItem(R.id.menu_font_options).setVisible(fontEnabled());
+  @SuppressWarnings(
+      "deprecation") // Using deprecated LocalBroadcastManager; migration to LiveData/Flow requires
+  // architectural changes
+  @Override
+  public void onDetach() {
+    mPreferenceObservable.unsubscribe(getActivity());
+    LocalBroadcastManager.getInstance(getActivity()).unregisterReceiver(mReceiver);
+    super.onDetach();
+  }
+
+  @Override
+  public void scrollToTop() {
+    if (mFullscreen) {
+      mWebView.pageUp(true);
+    } else {
+      mScrollableHelper.scrollToTop();
     }
+  }
 
-    @SuppressWarnings("deprecation") // Using deprecated Fragment menu API; migration to MenuProvider requires
-                                     // Activity cooperation
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        if (item.getItemId() == R.id.menu_font_options) {
-            showPreferences();
-            return true;
-        }
-        if (item.getItemId() == R.id.menu_readability) {
-            mReadability = !mReadability;
-            load();
-            return true;
-        }
-        return super.onOptionsItemSelected(item);
+  @Override
+  public boolean scrollToNext() {
+    if (mFullscreen) {
+      mWebView.pageDown(false);
+      return true;
+    } else {
+      return mScrollableHelper.scrollToNext();
     }
+  }
 
-    @Override
-    public void onResume() {
-        super.onResume();
-        mWebView.onResume();
-        mWebView.resumeTimers();
+  @Override
+  public boolean scrollToPrevious() {
+    if (mFullscreen) {
+      mWebView.pageUp(false);
+      return true;
+    } else {
+      return mScrollableHelper.scrollToPrevious();
     }
+  }
 
-    @Override
-    public void onStop() {
-        super.onStop();
-        pauseWebView();
+  @Override
+  public boolean onBackPressed() {
+    if (mWebView.canGoBack()) {
+      mWebView.goBack();
+      return true;
     }
+    return false;
+  }
 
-    @Override
-    public void onSaveInstanceState(Bundle outState) {
-        super.onSaveInstanceState(outState);
-        outState.putBoolean(STATE_FULLSCREEN, mFullscreen);
-        outState.putString(STATE_CONTENT, mContent);
-        outState.putParcelable(EXTRA_ITEM, mItem);
-        outState.putBoolean(STATE_EMPTY, mEmpty);
-        outState.putBoolean(STATE_READABILITY, mReadability);
+  @Override
+  protected void load() {
+    mWebView.setVisibility(View.INVISIBLE);
+    if (mIsHackerNewsUrl) {
+      bindContent();
+    } else if (mReadability && !mEmpty) {
+      if (TextUtils.isEmpty(mContent)) {
+        parse();
+      } else {
+        loadContent();
+      }
+    } else {
+      loadUrl();
     }
+  }
 
-    @Override
-    public void onDestroy() {
-        super.onDestroy();
-        if (mPdfAndroidJavascriptBridge != null) {
-            mPdfAndroidJavascriptBridge.cleanUp();
-        }
-        mWebView.destroy();
-        // Note: mReadabilityClient is a singleton, do not call destroy() here.
-        // Subscriptions are fire-and-forget and managed internally.
+  private void loadUrl() {
+    setWebSettings(true);
+    reloadUrl(mItem.getUrl());
+  }
+
+  private void reloadUrl(String url) {
+    reloadUrl(url, null);
+  }
+
+  @SuppressLint("AddJavascriptInterface")
+  private void reloadUrl(String url, @Nullable String pdfFilePath) {
+    mIsPdf = false;
+    if (mPdfAndroidJavascriptBridge != null) {
+      mPdfAndroidJavascriptBridge.cleanUp();
+      mWebView.removeJavascriptInterface("PdfAndroidJavascriptBridge");
     }
+    if (pdfFilePath != null && TextUtils.equals(PDF_LOADER_URL, url)) {
+      setProgress(80);
+      mIsPdf = true;
+      mPdfAndroidJavascriptBridge =
+          new PdfAndroidJavascriptBridge(
+              pdfFilePath,
+              new PdfAndroidJavascriptBridge.Callbacks() {
+                @Override
+                public void onFailure() {
+                  offerExternalApp();
+                  setProgress(100);
+                }
 
-    @SuppressWarnings("deprecation") // Using deprecated LocalBroadcastManager; migration to LiveData/Flow requires
-                                     // architectural changes
-    @Override
-    public void onDetach() {
-        mPreferenceObservable.unsubscribe(getActivity());
-        LocalBroadcastManager.getInstance(getActivity()).unregisterReceiver(mReceiver);
-        super.onDetach();
+                @Override
+                public void onLoad() {
+                  setProgress(100);
+                }
+              });
+      mWebView.addJavascriptInterface(mPdfAndroidJavascriptBridge, "PdfAndroidJavascriptBridge");
+      mWebView.setInitialScale(1);
     }
+    mWebView.reloadUrl(url);
+  }
 
-    @Override
-    public void scrollToTop() {
-        if (mFullscreen) {
-            mWebView.pageUp(true);
-        } else {
-            mScrollableHelper.scrollToTop();
-        }
+  @Synthetic
+  void loadContent() {
+    setWebSettings(false);
+    mWebView.reloadHtml(AppUtils.wrapHtml(getActivity(), mContent));
+  }
+
+  private void parse() {
+    mProgressBar.setProgress(DEFAULT_PROGRESS);
+    mReadabilityClient.parse(mItem.getId(), mItem.getUrl(), new ReadabilityCallback(this));
+  }
+
+  private void bindContent() {
+    if (mItem instanceof Item) {
+      mContent = ((Item) mItem).getText();
+      loadContent();
+    } else {
+      mItemManager.getItem(mItem.getId(), ItemManager.MODE_DEFAULT, new ItemResponseListener(this));
     }
+  }
 
-    @Override
-    public boolean scrollToNext() {
-        if (mFullscreen) {
-            mWebView.pageDown(false);
-            return true;
-        } else {
-            return mScrollableHelper.scrollToNext();
-        }
-    }
+  private void pauseWebView() {
+    mWebView.onPause();
+    mWebView.pauseTimers();
+  }
 
-    @Override
-    public boolean scrollToPrevious() {
-        if (mFullscreen) {
-            mWebView.pageUp(false);
-            return true;
-        } else {
-            return mScrollableHelper.scrollToPrevious();
-        }
-    }
+  private boolean fontEnabled() {
+    return mReadability && !mEmpty && !TextUtils.isEmpty(mContent);
+  }
 
-    @Override
-    public boolean onBackPressed() {
-        if (mWebView.canGoBack()) {
-            mWebView.goBack();
-            return true;
-        }
-        return false;
-    }
+  private boolean modeToggleEnabled() {
+    return !mIsHackerNewsUrl && !mWebView.canGoBack();
+  }
 
-    @Override
-    protected void load() {
-        mWebView.setVisibility(View.INVISIBLE);
-        if (mIsHackerNewsUrl) {
-            bindContent();
-        } else if (mReadability && !mEmpty) {
-            if (TextUtils.isEmpty(mContent)) {
-                parse();
-            } else {
-                loadContent();
-            }
-        } else {
-            loadUrl();
-        }
-    }
-
-    private void loadUrl() {
-        setWebSettings(true);
-        reloadUrl(mItem.getUrl());
-    }
-
-    private void reloadUrl(String url) {
-        reloadUrl(url, null);
-    }
-
-    @SuppressLint("AddJavascriptInterface")
-    private void reloadUrl(String url, @Nullable String pdfFilePath) {
-        mIsPdf = false;
-        if (mPdfAndroidJavascriptBridge != null) {
-            mPdfAndroidJavascriptBridge.cleanUp();
-            mWebView.removeJavascriptInterface("PdfAndroidJavascriptBridge");
-        }
-        if (pdfFilePath != null && TextUtils.equals(PDF_LOADER_URL, url)) {
-            setProgress(80);
-            mIsPdf = true;
-            mPdfAndroidJavascriptBridge = new PdfAndroidJavascriptBridge(pdfFilePath,
-                    new PdfAndroidJavascriptBridge.Callbacks() {
-                        @Override
-                        public void onFailure() {
-                            offerExternalApp();
-                            setProgress(100);
-                        }
-
-                        @Override
-                        public void onLoad() {
-                            setProgress(100);
-                        }
-                    });
-            mWebView.addJavascriptInterface(mPdfAndroidJavascriptBridge, "PdfAndroidJavascriptBridge");
-            mWebView.setInitialScale(1);
-        }
-        mWebView.reloadUrl(url);
-    }
-
-    @Synthetic
-    void loadContent() {
-        setWebSettings(false);
-        mWebView.reloadHtml(AppUtils.wrapHtml(getActivity(), mContent));
-    }
-
-    private void parse() {
-        mProgressBar.setProgress(DEFAULT_PROGRESS);
-        mReadabilityClient.parse(mItem.getId(), mItem.getUrl(), new ReadabilityCallback(this));
-    }
-
-    private void bindContent() {
-        if (mItem instanceof Item) {
-            mContent = ((Item) mItem).getText();
-            loadContent();
-        } else {
-            mItemManager.getItem(mItem.getId(), ItemManager.MODE_DEFAULT, new ItemResponseListener(this));
-        }
-    }
-
-    private void pauseWebView() {
-        mWebView.onPause();
-        mWebView.pauseTimers();
-    }
-
-    private boolean fontEnabled() {
-        return mReadability && !mEmpty && !TextUtils.isEmpty(mContent);
-    }
-
-    private boolean modeToggleEnabled() {
-        return !mIsHackerNewsUrl && !mWebView.canGoBack();
-    }
-
-    private void setUpWebControls(View view) {
-        view.findViewById(R.id.toolbar_web).setOnClickListener(v -> scrollToTop());
-        view.findViewById(R.id.button_back).setOnClickListener(v -> mWebView.goBack());
-        view.findViewById(R.id.button_forward).setOnClickListener(v -> mWebView.goForward());
-        view.findViewById(R.id.button_clear).setOnClickListener(v -> {
-            mSystemUiHelper.setFullscreen(true);
-            reset();
-            mControls.showNext();
+  private void setUpWebControls(View view) {
+    view.findViewById(R.id.toolbar_web).setOnClickListener(v -> scrollToTop());
+    view.findViewById(R.id.button_back).setOnClickListener(v -> mWebView.goBack());
+    view.findViewById(R.id.button_forward).setOnClickListener(v -> mWebView.goForward());
+    view.findViewById(R.id.button_clear)
+        .setOnClickListener(
+            v -> {
+              mSystemUiHelper.setFullscreen(true);
+              reset();
+              mControls.showNext();
+            });
+    view.findViewById(R.id.button_find)
+        .setOnClickListener(
+            v -> {
+              mEditText.requestFocus();
+              toggleSoftKeyboard(true);
+              mControls.showNext();
+            });
+    mButtonRefresh.setOnClickListener(
+        v -> {
+          if (mWebView.getProgress() < 100) {
+            mWebView.stopLoading();
+          } else {
+            mWebView.reload();
+          }
         });
-        view.findViewById(R.id.button_find).setOnClickListener(v -> {
-            mEditText.requestFocus();
-            toggleSoftKeyboard(true);
-            mControls.showNext();
-        });
-        mButtonRefresh.setOnClickListener(v -> {
-            if (mWebView.getProgress() < 100) {
-                mWebView.stopLoading();
-            } else {
-                mWebView.reload();
-            }
-        });
-        view.findViewById(R.id.button_exit)
-                .setOnClickListener(v -> {
-                    @SuppressWarnings("deprecation") // Using deprecated LocalBroadcastManager
-                    android.content.Intent intent = new Intent(WebFragment.ACTION_FULLSCREEN)
-                            .putExtra(EXTRA_FULLSCREEN, false);
-                    LocalBroadcastManager.getInstance(getActivity()).sendBroadcast(intent);
-                });
-        mButtonNext.setOnClickListener(v -> mWebView.findNext(true));
-        mButtonMore.setOnClickListener(v -> mPopupMenu.create(getActivity(), mButtonMore, Gravity.NO_GRAVITY)
+    view.findViewById(R.id.button_exit)
+        .setOnClickListener(
+            v -> {
+              @SuppressWarnings("deprecation") // Using deprecated LocalBroadcastManager
+              android.content.Intent intent =
+                  new Intent(WebFragment.ACTION_FULLSCREEN).putExtra(EXTRA_FULLSCREEN, false);
+              LocalBroadcastManager.getInstance(getActivity()).sendBroadcast(intent);
+            });
+    mButtonNext.setOnClickListener(v -> mWebView.findNext(true));
+    mButtonMore.setOnClickListener(
+        v ->
+            mPopupMenu
+                .create(getActivity(), mButtonMore, Gravity.NO_GRAVITY)
                 .inflate(R.menu.menu_web)
-                .setOnMenuItemClickListener(item -> {
-                    if (item.getItemId() == R.id.menu_font_options) {
+                .setOnMenuItemClickListener(
+                    item -> {
+                      if (item.getItemId() == R.id.menu_font_options) {
                         showPreferences();
                         return true;
-                    }
-                    if (item.getItemId() == R.id.menu_zoom_in) {
+                      }
+                      if (item.getItemId() == R.id.menu_zoom_in) {
                         mWebView.zoomIn();
                         return true;
-                    }
-                    if (item.getItemId() == R.id.menu_zoom_out) {
+                      }
+                      if (item.getItemId() == R.id.menu_zoom_out) {
                         mWebView.zoomOut();
                         return true;
-                    }
-                    return false;
-                })
+                      }
+                      return false;
+                    })
                 .setMenuItemVisible(R.id.menu_font_options, fontEnabled())
                 .show());
-        mEditText.setOnEditorActionListener((v, actionId, event) -> {
-            findInPage();
-            return true;
+    mEditText.setOnEditorActionListener(
+        (v, actionId, event) -> {
+          findInPage();
+          return true;
         });
-    }
+  }
 
-    private void setUpWebView(View view) {
-        mProgressBar = (ProgressBar) view.findViewById(R.id.progress);
-        mWebView.setBackgroundColor(Color.TRANSPARENT);
-        mWebView.setWebViewClient(new AdBlockWebViewClient(Preferences.adBlockEnabled(getActivity())) {
-            @Override
-            public void onPageStarted(android.webkit.WebView view, String url, Bitmap favicon) {
-                super.onPageStarted(view, url, favicon);
-                if (getActivity() != null) {
-                    getActivity().invalidateOptionsMenu();
-                }
-                if (mPdfAndroidJavascriptBridge != null && !TextUtils.equals(PDF_LOADER_URL, url)) {
-                    mPdfAndroidJavascriptBridge.cleanUp();
-                    mWebView.removeJavascriptInterface("PdfAndroidJavascriptBridge");
-                    mPdfAndroidJavascriptBridge = null;
-                }
+  private void setUpWebView(View view) {
+    mProgressBar = (ProgressBar) view.findViewById(R.id.progress);
+    mWebView.setBackgroundColor(Color.TRANSPARENT);
+    mWebView.setWebViewClient(
+        new AdBlockWebViewClient(Preferences.adBlockEnabled(getActivity())) {
+          @Override
+          public void onPageStarted(android.webkit.WebView view, String url, Bitmap favicon) {
+            super.onPageStarted(view, url, favicon);
+            if (getActivity() != null) {
+              getActivity().invalidateOptionsMenu();
             }
+            if (mPdfAndroidJavascriptBridge != null && !TextUtils.equals(PDF_LOADER_URL, url)) {
+              mPdfAndroidJavascriptBridge.cleanUp();
+              mWebView.removeJavascriptInterface("PdfAndroidJavascriptBridge");
+              mPdfAndroidJavascriptBridge = null;
+            }
+          }
 
-            @Override
-            public void onPageFinished(android.webkit.WebView view, String url) {
-                super.onPageFinished(view, url);
-                if (getActivity() != null) {
-                    getActivity().invalidateOptionsMenu();
-                }
+          @Override
+          public void onPageFinished(android.webkit.WebView view, String url) {
+            super.onPageFinished(view, url);
+            if (getActivity() != null) {
+              getActivity().invalidateOptionsMenu();
             }
+          }
         });
-        mWebView.setWebChromeClient(new CacheableWebView.ArchiveClient() {
-            @Override
-            public void onProgressChanged(android.webkit.WebView view, int newProgress) {
-                super.onProgressChanged(view, newProgress);
-                if (!mIsPdf) {
-                    setProgress(newProgress);
-                }
+    mWebView.setWebChromeClient(
+        new CacheableWebView.ArchiveClient() {
+          @Override
+          public void onProgressChanged(android.webkit.WebView view, int newProgress) {
+            super.onProgressChanged(view, newProgress);
+            if (!mIsPdf) {
+              setProgress(newProgress);
             }
+          }
         });
-        mWebView.setDownloadListener((url, userAgent, contentDisposition, mimetype, contentLength) -> {
-            if (getActivity() == null) {
-                return;
-            }
-            if (mimetype.equals(PDF_MIME_TYPE)) {
-                setProgress(10);
-                mIsPdf = true;
-                downloadFileAndRenderPdf();
-            } else {
-                offerExternalApp();
-            }
-        });
-        AppUtils.toggleWebViewZoom(mWebView.getSettings(), false);
-    }
-
-    private void offerExternalApp() {
-        final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(mItem.getUrl()));
-        if (intent.resolveActivity(getActivity().getPackageManager()) == null) {
+    mWebView.setDownloadListener(
+        (url, userAgent, contentDisposition, mimetype, contentLength) -> {
+          if (getActivity() == null) {
             return;
+          }
+          if (mimetype.equals(PDF_MIME_TYPE)) {
+            setProgress(10);
+            mIsPdf = true;
+            downloadFileAndRenderPdf();
+          } else {
+            offerExternalApp();
+          }
+        });
+    AppUtils.toggleWebViewZoom(mWebView.getSettings(), false);
+  }
+
+  private void offerExternalApp() {
+    final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(mItem.getUrl()));
+    if (intent.resolveActivity(getActivity().getPackageManager()) == null) {
+      return;
+    }
+    mExternalRequired = true;
+    mWebView.setVisibility(GONE);
+    getActivity().findViewById(R.id.empty).setVisibility(VISIBLE);
+    getActivity().findViewById(R.id.download_button).setOnClickListener(v -> startActivity(intent));
+  }
+
+  private void setProgress(int progress) {
+    mProgressBar.setProgress(progress);
+    mProgressBar.setVisibility(progress == 100 ? GONE : VISIBLE);
+    mButtonRefresh.setImageResource(
+        progress == 100 ? R.drawable.ic_refresh_white_24dp : R.drawable.ic_clear_white_24dp);
+  }
+
+  @SuppressLint("SetJavaScriptEnabled")
+  private void setWebSettings(boolean isRemote) {
+    mReadability = !isRemote;
+    mWebView.setBackgroundColor(isRemote ? Color.WHITE : Color.TRANSPARENT);
+    mWebView.getSettings().setLoadWithOverviewMode(isRemote);
+    mWebView.getSettings().setUseWideViewPort(isRemote);
+    mWebView.getSettings().setJavaScriptEnabled(true);
+    getActivity().invalidateOptionsMenu();
+  }
+
+  @Synthetic
+  void setFullscreen(boolean isFullscreen) {
+    if (getView() == null) {
+      return;
+    }
+    mFullscreen = isFullscreen;
+    mControls.setVisibility(isFullscreen ? VISIBLE : View.GONE);
+    AppUtils.toggleWebViewZoom(mWebView.getSettings(), isFullscreen);
+    ViewGroup.LayoutParams params = mWebView.getLayoutParams();
+    if (isFullscreen) {
+      mScrollView.removeView(mScrollViewContent);
+      mWebView.scrollTo(mScrollView.getScrollX(), mScrollView.getScrollY());
+      mFullscreenView.addView(mScrollViewContent);
+      params.height = ViewGroup.LayoutParams.MATCH_PARENT;
+    } else {
+      reset();
+      // We'll zoom out until it returns false, which means it has min zoom level.
+      // It's quite dangerous piece of code - potentially could lead to infinite loop,
+      // so let's add some reasonable limit just in case
+      int i = 0;
+      while (mWebView.zoomOut() && i < 30) {
+        i++;
+      }
+      mFullscreenView.removeView(mScrollViewContent);
+      mScrollView.addView(mScrollViewContent);
+      mScrollView.post(() -> mScrollView.scrollTo(mWebView.getScrollX(), mWebView.getScrollY()));
+      params.height = ViewGroup.LayoutParams.WRAP_CONTENT;
+    }
+    mWebView.setLayoutParams(params);
+  }
+
+  private void showPreferences() {
+    Bundle args = new Bundle();
+    args.putInt(PopupSettingsFragment.EXTRA_TITLE, R.string.font_options);
+    args.putIntArray(
+        PopupSettingsFragment.EXTRA_XML_PREFERENCES, new int[] {R.xml.preferences_readability});
+    PopupSettingsFragment fragment = new PopupSettingsFragment();
+    fragment.setArguments(args);
+    fragment.show(getParentFragmentManager(), PopupSettingsFragment.class.getName());
+  }
+
+  private void onPreferenceChanged(int key, boolean contextChanged) {
+    if (!contextChanged) {
+      load();
+    }
+  }
+
+  private void reset() {
+    mEditText.setText(null);
+    mButtonNext.setEnabled(false);
+    toggleSoftKeyboard(false);
+    mWebView.clearMatches();
+  }
+
+  private void findInPage() {
+    String query = mEditText.getText().toString().trim();
+    if (TextUtils.isEmpty(query)) {
+      return;
+    }
+    mWebView.setFindListener(
+        (activeMatchOrdinal, numberOfMatches, isDoneCounting) -> {
+          if (isDoneCounting) {
+            handleFindResults(numberOfMatches);
+          }
+        });
+    mWebView.findAllAsync(query);
+  }
+
+  private void handleFindResults(int numberOfMatches) {
+    mButtonNext.setEnabled(numberOfMatches > 0);
+    if (numberOfMatches == 0) {
+      Toast.makeText(getContext(), R.string.no_matches, Toast.LENGTH_SHORT).show();
+    } else {
+      toggleSoftKeyboard(false);
+    }
+  }
+
+  private void toggleSoftKeyboard(boolean visible) {
+    InputMethodManager imm =
+        (InputMethodManager) getActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
+    if (visible) {
+      imm.showSoftInput(mEditText, InputMethodManager.SHOW_IMPLICIT);
+    } else {
+      imm.hideSoftInputFromWindow(mEditText.getWindowToken(), 0);
+    }
+  }
+
+  @Synthetic
+  void onParsed(String content) {
+    if (isAttached()) {
+      mContent = content;
+      if (!TextUtils.isEmpty(mContent)) {
+        loadContent();
+      } else {
+        mEmpty = true;
+        if (mReadability) {
+          Toast.makeText(getActivity(), R.string.readability_failed, Toast.LENGTH_SHORT).show();
         }
-        mExternalRequired = true;
-        mWebView.setVisibility(GONE);
-        getActivity().findViewById(R.id.empty).setVisibility(VISIBLE);
-        getActivity().findViewById(R.id.download_button).setOnClickListener(v -> startActivity(intent));
+        loadUrl();
+      }
     }
+  }
 
-    private void setProgress(int progress) {
-        mProgressBar.setProgress(progress);
-        mProgressBar.setVisibility(progress == 100 ? GONE : VISIBLE);
-        mButtonRefresh
-                .setImageResource(progress == 100 ? R.drawable.ic_refresh_white_24dp : R.drawable.ic_clear_white_24dp);
-    }
+  @Synthetic
+  void onItemLoaded(@NonNull Item response) {
+    getActivity().invalidateOptionsMenu();
+    mItem = response;
+    bindContent();
+  }
 
-    @SuppressLint("SetJavaScriptEnabled")
-    private void setWebSettings(boolean isRemote) {
-        mReadability = !isRemote;
-        mWebView.setBackgroundColor(isRemote ? Color.WHITE : Color.TRANSPARENT);
-        mWebView.getSettings().setLoadWithOverviewMode(isRemote);
-        mWebView.getSettings().setUseWideViewPort(isRemote);
-        mWebView.getSettings().setJavaScriptEnabled(true);
-        getActivity().invalidateOptionsMenu();
-    }
+  private void downloadFileAndRenderPdf() {
+    mFileDownloader.downloadFile(
+        mItem.getUrl(),
+        PDF_MIME_TYPE,
+        new FileDownloader.FileDownloaderCallback() {
+          @Override
+          public void onFailure(Call call, IOException e) {
+            offerExternalApp();
+          }
+
+          @Override
+          public void onSuccess(String filePath) {
+            reloadUrl(PDF_LOADER_URL, filePath);
+          }
+        });
+  }
+
+  static class ReadabilityCallback implements ReadabilityClient.Callback {
+    private final WeakReference<WebFragment> mReadabilityFragment;
 
     @Synthetic
-    void setFullscreen(boolean isFullscreen) {
-        if (getView() == null) {
-            return;
-        }
-        mFullscreen = isFullscreen;
-        mControls.setVisibility(isFullscreen ? VISIBLE : View.GONE);
-        AppUtils.toggleWebViewZoom(mWebView.getSettings(), isFullscreen);
-        ViewGroup.LayoutParams params = mWebView.getLayoutParams();
-        if (isFullscreen) {
-            mScrollView.removeView(mScrollViewContent);
-            mWebView.scrollTo(mScrollView.getScrollX(), mScrollView.getScrollY());
-            mFullscreenView.addView(mScrollViewContent);
-            params.height = ViewGroup.LayoutParams.MATCH_PARENT;
-        } else {
-            reset();
-            // We'll zoom out until it returns false, which means it has min zoom level.
-            // It's quite dangerous piece of code - potentially could lead to infinite loop,
-            // so let's add some reasonable limit just in case
-            int i = 0;
-            while (mWebView.zoomOut() && i < 30) {
-                i++;
-            }
-            mFullscreenView.removeView(mScrollViewContent);
-            mScrollView.addView(mScrollViewContent);
-            mScrollView.post(() -> mScrollView.scrollTo(mWebView.getScrollX(), mWebView.getScrollY()));
-            params.height = ViewGroup.LayoutParams.WRAP_CONTENT;
-        }
-        mWebView.setLayoutParams(params);
+    ReadabilityCallback(WebFragment webFragment) {
+      mReadabilityFragment = new WeakReference<>(webFragment);
     }
 
-    private void showPreferences() {
-        Bundle args = new Bundle();
-        args.putInt(PopupSettingsFragment.EXTRA_TITLE, R.string.font_options);
-        args.putIntArray(PopupSettingsFragment.EXTRA_XML_PREFERENCES,
-                new int[] { R.xml.preferences_readability });
-        PopupSettingsFragment fragment = new PopupSettingsFragment();
-        fragment.setArguments(args);
-        fragment.show(getParentFragmentManager(), PopupSettingsFragment.class.getName());
+    @Override
+    public void onResponse(String content) {
+      if (mReadabilityFragment.get() != null && mReadabilityFragment.get().isAttached()) {
+        mReadabilityFragment.get().onParsed(content);
+      }
     }
+  }
 
-    private void onPreferenceChanged(int key, boolean contextChanged) {
-        if (!contextChanged) {
-            load();
-        }
-    }
-
-    private void reset() {
-        mEditText.setText(null);
-        mButtonNext.setEnabled(false);
-        toggleSoftKeyboard(false);
-        mWebView.clearMatches();
-    }
-
-    private void findInPage() {
-        String query = mEditText.getText().toString().trim();
-        if (TextUtils.isEmpty(query)) {
-            return;
-        }
-        mWebView.setFindListener((activeMatchOrdinal, numberOfMatches, isDoneCounting) -> {
-            if (isDoneCounting) {
-                handleFindResults(numberOfMatches);
-            }
-        });
-        mWebView.findAllAsync(query);
-    }
-
-    private void handleFindResults(int numberOfMatches) {
-        mButtonNext.setEnabled(numberOfMatches > 0);
-        if (numberOfMatches == 0) {
-            Toast.makeText(getContext(), R.string.no_matches, Toast.LENGTH_SHORT).show();
-        } else {
-            toggleSoftKeyboard(false);
-        }
-    }
-
-    private void toggleSoftKeyboard(boolean visible) {
-        InputMethodManager imm = (InputMethodManager) getActivity().getSystemService(
-                Context.INPUT_METHOD_SERVICE);
-        if (visible) {
-            imm.showSoftInput(mEditText, InputMethodManager.SHOW_IMPLICIT);
-        } else {
-            imm.hideSoftInputFromWindow(mEditText.getWindowToken(), 0);
-        }
-    }
+  static class ItemResponseListener implements ResponseListener<Item> {
+    private final WeakReference<WebFragment> mFragment;
 
     @Synthetic
-    void onParsed(String content) {
-        if (isAttached()) {
-            mContent = content;
-            if (!TextUtils.isEmpty(mContent)) {
-                loadContent();
-            } else {
-                mEmpty = true;
-                if (mReadability) {
-                    Toast.makeText(getActivity(), R.string.readability_failed, Toast.LENGTH_SHORT).show();
-                }
-                loadUrl();
-            }
-        }
+    ItemResponseListener(WebFragment webFragment) {
+      mFragment = new WeakReference<>(webFragment);
     }
 
-    @Synthetic
-    void onItemLoaded(@NonNull Item response) {
-        getActivity().invalidateOptionsMenu();
-        mItem = response;
-        bindContent();
+    @Override
+    public void onResponse(@Nullable Item response) {
+      if (mFragment.get() != null && mFragment.get().isAttached() && response != null) {
+        mFragment.get().onItemLoaded(response);
+      }
     }
 
-    private void downloadFileAndRenderPdf() {
-        mFileDownloader.downloadFile(mItem.getUrl(), PDF_MIME_TYPE, new FileDownloader.FileDownloaderCallback() {
-            @Override
-            public void onFailure(Call call, IOException e) {
-                offerExternalApp();
-            }
+    @Override
+    public void onError(String errorMessage) {
+      // do nothing
+    }
+  }
 
-            @Override
-            public void onSuccess(String filePath) {
-                reloadUrl(PDF_LOADER_URL, filePath);
-            }
-        });
+  static class PdfAndroidJavascriptBridge {
+    private File mFile;
+    private @Nullable RandomAccessFile mRandomAccessFile;
+    private @Nullable Callbacks mCallback;
+    private Handler mHandler;
+
+    PdfAndroidJavascriptBridge(String filePath, @Nullable Callbacks callback) {
+      mFile = new File(filePath);
+      mCallback = callback;
+      mHandler = new Handler(Looper.getMainLooper());
     }
 
-    static class ReadabilityCallback implements ReadabilityClient.Callback {
-        private final WeakReference<WebFragment> mReadabilityFragment;
-
-        @Synthetic
-        ReadabilityCallback(WebFragment webFragment) {
-            mReadabilityFragment = new WeakReference<>(webFragment);
+    @JavascriptInterface
+    public String getChunk(long begin, long end) {
+      try {
+        if (mRandomAccessFile == null) {
+          mRandomAccessFile = new RandomAccessFile(mFile, "r");
         }
-
-        @Override
-        public void onResponse(String content) {
-            if (mReadabilityFragment.get() != null && mReadabilityFragment.get().isAttached()) {
-                mReadabilityFragment.get().onParsed(content);
-            }
+        if (mRandomAccessFile != null) {
+          final int bufferSize = (int) (end - begin);
+          byte[] data = new byte[bufferSize];
+          mRandomAccessFile.seek(begin);
+          mRandomAccessFile.read(data);
+          return Base64.encodeToString(data, Base64.DEFAULT);
+        } else {
+          return "";
         }
+      } catch (IOException e) {
+        Log.e("Exception", e.toString());
+        return "";
+      }
     }
 
-    static class ItemResponseListener implements ResponseListener<Item> {
-        private final WeakReference<WebFragment> mFragment;
-
-        @Synthetic
-        ItemResponseListener(WebFragment webFragment) {
-            mFragment = new WeakReference<>(webFragment);
-        }
-
-        @Override
-        public void onResponse(@Nullable Item response) {
-            if (mFragment.get() != null && mFragment.get().isAttached() && response != null) {
-                mFragment.get().onItemLoaded(response);
-            }
-        }
-
-        @Override
-        public void onError(String errorMessage) {
-            // do nothing
-        }
+    @JavascriptInterface
+    public long getSize() {
+      return mFile.length();
     }
 
-    static class PdfAndroidJavascriptBridge {
-        private File mFile;
-        private @Nullable RandomAccessFile mRandomAccessFile;
-        private @Nullable Callbacks mCallback;
-        private Handler mHandler;
-
-        PdfAndroidJavascriptBridge(String filePath, @Nullable Callbacks callback) {
-            mFile = new File(filePath);
-            mCallback = callback;
-            mHandler = new Handler(Looper.getMainLooper());
-        }
-
-        @JavascriptInterface
-        public String getChunk(long begin, long end) {
-            try {
-                if (mRandomAccessFile == null) {
-                    mRandomAccessFile = new RandomAccessFile(mFile, "r");
-                }
-                if (mRandomAccessFile != null) {
-                    final int bufferSize = (int) (end - begin);
-                    byte[] data = new byte[bufferSize];
-                    mRandomAccessFile.seek(begin);
-                    mRandomAccessFile.read(data);
-                    return Base64.encodeToString(data, Base64.DEFAULT);
-                } else {
-                    return "";
-                }
-            } catch (IOException e) {
-                Log.e("Exception", e.toString());
-                return "";
-            }
-        }
-
-        @JavascriptInterface
-        public long getSize() {
-            return mFile.length();
-        }
-
-        @JavascriptInterface
-        public void onLoad() {
-            if (mCallback != null) {
-                mHandler.post(() -> mCallback.onLoad());
-            }
-        }
-
-        @JavascriptInterface
-        public void onFailure() {
-            if (mCallback != null) {
-                mHandler.post(() -> mCallback.onFailure());
-            }
-        }
-
-        public void cleanUp() {
-            try {
-                if (mRandomAccessFile != null) {
-                    mRandomAccessFile.close();
-                }
-            } catch (IOException e) {
-                Log.e("Exception", e.toString());
-            }
-        }
-
-        @Override
-        public void finalize() throws Throwable {
-            try {
-                cleanUp();
-            } finally {
-                super.finalize();
-            }
-        }
-
-        interface Callbacks {
-            void onFailure();
-
-            void onLoad();
-        }
+    @JavascriptInterface
+    public void onLoad() {
+      if (mCallback != null) {
+        mHandler.post(() -> mCallback.onLoad());
+      }
     }
+
+    @JavascriptInterface
+    public void onFailure() {
+      if (mCallback != null) {
+        mHandler.post(() -> mCallback.onFailure());
+      }
+    }
+
+    public void cleanUp() {
+      try {
+        if (mRandomAccessFile != null) {
+          mRandomAccessFile.close();
+        }
+      } catch (IOException e) {
+        Log.e("Exception", e.toString());
+      }
+    }
+
+    @Override
+    public void finalize() throws Throwable {
+      try {
+        cleanUp();
+      } finally {
+        super.finalize();
+      }
+    }
+
+    interface Callbacks {
+      void onFailure();
+
+      void onLoad();
+    }
+  }
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: When navigating away from a PDF to an untrusted website (e.g., via a link inside the PDF view or hitting back/forward), the `PdfAndroidJavascriptBridge` object could remain exposed in the WebView. This bridge has access to `RandomAccessFile` and local files, meaning an untrusted site could call `getChunk` and potentially read the contents of the last downloaded PDF.
🎯 Impact: Data leakage of cached PDF files to untrusted, 3rd party websites.
🔧 Fix: Overrode `onPageStarted` in `WebFragment`'s `AdBlockWebViewClient`. When navigating to any URL other than `PDF_LOADER_URL` (the trusted local viewer), the code securely calls `cleanUp()` and `removeJavascriptInterface` to ensure the bridge is completely destroyed and detached from the WebView.
✅ Verification: Ran unit tests and linting. Verified that `onPageStarted` cleans up the bridge correctly and safely avoids `NullPointerException`.

---
*PR created automatically by Jules for task [15875343100090662173](https://jules.google.com/task/15875343100090662173) started by @sheepdestroyer*

## Summary by Sourcery

Bug Fixes:
- Destroy and detach the PdfAndroidJavascriptBridge when a new page starts loading that is not the trusted PDF loader URL, preventing potential data leakage to untrusted sites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PDF resource cleanup during web navigation to prevent stale connections.

* **Chores**
  * Updated code organization and imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->