### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Local File Inclusion (LFI) in WebView

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-20 - [CRITICAL] WebViews Vulnerable to LFI Bypass via URL encoding
+**Vulnerability:** Local File Inclusion (LFI) in `CacheableWebView` due to unrestricted `file://` access while using `AdBlockWebViewClient`.
+**Learning:** In Android WebViews, if `setAllowFileAccess(true)` is enabled for native caching features, `WebViewClient.shouldInterceptRequest` must robustly intercept and validate `file://` schemes. Naive string replacement or omitting URL decoding (`Uri.parse(url).getPath()`) allows attackers to bypass checks via URL-encoded characters (e.g. `%2e%2e%2f`).
+**Prevention:** Always validate the canonical path of decoded `file://` URLs against a safe base directory (like `getCacheDir().getCanonicalPath()`) and return an empty `WebResourceResponse` for invalid paths, rather than relying solely on Android's default file access protections.

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
@@ -16,94 +16,91 @@
 
 package io.github.sheepdestroyer.materialisheep.widget;
 
-import android.annotation.TargetApi;
-import android.os.Build;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
-
-import java.util.HashMap;
-import java.util.Map;
-
 import androidx.annotation.Nullable;
 import io.github.sheepdestroyer.materialisheep.AdBlocker;
+import java.util.Map;
 
 @SuppressWarnings("deprecation") // TODO: Uses deprecated WebResourceRequest API
 public class AdBlockWebViewClient extends WebViewClient {
-    private final boolean mAdBlockEnabled;
-    private final Map<String, Boolean> mLoadedUrls = new java.util.concurrent.ConcurrentHashMap<>();
+  private final boolean mAdBlockEnabled;
+  private final Map<String, Boolean> mLoadedUrls = new java.util.concurrent.ConcurrentHashMap<>();
 
-    public AdBlockWebViewClient(boolean adBlockEnabled) {
-        mAdBlockEnabled = adBlockEnabled;
+  public AdBlockWebViewClient(boolean adBlockEnabled) {
+    mAdBlockEnabled = adBlockEnabled;
+  }
+
+  @Override
+  public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
+    WebResourceResponse lfiCheck = checkLocalFileAccess(view, url);
+    if (lfiCheck != null) {
+      return lfiCheck;
     }
 
-    @Override
-    public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
-        WebResourceResponse lfiCheck = checkLocalFileAccess(view, url);
-        if (lfiCheck != null) {
-            return lfiCheck;
-        }
+    if (!mAdBlockEnabled) {
+      return super.shouldInterceptRequest(view, url);
+    }
+    boolean ad;
+    if (!mLoadedUrls.containsKey(url)) {
+      ad = AdBlocker.isAd(url);
+      mLoadedUrls.put(url, ad);
+    } else {
+      ad = mLoadedUrls.get(url);
+    }
+    return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, url);
+  }
 
-        if (!mAdBlockEnabled) {
-            return super.shouldInterceptRequest(view, url);
-        }
-        boolean ad;
-        if (!mLoadedUrls.containsKey(url)) {
-            ad = AdBlocker.isAd(url);
-            mLoadedUrls.put(url, ad);
-        } else {
-            ad = mLoadedUrls.get(url);
-        }
-        return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, url);
+  @Nullable
+  @Override
+  public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+    String url = request.getUrl().toString();
+    WebResourceResponse lfiCheck = checkLocalFileAccess(view, url);
+    if (lfiCheck != null) {
+      return lfiCheck;
     }
 
-    @Nullable
-    @Override
-    public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
-        String url = request.getUrl().toString();
-        WebResourceResponse lfiCheck = checkLocalFileAccess(view, url);
-        if (lfiCheck != null) {
-            return lfiCheck;
-        }
-
-        if (!mAdBlockEnabled) {
-            return super.shouldInterceptRequest(view, request);
-        }
-        boolean ad;
-        if (!mLoadedUrls.containsKey(url)) {
-            ad = AdBlocker.isAd(url);
-            mLoadedUrls.put(url, ad);
-        } else {
-            ad = mLoadedUrls.get(url);
-        }
-        return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, request);
+    if (!mAdBlockEnabled) {
+      return super.shouldInterceptRequest(view, request);
     }
-
-    private WebResourceResponse checkLocalFileAccess(WebView view, String url) {
-        if (url != null && url.toLowerCase(java.util.Locale.ROOT).startsWith("file://")) {
-            try {
-                String decodedPath = android.net.Uri.parse(url).getPath();
-                if (decodedPath == null) {
-                    return AdBlocker.createEmptyResource();
-                }
-                if (url.toLowerCase(java.util.Locale.ROOT).startsWith("file:///android_asset/")) {
-                    if (decodedPath.contains("..")) {
-                         return AdBlocker.createEmptyResource();
-                    }
-                    return null; // Safe asset, let Chromium load it natively
-                }
-                java.io.File requestedFile = new java.io.File(decodedPath);
-                String canonicalRequested = requestedFile.getCanonicalPath();
-                String cacheDirCanonical = view.getContext().getApplicationContext().getCacheDir().getCanonicalPath() + java.io.File.separator;
-
-                if (!canonicalRequested.startsWith(cacheDirCanonical)) {
-                    return AdBlocker.createEmptyResource();
-                }
-            } catch (java.io.IOException | SecurityException e) {
-                return AdBlocker.createEmptyResource();
-            }
-        }
-        return null;
+    boolean ad;
+    if (!mLoadedUrls.containsKey(url)) {
+      ad = AdBlocker.isAd(url);
+      mLoadedUrls.put(url, ad);
+    } else {
+      ad = mLoadedUrls.get(url);
     }
+    return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, request);
+  }
+
+  private WebResourceResponse checkLocalFileAccess(WebView view, String url) {
+    if (url != null && url.toLowerCase(java.util.Locale.ROOT).startsWith("file://")) {
+      try {
+        String decodedPath = android.net.Uri.parse(url).getPath();
+        if (decodedPath == null) {
+          return AdBlocker.createEmptyResource();
+        }
+        if (url.toLowerCase(java.util.Locale.ROOT).startsWith("file:///android_asset/")) {
+          if (decodedPath.contains("..")) {
+            return AdBlocker.createEmptyResource();
+          }
+          return null; // Safe asset, let Chromium load it natively
+        }
+        java.io.File requestedFile = new java.io.File(decodedPath);
+        String canonicalRequested = requestedFile.getCanonicalPath();
+        String cacheDirCanonical =
+            view.getContext().getApplicationContext().getCacheDir().getCanonicalPath()
+                + java.io.File.separator;
+
+        if (!canonicalRequested.startsWith(cacheDirCanonical)) {
+          return AdBlocker.createEmptyResource();
+        }
+      } catch (java.io.IOException | SecurityException e) {
+        return AdBlocker.createEmptyResource();
+      }
+    }
+    return null;
+  }
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
@@ -32,7 +32,7 @@ import io.github.sheepdestroyer.materialisheep.AdBlocker;
 @SuppressWarnings("deprecation") // TODO: Uses deprecated WebResourceRequest API
 public class AdBlockWebViewClient extends WebViewClient {
     private final boolean mAdBlockEnabled;
-    private final Map<String, Boolean> mLoadedUrls = new HashMap<>();
+    private final Map<String, Boolean> mLoadedUrls = new java.util.concurrent.ConcurrentHashMap<>();
 
     public AdBlockWebViewClient(boolean adBlockEnabled) {
         mAdBlockEnabled = adBlockEnabled;
@@ -40,6 +40,11 @@ public class AdBlockWebViewClient extends WebViewClient {
 
     @Override
     public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
+        WebResourceResponse lfiCheck = checkLocalFileAccess(view, url);
+        if (lfiCheck != null) {
+            return lfiCheck;
+        }
+
         if (!mAdBlockEnabled) {
             return super.shouldInterceptRequest(view, url);
         }
@@ -56,11 +61,16 @@ public class AdBlockWebViewClient extends WebViewClient {
     @Nullable
     @Override
     public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+        String url = request.getUrl().toString();
+        WebResourceResponse lfiCheck = checkLocalFileAccess(view, url);
+        if (lfiCheck != null) {
+            return lfiCheck;
+        }
+
         if (!mAdBlockEnabled) {
             return super.shouldInterceptRequest(view, request);
         }
         boolean ad;
-        String url = request.getUrl().toString();
         if (!mLoadedUrls.containsKey(url)) {
             ad = AdBlocker.isAd(url);
             mLoadedUrls.put(url, ad);
@@ -68,5 +78,32 @@ public class AdBlockWebViewClient extends WebViewClient {
             ad = mLoadedUrls.get(url);
         }
         return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, request);
+    }
+
+    private WebResourceResponse checkLocalFileAccess(WebView view, String url) {
+        if (url != null && url.toLowerCase(java.util.Locale.ROOT).startsWith("file://")) {
+            try {
+                String decodedPath = android.net.Uri.parse(url).getPath();
+                if (decodedPath == null) {
+                    return AdBlocker.createEmptyResource();
+                }
+                if (url.toLowerCase(java.util.Locale.ROOT).startsWith("file:///android_asset/")) {
+                    if (decodedPath.contains("..")) {
+                         return AdBlocker.createEmptyResource();
+                    }
+                    return null; // Safe asset, let Chromium load it natively
+                }
+                java.io.File requestedFile = new java.io.File(decodedPath);
+                String canonicalRequested = requestedFile.getCanonicalPath();
+                String cacheDirCanonical = view.getContext().getApplicationContext().getCacheDir().getCanonicalPath() + java.io.File.separator;
+
+                if (!canonicalRequested.startsWith(cacheDirCanonical)) {
+                    return AdBlocker.createEmptyResource();
+                }
+            } catch (java.io.IOException | SecurityException e) {
+                return AdBlocker.createEmptyResource();
+            }
+        }
+        return null;
     }
 }


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Local File Inclusion (LFI) in `CacheableWebView` via URL-encoded characters in the `file://` scheme. 
🎯 **Impact:** An attacker could bypass naïve file access checks (like string replacements or basic path segments) using `%2e%2e%2f` to navigate outside the `cacheDir` and access arbitrary files on the device filesystem.
🔧 **Fix:** 
1. Decoded the path using `Uri.parse(url).getPath()`.
2. Added canonical path validation `getCanonicalPath()` to strictly lock all local file access down to the application's `cacheDir`.
3. Allowed native chromium fallback `return null` for safe `.mht` cache files and `/android_asset/` without regressions.
4. Upgraded the unsynchronized `HashMap` used for tracking ad hosts to a `ConcurrentHashMap` to fix concurrent modifications from WebView background threads.
✅ **Verification:** Run `./gradlew clean lint testDebugUnitTest --no-daemon` to ensure the project continues to compile, pass all lint checks, and test suites are not degraded.

---
*PR created automatically by Jules for task [5246325447020041952](https://jules.google.com/task/5246325447020041952) started by @sheepdestroyer*

## Summary by Sourcery

Harden WebView request handling against local file inclusion and improve ad-blocking URL tracking concurrency.

Bug Fixes:
- Block unsafe file:// URL access in AdBlockWebViewClient by validating decoded canonical paths against the app cache directory and rejecting suspicious asset paths.
- Prevent concurrent modification issues in ad-block URL tracking by replacing the non-thread-safe HashMap with a ConcurrentHashMap in AdBlockWebViewClient.

Documentation:
- Add a Sentinel security note documenting the WebView local file inclusion vulnerability, its root cause, and recommended mitigation.