### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Local File Inclusion in AdBlockWebViewClient

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - Fix Local File Inclusion in AdBlockWebViewClient
+**Vulnerability:** AdBlockWebViewClient intercepted requests but missed mitigating LFI via URL.
+**Learning:** CacheableWebView enables file access to support offline archives. Attackers could request file:// URIs via the WebView, leading to LFI. Interception mechanisms must explicitly block access to local files.
+**Prevention:** In WebView clients, explicitly validate the canonical path for 'file://' URIs. Deny everything outside the application's legitimate asset and cache directories before checking ad block rules.

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
@@ -16,82 +16,79 @@
 
 package io.github.sheepdestroyer.materialisheep.widget;
 
-import android.annotation.TargetApi;
-import android.os.Build;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
-
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.Map;
-
 import androidx.annotation.Nullable;
 import io.github.sheepdestroyer.materialisheep.AdBlocker;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 @SuppressWarnings("deprecation") // TODO: Uses deprecated WebResourceRequest API
 public class AdBlockWebViewClient extends WebViewClient {
-    private final boolean mAdBlockEnabled;
-    private final Map<String, Boolean> mLoadedUrls = new ConcurrentHashMap<>();
+  private final boolean mAdBlockEnabled;
+  private final Map<String, Boolean> mLoadedUrls = new ConcurrentHashMap<>();
 
-    public AdBlockWebViewClient(boolean adBlockEnabled) {
-        mAdBlockEnabled = adBlockEnabled;
+  public AdBlockWebViewClient(boolean adBlockEnabled) {
+    mAdBlockEnabled = adBlockEnabled;
+  }
+
+  private WebResourceResponse handleLocalFile(WebView view, String url) {
+    try {
+      String path = android.net.Uri.parse(url).getPath();
+      if (path != null) {
+        java.io.File file = new java.io.File(path);
+        String canonicalPath = file.getCanonicalPath();
+        String cacheDir =
+            view.getContext().getCacheDir().getCanonicalPath() + java.io.File.separator;
+        if (canonicalPath.startsWith(cacheDir) || path.startsWith("/android_asset/")) {
+          return null;
+        }
+      }
+    } catch (Exception e) {
+      // Log or ignore
+    }
+    return AdBlocker.createEmptyResource();
+  }
+
+  @Override
+  public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
+    if (url != null && url.toLowerCase().startsWith("file://")) {
+      return handleLocalFile(view, url);
     }
 
-    private WebResourceResponse handleLocalFile(WebView view, String url) {
-        try {
-            String path = android.net.Uri.parse(url).getPath();
-            if (path != null) {
-                java.io.File file = new java.io.File(path);
-                String canonicalPath = file.getCanonicalPath();
-                String cacheDir = view.getContext().getCacheDir().getCanonicalPath() + java.io.File.separator;
-                if (canonicalPath.startsWith(cacheDir) || path.startsWith("/android_asset/")) {
-                    return null;
-                }
-            }
-        } catch (Exception e) {
-            // Log or ignore
-        }
-        return AdBlocker.createEmptyResource();
+    if (!mAdBlockEnabled) {
+      return super.shouldInterceptRequest(view, url);
+    }
+    boolean ad;
+    if (!mLoadedUrls.containsKey(url)) {
+      ad = AdBlocker.isAd(url);
+      mLoadedUrls.put(url, ad);
+    } else {
+      ad = mLoadedUrls.get(url);
+    }
+    return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, url);
+  }
+
+  @Nullable
+  @Override
+  public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+    String url = request.getUrl().toString();
+    if (url.toLowerCase().startsWith("file://")) {
+      return handleLocalFile(view, url);
     }
 
-    @Override
-    public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
-        if (url != null && url.toLowerCase().startsWith("file://")) {
-            return handleLocalFile(view, url);
-        }
-
-        if (!mAdBlockEnabled) {
-            return super.shouldInterceptRequest(view, url);
-        }
-        boolean ad;
-        if (!mLoadedUrls.containsKey(url)) {
-            ad = AdBlocker.isAd(url);
-            mLoadedUrls.put(url, ad);
-        } else {
-            ad = mLoadedUrls.get(url);
-        }
-        return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, url);
+    if (!mAdBlockEnabled) {
+      return super.shouldInterceptRequest(view, request);
     }
-
-    @Nullable
-    @Override
-    public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
-        String url = request.getUrl().toString();
-        if (url.toLowerCase().startsWith("file://")) {
-            return handleLocalFile(view, url);
-        }
-
-        if (!mAdBlockEnabled) {
-            return super.shouldInterceptRequest(view, request);
-        }
-        boolean ad;
-        if (!mLoadedUrls.containsKey(url)) {
-            ad = AdBlocker.isAd(url);
-            mLoadedUrls.put(url, ad);
-        } else {
-            ad = mLoadedUrls.get(url);
-        }
-        return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, request);
+    boolean ad;
+    if (!mLoadedUrls.containsKey(url)) {
+      ad = AdBlocker.isAd(url);
+      mLoadedUrls.put(url, ad);
+    } else {
+      ad = mLoadedUrls.get(url);
     }
+    return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, request);
+  }
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
@@ -23,7 +23,7 @@ import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
-import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.Map;
 
 import androidx.annotation.Nullable;
@@ -32,14 +32,35 @@ import io.github.sheepdestroyer.materialisheep.AdBlocker;
 @SuppressWarnings("deprecation") // TODO: Uses deprecated WebResourceRequest API
 public class AdBlockWebViewClient extends WebViewClient {
     private final boolean mAdBlockEnabled;
-    private final Map<String, Boolean> mLoadedUrls = new HashMap<>();
+    private final Map<String, Boolean> mLoadedUrls = new ConcurrentHashMap<>();
 
     public AdBlockWebViewClient(boolean adBlockEnabled) {
         mAdBlockEnabled = adBlockEnabled;
     }
 
+    private WebResourceResponse handleLocalFile(WebView view, String url) {
+        try {
+            String path = android.net.Uri.parse(url).getPath();
+            if (path != null) {
+                java.io.File file = new java.io.File(path);
+                String canonicalPath = file.getCanonicalPath();
+                String cacheDir = view.getContext().getCacheDir().getCanonicalPath() + java.io.File.separator;
+                if (canonicalPath.startsWith(cacheDir) || path.startsWith("/android_asset/")) {
+                    return null;
+                }
+            }
+        } catch (Exception e) {
+            // Log or ignore
+        }
+        return AdBlocker.createEmptyResource();
+    }
+
     @Override
     public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
+        if (url != null && url.toLowerCase().startsWith("file://")) {
+            return handleLocalFile(view, url);
+        }
+
         if (!mAdBlockEnabled) {
             return super.shouldInterceptRequest(view, url);
         }
@@ -56,11 +77,15 @@ public class AdBlockWebViewClient extends WebViewClient {
     @Nullable
     @Override
     public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+        String url = request.getUrl().toString();
+        if (url.toLowerCase().startsWith("file://")) {
+            return handleLocalFile(view, url);
+        }
+
         if (!mAdBlockEnabled) {
             return super.shouldInterceptRequest(view, request);
         }
         boolean ad;
-        String url = request.getUrl().toString();
         if (!mLoadedUrls.containsKey(url)) {
             ad = AdBlocker.isAd(url);
             mLoadedUrls.put(url, ad);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Local File Inclusion (LFI). `CacheableWebView` correctly enables `setAllowFileAccess(true)` to support loading internal cache archives (`.mht` files). However, `AdBlockWebViewClient` failed to intercept and restrict `file://` URIs. An attacker could exploit this by navigating the WebView to a local file URI (`file:///data/data/io.github.sheepdestroyer.materialisheep/shared_prefs/...`) to expose sensitive data.
🎯 Impact: An attacker could read arbitrary private application data, preferences, databases, or cache data.
🔧 Fix: Added explicit checks inside both variants of `shouldInterceptRequest` to intercept all `file://` URIs. Allowed files are strictly constrained to the app's cache directory (via `getCanonicalPath()` to prevent traversal attacks) and `/android_asset/`. All other local paths are blocked by returning an empty `WebResourceResponse`. Also upgraded the internal state map `mLoadedUrls` to a `ConcurrentHashMap` to eliminate a race condition since `shouldInterceptRequest` is invoked concurrently.
✅ Verification: `./gradlew clean lint testDebugUnitTest` executed and passed successfully. Tested logic properly intercepts and evaluates internal URI structures.

---
*PR created automatically by Jules for task [11991326720120098890](https://jules.google.com/task/11991326720120098890) started by @sheepdestroyer*

## Summary by Sourcery

Harden WebView request handling to prevent local file inclusion and improve thread safety of URL tracking.

Bug Fixes:
- Block access to local file URIs in AdBlockWebViewClient, only allowing resources from the app cache directory and /android_asset/, and return empty responses for all other file paths to mitigate LFI.

Enhancements:
- Replace the HashMap used to track loaded URLs in AdBlockWebViewClient with a ConcurrentHashMap to support concurrent request interception safely.

Documentation:
- Add a Sentinel security note documenting the LFI vulnerability, its root cause, and recommended prevention practices for WebView file URI handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security advisory documenting local file inclusion vulnerability in WebView client handling.

* **Bug Fixes**
  * Enhanced file path validation in WebView client for requests under application cache and asset directories.
  * Improved concurrency handling for cached URL requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->