### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Local File Inclusion (LFI) in WebView

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - [WebResourceResponse NullPointer Crash]
+**Vulnerability:** NullPointerException risk when blocking requests in `shouldInterceptRequest`.
+**Learning:** Android's `WebResourceResponse` constructor throws an exception or crashes the app if the `InputStream` is null when returning a blocked resource response.
+**Prevention:** Always use a valid empty stream (e.g., `new ByteArrayInputStream(new byte[0])`) or existing helpers like `AdBlocker.createEmptyResource()` instead of passing `null`.

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
@@ -16,89 +16,87 @@
 
 package io.github.sheepdestroyer.materialisheep.widget;
 
-import android.annotation.TargetApi;
-import android.os.Build;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
-
+import androidx.annotation.Nullable;
+import io.github.sheepdestroyer.materialisheep.AdBlocker;
 import java.util.HashMap;
 import java.util.Map;
 
-import androidx.annotation.Nullable;
-import io.github.sheepdestroyer.materialisheep.AdBlocker;
-
 @SuppressWarnings("deprecation") // TODO: Uses deprecated WebResourceRequest API
 public class AdBlockWebViewClient extends WebViewClient {
-    private final boolean mAdBlockEnabled;
-    private final Map<String, Boolean> mLoadedUrls = new HashMap<>();
+  private final boolean mAdBlockEnabled;
+  private final Map<String, Boolean> mLoadedUrls = new HashMap<>();
 
-    public AdBlockWebViewClient(boolean adBlockEnabled) {
-        mAdBlockEnabled = adBlockEnabled;
-    }
+  public AdBlockWebViewClient(boolean adBlockEnabled) {
+    mAdBlockEnabled = adBlockEnabled;
+  }
 
-    @Override
-    public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
-        if (url != null && url.toLowerCase(java.util.Locale.ROOT).startsWith("file://")) {
-            try {
-                String path = android.net.Uri.parse(url).getPath();
-                if (path != null) {
-                    java.io.File file = new java.io.File(path);
-                    String canonicalPath = file.getCanonicalPath();
-                    String cacheDir = view.getContext().getCacheDir().getCanonicalPath() + java.io.File.separator;
-                    if (canonicalPath.startsWith(cacheDir) || canonicalPath.startsWith("/android_asset/")) {
-                        return null;
-                    }
-                }
-            } catch (Exception e) {
-                // Ignore exception and block
-            }
-            return AdBlocker.createEmptyResource();
+  @Override
+  public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
+    if (url != null && url.toLowerCase(java.util.Locale.ROOT).startsWith("file://")) {
+      try {
+        String path = android.net.Uri.parse(url).getPath();
+        if (path != null) {
+          java.io.File file = new java.io.File(path);
+          String canonicalPath = file.getCanonicalPath();
+          String cacheDir =
+              view.getContext().getCacheDir().getCanonicalPath() + java.io.File.separator;
+          if (canonicalPath.startsWith(cacheDir) || canonicalPath.startsWith("/android_asset/")) {
+            return null;
+          }
         }
-        if (!mAdBlockEnabled) {
-            return super.shouldInterceptRequest(view, url);
-        }
-        boolean ad;
-        if (!mLoadedUrls.containsKey(url)) {
-            ad = AdBlocker.isAd(url);
-            mLoadedUrls.put(url, ad);
-        } else {
-            ad = mLoadedUrls.get(url);
-        }
-        return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, url);
+      } catch (Exception e) {
+        // Ignore exception and block
+      }
+      return AdBlocker.createEmptyResource();
     }
+    if (!mAdBlockEnabled) {
+      return super.shouldInterceptRequest(view, url);
+    }
+    boolean ad;
+    if (!mLoadedUrls.containsKey(url)) {
+      ad = AdBlocker.isAd(url);
+      mLoadedUrls.put(url, ad);
+    } else {
+      ad = mLoadedUrls.get(url);
+    }
+    return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, url);
+  }
 
-    @Nullable
-    @Override
-    public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
-        String urlStr = request.getUrl().toString();
-        if (urlStr.toLowerCase(java.util.Locale.ROOT).startsWith("file://")) {
-            try {
-                String path = request.getUrl().getPath();
-                if (path != null) {
-                    java.io.File file = new java.io.File(path);
-                    String canonicalPath = file.getCanonicalPath();
-                    String cacheDir = view.getContext().getCacheDir().getCanonicalPath() + java.io.File.separator;
-                    if (canonicalPath.startsWith(cacheDir) || canonicalPath.startsWith("/android_asset/")) {
-                        return null;
-                    }
-                }
-            } catch (Exception e) {
-                // Ignore exception and block
-            }
-            return AdBlocker.createEmptyResource();
+  @Nullable
+  @Override
+  public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+    String urlStr = request.getUrl().toString();
+    if (urlStr.toLowerCase(java.util.Locale.ROOT).startsWith("file://")) {
+      try {
+        String path = request.getUrl().getPath();
+        if (path != null) {
+          java.io.File file = new java.io.File(path);
+          String canonicalPath = file.getCanonicalPath();
+          String cacheDir =
+              view.getContext().getCacheDir().getCanonicalPath() + java.io.File.separator;
+          if (canonicalPath.startsWith(cacheDir) || canonicalPath.startsWith("/android_asset/")) {
+            return null;
+          }
         }
-        if (!mAdBlockEnabled) {
-            return super.shouldInterceptRequest(view, request);
-        }
-        boolean ad;
-        if (!mLoadedUrls.containsKey(urlStr)) {
-            ad = AdBlocker.isAd(urlStr);
-            mLoadedUrls.put(urlStr, ad);
-        } else {
-            ad = mLoadedUrls.get(urlStr);
-        }
-        return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, request);
+      } catch (Exception e) {
+        // Ignore exception and block
+      }
+      return AdBlocker.createEmptyResource();
     }
+    if (!mAdBlockEnabled) {
+      return super.shouldInterceptRequest(view, request);
+    }
+    boolean ad;
+    if (!mLoadedUrls.containsKey(urlStr)) {
+      ad = AdBlocker.isAd(urlStr);
+      mLoadedUrls.put(urlStr, ad);
+    } else {
+      ad = mLoadedUrls.get(urlStr);
+    }
+    return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, request);
+  }
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
@@ -40,6 +40,22 @@ public class AdBlockWebViewClient extends WebViewClient {
 
     @Override
     public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
+        if (url != null && url.toLowerCase(java.util.Locale.ROOT).startsWith("file://")) {
+            try {
+                String path = android.net.Uri.parse(url).getPath();
+                if (path != null) {
+                    java.io.File file = new java.io.File(path);
+                    String canonicalPath = file.getCanonicalPath();
+                    String cacheDir = view.getContext().getCacheDir().getCanonicalPath() + java.io.File.separator;
+                    if (canonicalPath.startsWith(cacheDir) || canonicalPath.startsWith("/android_asset/")) {
+                        return null;
+                    }
+                }
+            } catch (Exception e) {
+                // Ignore exception and block
+            }
+            return AdBlocker.createEmptyResource();
+        }
         if (!mAdBlockEnabled) {
             return super.shouldInterceptRequest(view, url);
         }
@@ -56,16 +72,32 @@ public class AdBlockWebViewClient extends WebViewClient {
     @Nullable
     @Override
     public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+        String urlStr = request.getUrl().toString();
+        if (urlStr.toLowerCase(java.util.Locale.ROOT).startsWith("file://")) {
+            try {
+                String path = request.getUrl().getPath();
+                if (path != null) {
+                    java.io.File file = new java.io.File(path);
+                    String canonicalPath = file.getCanonicalPath();
+                    String cacheDir = view.getContext().getCacheDir().getCanonicalPath() + java.io.File.separator;
+                    if (canonicalPath.startsWith(cacheDir) || canonicalPath.startsWith("/android_asset/")) {
+                        return null;
+                    }
+                }
+            } catch (Exception e) {
+                // Ignore exception and block
+            }
+            return AdBlocker.createEmptyResource();
+        }
         if (!mAdBlockEnabled) {
             return super.shouldInterceptRequest(view, request);
         }
         boolean ad;
-        String url = request.getUrl().toString();
-        if (!mLoadedUrls.containsKey(url)) {
-            ad = AdBlocker.isAd(url);
-            mLoadedUrls.put(url, ad);
+        if (!mLoadedUrls.containsKey(urlStr)) {
+            ad = AdBlocker.isAd(urlStr);
+            mLoadedUrls.put(urlStr, ad);
         } else {
-            ad = mLoadedUrls.get(url);
+            ad = mLoadedUrls.get(urlStr);
         }
         return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, request);
     }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `AdBlockWebViewClient` allowed unrestricted `file://` access because `CacheableWebView` explicitly enabled `setAllowFileAccess(true)` to support its caching mechanism. This creates a Path Traversal / Local File Inclusion vulnerability where a malicious webpage loaded into the WebView could access sensitive application data (like `/data/data/io.github.sheepdestroyer.materialisheep/databases/`).
🎯 Impact: An attacker could execute JavaScript in the context of the app to read internal files, leading to sensitive data exfiltration (e.g., cached user data, internal databases, shared preferences).
🔧 Fix: Implemented path validation in `shouldInterceptRequest`. `file://` requests are now intercepted, their canonical paths are resolved (preventing `../` traversal), and they are blocked unless the path strictly falls under the application's cache directory or `/android_asset/`. Used `AdBlocker.createEmptyResource()` to block unauthorized access safely.
✅ Verification: `file://` requests that traverse out of allowed directories are safely blocked without crashing the app, and legitimate cache files continue to load perfectly.

---
*PR created automatically by Jules for task [7158224934039338836](https://jules.google.com/task/7158224934039338836) started by @sheepdestroyer*

## Summary by Sourcery

Harden WebView request handling to prevent local file inclusion via file:// URLs and document the associated Sentinel finding.

Bug Fixes:
- Block unauthorized file:// requests in WebView by validating canonical paths and only allowing access to cache and android_asset directories to prevent local file inclusion.

Enhancements:
- Refine WebView URL handling by reusing the computed URL string when checking and caching ad-blocking results.

Chores:
- Add a Sentinel security note documenting a prior WebResourceResponse null-input crash and the recommended safe blocking pattern.