### PR TITLE
⚡ Bolt: [performance improvement] Optimize AdBlocker domain matching to use iterative approach

### DIFF
--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/AdBlocker.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/AdBlocker.java
@@ -92,7 +92,7 @@ public class AdBlocker {
     }
 
     /**
-     * Recursively walking up sub domain chain until we exhaust or find a match,
+     * Iteratively walking up sub domain chain until we exhaust or find a match,
      * effectively doing a longest substring matching here
      */
     private static boolean isAdHost(String host) {
@@ -100,7 +100,17 @@ public class AdBlocker {
             return false;
         }
         int index = host.indexOf(".");
-        return index >= 0 && (AD_HOSTS.contains(host) ||
-                index + 1 < host.length() && isAdHost(host.substring(index + 1)));
+        while (index >= 0) {
+            if (AD_HOSTS.contains(host)) {
+                return true;
+            }
+            if (index + 1 < host.length()) {
+                host = host.substring(index + 1);
+                index = host.indexOf(".");
+            } else {
+                break;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
💡 What: Refactored the `isAdHost` method in `AdBlocker.java` to use a `while` loop instead of a recursive method call.
🎯 Why: The original recursive approach created a new stack frame for each subdomain check. This had a small but measurable performance overhead for each intercepted request, and critically, it opened up a potential `StackOverflowError` if a host string was artificially long (e.g., thousands of dots). An iterative approach is faster and safe.
📊 Impact: Eliminates method invocation overhead and prevents stack overflows, making ad-blocking interception slightly faster and much safer.
🔬 Measurement: Verify the logic remains exactly the same by ensuring `AdBlockerTest` (or equivalent domain matching) continues to function perfectly and no network errors appear for very long domain strings.

---
*PR created automatically by Jules for task [17682968626905409473](https://jules.google.com/task/17682968626905409473) started by @sheepdestroyer*

## Summary by Sourcery

Enhancements:
- Replace recursive subdomain checks in ad host matching with an iterative loop to improve performance and avoid potential stack overflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized ad blocking logic for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->