### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix LFI vulnerability in AdBlockWebViewClient

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - LFI vulnerability in AdBlockWebViewClient
+**Vulnerability:** A local file inclusion (LFI) vulnerability exists in the WebViews because `setAllowFileAccess(true)` is required for caching. This allowed any `file://` URL loaded within the WebView to bypass normal constraints if intercepted incorrectly.
+**Learning:** `AdBlockWebViewClient` was missing logic to validate `file://` accesses to restrict them specifically to the app's cache dir and the `/android_asset/` directory. Without explicit filtering, malicious inputs could construct a file URL pointing anywhere and the WebView would happily load it.
+**Prevention:** In `shouldInterceptRequest`, explicitly parse the `file://` URL scheme, resolve the absolute path, and compare its canonical path against allowed base directories (`getCacheDir().getCanonicalPath()` and `/android_asset/`). Return an empty web resource if the request tries to escape the allowed roots.

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
@@ -16,89 +16,85 @@
 
 package io.github.sheepdestroyer.materialisheep.widget;
 
-import android.annotation.TargetApi;
-import android.os.Build;
+import android.net.Uri;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
-
-import java.util.concurrent.ConcurrentHashMap;
-import java.io.File;
-import android.net.Uri;
-import java.util.Map;
-
 import androidx.annotation.Nullable;
 import io.github.sheepdestroyer.materialisheep.AdBlocker;
+import java.io.File;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 @SuppressWarnings("deprecation") // TODO: Uses deprecated WebResourceRequest API
 public class AdBlockWebViewClient extends WebViewClient {
-    private final boolean mAdBlockEnabled;
-    private final Map<String, Boolean> mLoadedUrls = new ConcurrentHashMap<>();
+  private final boolean mAdBlockEnabled;
+  private final Map<String, Boolean> mLoadedUrls = new ConcurrentHashMap<>();
 
-    public AdBlockWebViewClient(boolean adBlockEnabled) {
-        mAdBlockEnabled = adBlockEnabled;
+  public AdBlockWebViewClient(boolean adBlockEnabled) {
+    mAdBlockEnabled = adBlockEnabled;
+  }
+
+  private WebResourceResponse checkFileAccess(WebView view, String url) {
+    if (url != null && url.toLowerCase(java.util.Locale.ROOT).startsWith("file://")) {
+      try {
+        String path = Uri.parse(url).getPath();
+        if (path != null) {
+          File file = new File(path);
+          String canonicalPath = file.getCanonicalPath();
+          String cacheDirPath = view.getContext().getCacheDir().getCanonicalPath() + File.separator;
+          if (!canonicalPath.startsWith(cacheDirPath)
+              && !canonicalPath.startsWith("/android_asset/")) {
+            return AdBlocker.createEmptyResource();
+          }
+        }
+      } catch (Exception e) {
+        return AdBlocker.createEmptyResource();
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
+    WebResourceResponse fileCheck = checkFileAccess(view, url);
+    if (fileCheck != null) {
+      return fileCheck;
     }
 
-    private WebResourceResponse checkFileAccess(WebView view, String url) {
-        if (url != null && url.toLowerCase(java.util.Locale.ROOT).startsWith("file://")) {
-            try {
-                String path = Uri.parse(url).getPath();
-                if (path != null) {
-                    File file = new File(path);
-                    String canonicalPath = file.getCanonicalPath();
-                    String cacheDirPath = view.getContext().getCacheDir().getCanonicalPath() + File.separator;
-                    if (!canonicalPath.startsWith(cacheDirPath) && !canonicalPath.startsWith("/android_asset/")) {
-                        return AdBlocker.createEmptyResource();
-                    }
-                }
-            } catch (Exception e) {
-                return AdBlocker.createEmptyResource();
-            }
-        }
-        return null;
+    if (!mAdBlockEnabled) {
+      return super.shouldInterceptRequest(view, url);
+    }
+    boolean ad;
+    if (!mLoadedUrls.containsKey(url)) {
+      ad = AdBlocker.isAd(url);
+      mLoadedUrls.put(url, ad);
+    } else {
+      ad = mLoadedUrls.get(url);
+    }
+    return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, url);
+  }
+
+  @Nullable
+  @Override
+  public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+    WebResourceResponse fileCheck = checkFileAccess(view, request.getUrl().toString());
+    if (fileCheck != null) {
+      return fileCheck;
     }
 
-
-    @Override
-    public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
-        WebResourceResponse fileCheck = checkFileAccess(view, url);
-        if (fileCheck != null) {
-            return fileCheck;
-        }
-
-        if (!mAdBlockEnabled) {
-            return super.shouldInterceptRequest(view, url);
-        }
-        boolean ad;
-        if (!mLoadedUrls.containsKey(url)) {
-            ad = AdBlocker.isAd(url);
-            mLoadedUrls.put(url, ad);
-        } else {
-            ad = mLoadedUrls.get(url);
-        }
-        return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, url);
+    if (!mAdBlockEnabled) {
+      return super.shouldInterceptRequest(view, request);
     }
-
-    @Nullable
-    @Override
-    public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
-        WebResourceResponse fileCheck = checkFileAccess(view, request.getUrl().toString());
-        if (fileCheck != null) {
-            return fileCheck;
-        }
-
-        if (!mAdBlockEnabled) {
-            return super.shouldInterceptRequest(view, request);
-        }
-        boolean ad;
-        String url = request.getUrl().toString();
-        if (!mLoadedUrls.containsKey(url)) {
-            ad = AdBlocker.isAd(url);
-            mLoadedUrls.put(url, ad);
-        } else {
-            ad = mLoadedUrls.get(url);
-        }
-        return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, request);
+    boolean ad;
+    String url = request.getUrl().toString();
+    if (!mLoadedUrls.containsKey(url)) {
+      ad = AdBlocker.isAd(url);
+      mLoadedUrls.put(url, ad);
+    } else {
+      ad = mLoadedUrls.get(url);
     }
+    return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, request);
+  }
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
@@ -23,7 +23,9 @@ import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
-import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.io.File;
+import android.net.Uri;
 import java.util.Map;
 
 import androidx.annotation.Nullable;
@@ -32,14 +34,39 @@ import io.github.sheepdestroyer.materialisheep.AdBlocker;
 @SuppressWarnings("deprecation") // TODO: Uses deprecated WebResourceRequest API
 public class AdBlockWebViewClient extends WebViewClient {
     private final boolean mAdBlockEnabled;
-    private final Map<String, Boolean> mLoadedUrls = new HashMap<>();
+    private final Map<String, Boolean> mLoadedUrls = new ConcurrentHashMap<>();
 
     public AdBlockWebViewClient(boolean adBlockEnabled) {
         mAdBlockEnabled = adBlockEnabled;
     }
 
+    private WebResourceResponse checkFileAccess(WebView view, String url) {
+        if (url != null && url.toLowerCase(java.util.Locale.ROOT).startsWith("file://")) {
+            try {
+                String path = Uri.parse(url).getPath();
+                if (path != null) {
+                    File file = new File(path);
+                    String canonicalPath = file.getCanonicalPath();
+                    String cacheDirPath = view.getContext().getCacheDir().getCanonicalPath() + File.separator;
+                    if (!canonicalPath.startsWith(cacheDirPath) && !canonicalPath.startsWith("/android_asset/")) {
+                        return AdBlocker.createEmptyResource();
+                    }
+                }
+            } catch (Exception e) {
+                return AdBlocker.createEmptyResource();
+            }
+        }
+        return null;
+    }
+
+
     @Override
     public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
+        WebResourceResponse fileCheck = checkFileAccess(view, url);
+        if (fileCheck != null) {
+            return fileCheck;
+        }
+
         if (!mAdBlockEnabled) {
             return super.shouldInterceptRequest(view, url);
         }
@@ -56,6 +83,11 @@ public class AdBlockWebViewClient extends WebViewClient {
     @Nullable
     @Override
     public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+        WebResourceResponse fileCheck = checkFileAccess(view, request.getUrl().toString());
+        if (fileCheck != null) {
+            return fileCheck;
+        }
+
         if (!mAdBlockEnabled) {
             return super.shouldInterceptRequest(view, request);
         }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A local file inclusion (LFI) vulnerability exists in `AdBlockWebViewClient`. `setAllowFileAccess(true)` is required for caching in `CacheableWebView`, which allows any `file://` URL loaded within the WebView to bypass normal constraints and potentially access sensitive files on the device.
🎯 Impact: Malicious content loaded within the WebView could construct `file://` URLs with path traversal (`../`) to read arbitrary files from the application's internal storage or other accessible directories on the filesystem.
🔧 Fix: Added explicit scheme checking in `AdBlockWebViewClient.shouldInterceptRequest`. For any `file://` request, it resolves the canonical path and strictly enforces that it resides within either the application's cache directory or the `/android_asset/` directory. Requests escaping these bounds are blocked (returning an empty resource). Additionally, upgraded `mLoadedUrls` to `ConcurrentHashMap` to ensure thread safety during interception.
✅ Verification: Ran unit tests and lint checks successfully. Validated that canonical path resolution blocks path traversals.

---
*PR created automatically by Jules for task [1625419950835421616](https://jules.google.com/task/1625419950835421616) started by @sheepdestroyer*

## Summary by Sourcery

Harden WebView request handling in AdBlockWebViewClient to prevent unsafe local file access while maintaining ad-blocking behavior.

Bug Fixes:
- Block local file inclusion by restricting WebView file:// requests to the app cache directory and /android_asset/, returning an empty resource for any other file paths.

Enhancements:
- Make the AdBlockWebViewClient URL tracking map thread-safe with ConcurrentHashMap to avoid concurrency issues during request interception.

Documentation:
- Add a Sentinel security incident note documenting the LFI vulnerability, its root cause, and the prevention measures implemented.