### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Local File Inclusion (LFI) in WebView

### DIFF
--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
@@ -23,8 +23,11 @@ import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
-import java.util.HashMap;
+import android.net.Uri;
+
+import java.io.File;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import androidx.annotation.Nullable;
 import io.github.sheepdestroyer.materialisheep.AdBlocker;
@@ -32,23 +35,56 @@ import io.github.sheepdestroyer.materialisheep.AdBlocker;
 @SuppressWarnings("deprecation") // TODO: Uses deprecated WebResourceRequest API
 public class AdBlockWebViewClient extends WebViewClient {
     private final boolean mAdBlockEnabled;
-    private final Map<String, Boolean> mLoadedUrls = new HashMap<>();
+    private final Map<String, Boolean> mLoadedUrls = new ConcurrentHashMap<>();
 
     public AdBlockWebViewClient(boolean adBlockEnabled) {
         mAdBlockEnabled = adBlockEnabled;
     }
 
+    private boolean isLocalFileAccessAllowed(WebView view, String url) {
+        try {
+            String path = Uri.parse(url).getPath();
+            if (path == null) {
+                return false;
+            }
+            File requestedFile = new File(path);
+            String canonicalPath = requestedFile.getCanonicalPath();
+
+            File cacheDir = view.getContext().getApplicationContext().getCacheDir();
+            String cacheDirPath = cacheDir.getCanonicalPath() + File.separator;
+
+            if (canonicalPath.startsWith(cacheDirPath)) {
+                return true;
+            }
+
+            if (canonicalPath.startsWith("/android_asset/")) {
+                return true;
+            }
+
+            return false;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
     @Override
     public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
+        if (url != null && url.toLowerCase().startsWith("file://") && !isLocalFileAccessAllowed(view, url)) {
+            return AdBlocker.createEmptyResource();
+        }
+
         if (!mAdBlockEnabled) {
             return super.shouldInterceptRequest(view, url);
         }
-        boolean ad;
-        if (!mLoadedUrls.containsKey(url)) {
-            ad = AdBlocker.isAd(url);
-            mLoadedUrls.put(url, ad);
+        Boolean ad;
+        if (url == null) {
+            ad = false;
         } else {
             ad = mLoadedUrls.get(url);
+            if (ad == null) {
+                ad = AdBlocker.isAd(url);
+                mLoadedUrls.put(url, ad);
+            }
         }
         return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, url);
     }
@@ -56,16 +92,24 @@ public class AdBlockWebViewClient extends WebViewClient {
     @Nullable
     @Override
     public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+        String url = request.getUrl() != null ? request.getUrl().toString() : null;
+
+        if (url != null && url.toLowerCase().startsWith("file://") && !isLocalFileAccessAllowed(view, url)) {
+            return AdBlocker.createEmptyResource();
+        }
+
         if (!mAdBlockEnabled) {
             return super.shouldInterceptRequest(view, request);
         }
-        boolean ad;
-        String url = request.getUrl().toString();
-        if (!mLoadedUrls.containsKey(url)) {
-            ad = AdBlocker.isAd(url);
-            mLoadedUrls.put(url, ad);
+        Boolean ad;
+        if (url == null) {
+            ad = false;
         } else {
             ad = mLoadedUrls.get(url);
+            if (ad == null) {
+                ad = AdBlocker.isAd(url);
+                mLoadedUrls.put(url, ad);
+            }
         }
         return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, request);
     }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
@@ -16,101 +16,100 @@
 
 package io.github.sheepdestroyer.materialisheep.widget;
 
-import android.annotation.TargetApi;
-import android.os.Build;
+import android.net.Uri;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
-
-import android.net.Uri;
-
+import androidx.annotation.Nullable;
+import io.github.sheepdestroyer.materialisheep.AdBlocker;
 import java.io.File;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import androidx.annotation.Nullable;
-import io.github.sheepdestroyer.materialisheep.AdBlocker;
-
 @SuppressWarnings("deprecation") // TODO: Uses deprecated WebResourceRequest API
 public class AdBlockWebViewClient extends WebViewClient {
-    private final boolean mAdBlockEnabled;
-    private final Map<String, Boolean> mLoadedUrls = new ConcurrentHashMap<>();
+  private final boolean mAdBlockEnabled;
+  private final Map<String, Boolean> mLoadedUrls = new ConcurrentHashMap<>();
 
-    public AdBlockWebViewClient(boolean adBlockEnabled) {
-        mAdBlockEnabled = adBlockEnabled;
+  public AdBlockWebViewClient(boolean adBlockEnabled) {
+    mAdBlockEnabled = adBlockEnabled;
+  }
+
+  private boolean isLocalFileAccessAllowed(WebView view, String url) {
+    try {
+      String path = Uri.parse(url).getPath();
+      if (path == null) {
+        return false;
+      }
+      File requestedFile = new File(path);
+      String canonicalPath = requestedFile.getCanonicalPath();
+
+      File cacheDir = view.getContext().getApplicationContext().getCacheDir();
+      String cacheDirPath = cacheDir.getCanonicalPath() + File.separator;
+
+      if (canonicalPath.startsWith(cacheDirPath)) {
+        return true;
+      }
+
+      if (canonicalPath.startsWith("/android_asset/")) {
+        return true;
+      }
+
+      return false;
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  @Override
+  public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
+    if (url != null
+        && url.toLowerCase().startsWith("file://")
+        && !isLocalFileAccessAllowed(view, url)) {
+      return AdBlocker.createEmptyResource();
     }
 
-    private boolean isLocalFileAccessAllowed(WebView view, String url) {
-        try {
-            String path = Uri.parse(url).getPath();
-            if (path == null) {
-                return false;
-            }
-            File requestedFile = new File(path);
-            String canonicalPath = requestedFile.getCanonicalPath();
+    if (!mAdBlockEnabled) {
+      return super.shouldInterceptRequest(view, url);
+    }
+    Boolean ad;
+    if (url == null) {
+      ad = false;
+    } else {
+      ad = mLoadedUrls.get(url);
+      if (ad == null) {
+        ad = AdBlocker.isAd(url);
+        mLoadedUrls.put(url, ad);
+      }
+    }
+    return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, url);
+  }
 
-            File cacheDir = view.getContext().getApplicationContext().getCacheDir();
-            String cacheDirPath = cacheDir.getCanonicalPath() + File.separator;
+  @Nullable
+  @Override
+  public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+    String url = request.getUrl() != null ? request.getUrl().toString() : null;
 
-            if (canonicalPath.startsWith(cacheDirPath)) {
-                return true;
-            }
-
-            if (canonicalPath.startsWith("/android_asset/")) {
-                return true;
-            }
-
-            return false;
-        } catch (Exception e) {
-            return false;
-        }
+    if (url != null
+        && url.toLowerCase().startsWith("file://")
+        && !isLocalFileAccessAllowed(view, url)) {
+      return AdBlocker.createEmptyResource();
     }
 
-    @Override
-    public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
-        if (url != null && url.toLowerCase().startsWith("file://") && !isLocalFileAccessAllowed(view, url)) {
-            return AdBlocker.createEmptyResource();
-        }
-
-        if (!mAdBlockEnabled) {
-            return super.shouldInterceptRequest(view, url);
-        }
-        Boolean ad;
-        if (url == null) {
-            ad = false;
-        } else {
-            ad = mLoadedUrls.get(url);
-            if (ad == null) {
-                ad = AdBlocker.isAd(url);
-                mLoadedUrls.put(url, ad);
-            }
-        }
-        return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, url);
+    if (!mAdBlockEnabled) {
+      return super.shouldInterceptRequest(view, request);
     }
-
-    @Nullable
-    @Override
-    public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
-        String url = request.getUrl() != null ? request.getUrl().toString() : null;
-
-        if (url != null && url.toLowerCase().startsWith("file://") && !isLocalFileAccessAllowed(view, url)) {
-            return AdBlocker.createEmptyResource();
-        }
-
-        if (!mAdBlockEnabled) {
-            return super.shouldInterceptRequest(view, request);
-        }
-        Boolean ad;
-        if (url == null) {
-            ad = false;
-        } else {
-            ad = mLoadedUrls.get(url);
-            if (ad == null) {
-                ad = AdBlocker.isAd(url);
-                mLoadedUrls.put(url, ad);
-            }
-        }
-        return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, request);
+    Boolean ad;
+    if (url == null) {
+      ad = false;
+    } else {
+      ad = mLoadedUrls.get(url);
+      if (ad == null) {
+        ad = AdBlocker.isAd(url);
+        mLoadedUrls.put(url, ad);
+      }
     }
+    return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, request);
+  }
 }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `AdBlockWebViewClient` was missing validation for `file://` scheme requests during URL interception, allowing for arbitrary local file access (Local File Inclusion / Path Traversal). The `mLoadedUrls` map was also using an unsafe `HashMap` on background threads.
🎯 Impact: Malicious content loaded in the WebView could potentially read sensitive files from the application's internal storage directory or bypass file constraints using relative paths (`../`). Furthermore, `HashMap` concurrency issues could crash the application via `ConcurrentModificationException`.
🔧 Fix: Added robust URL scheme checking and Canonical Path validation. The `isLocalFileAccessAllowed` method decodes paths safely and verifies they strictly start with the canonical paths of either the `getCacheDir()` (with trailing separator) or `/android_asset/`. Unauthorized attempts are immediately blocked with an empty resource. Also replaced `HashMap` with `ConcurrentHashMap` for thread safety while protecting against null references.
✅ Verification: Ran `./gradlew clean lint testDebugUnitTest` and confirmed compilation, passing tests, and no related lint issues. Read verification via `git diff`.

---
*PR created automatically by Jules for task [8146750970329592979](https://jules.google.com/task/8146750970329592979) started by @sheepdestroyer*

## Summary by Sourcery

Harden WebView URL interception against unsafe local file access while improving thread safety and null handling in ad-blocking logic.

Bug Fixes:
- Block unauthorized WebView access to local files by validating file:// URLs against canonical cache and /android_asset paths before loading resources.
- Prevent potential concurrency issues in the URL cache by replacing the non-thread-safe HashMap with a ConcurrentHashMap and handling missing entries safely.
- Avoid null-related crashes in ad-blocking interception by safely handling null URLs when checking and caching ad status.

Enhancements:
- Centralize local file access checks into a dedicated helper to consistently enforce safe path validation across both shouldInterceptRequest overloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added file access control for local files in WebView, blocking unauthorized access while allowing assets and cache directories.

* **Improvements**
  * Enhanced ad-blocking performance through URL caching mechanism.
  * Updated request interception logic for both standard and modern WebView APIs with consistent security handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->