### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Local File Inclusion in AdBlockWebViewClient

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-04-26 - [Fix Local File Inclusion in AdBlockWebViewClient]
+**Vulnerability:** Path traversal payload via `file://` URLs bypassed the ad-blocker allowing access to sensitive local files, and state modification map could suffer race condition due to background thread invocations.
+**Learning:** `WebViewClient.shouldInterceptRequest` is invoked on background threads and needs explicit security checks for `file://` URLs, specifically preventing directory traversal (using `..`) and ensuring the file remains in an expected safe zone like `cacheDir`. Furthermore, state maps used here must be thread-safe (e.g. `ConcurrentHashMap`).
+**Prevention:** Intercept all `file://` schemes in custom `WebViewClient` methods, apply `getCanonicalPath` verification against an intended base directory, explicitly return empty `WebResourceResponse` objects when violations are detected, and ensure shared state uses concurrent collections.

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
@@ -16,96 +16,92 @@
 
 package io.github.sheepdestroyer.materialisheep.widget;
 
-import android.annotation.TargetApi;
 import android.net.Uri;
-import android.os.Build;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
-
+import androidx.annotation.Nullable;
+import io.github.sheepdestroyer.materialisheep.AdBlocker;
 import java.io.File;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import androidx.annotation.Nullable;
-import io.github.sheepdestroyer.materialisheep.AdBlocker;
-
 @SuppressWarnings("deprecation") // TODO: Uses deprecated WebResourceRequest API
 public class AdBlockWebViewClient extends WebViewClient {
-    private final boolean mAdBlockEnabled;
-    private final Map<String, Boolean> mLoadedUrls = new ConcurrentHashMap<>();
+  private final boolean mAdBlockEnabled;
+  private final Map<String, Boolean> mLoadedUrls = new ConcurrentHashMap<>();
 
-    public AdBlockWebViewClient(boolean adBlockEnabled) {
-        mAdBlockEnabled = adBlockEnabled;
+  public AdBlockWebViewClient(boolean adBlockEnabled) {
+    mAdBlockEnabled = adBlockEnabled;
+  }
+
+  private boolean isInvalidFileAccess(WebView view, String url) {
+    if (url == null) return false;
+    String lowerUrl = url.toLowerCase(java.util.Locale.ROOT);
+    if (!lowerUrl.startsWith("file://")) {
+      return false;
+    }
+    try {
+      String decodedPath = Uri.parse(url).getPath();
+      if (decodedPath == null) return true;
+
+      if (lowerUrl.startsWith("file:///android_asset/")) {
+        return decodedPath.contains("..");
+      }
+
+      File file = new File(decodedPath);
+      String canonicalPath = file.getCanonicalPath();
+      String cacheDirPath = view.getContext().getCacheDir().getCanonicalPath() + File.separator;
+      return !canonicalPath.startsWith(cacheDirPath);
+    } catch (Exception e) {
+      return true;
+    }
+  }
+
+  @Override
+  public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
+    if (isInvalidFileAccess(view, url)) {
+      return AdBlocker.createEmptyResource();
+    }
+    if (url != null && url.toLowerCase(java.util.Locale.ROOT).startsWith("file://")) {
+      return null; // Native loading
     }
 
-    private boolean isInvalidFileAccess(WebView view, String url) {
-        if (url == null) return false;
-        String lowerUrl = url.toLowerCase(java.util.Locale.ROOT);
-        if (!lowerUrl.startsWith("file://")) {
-            return false;
-        }
-        try {
-            String decodedPath = Uri.parse(url).getPath();
-            if (decodedPath == null) return true;
-
-            if (lowerUrl.startsWith("file:///android_asset/")) {
-                return decodedPath.contains("..");
-            }
-
-            File file = new File(decodedPath);
-            String canonicalPath = file.getCanonicalPath();
-            String cacheDirPath = view.getContext().getCacheDir().getCanonicalPath() + File.separator;
-            return !canonicalPath.startsWith(cacheDirPath);
-        } catch (Exception e) {
-            return true;
-        }
+    if (!mAdBlockEnabled) {
+      return super.shouldInterceptRequest(view, url);
     }
 
-    @Override
-    public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
-        if (isInvalidFileAccess(view, url)) {
-            return AdBlocker.createEmptyResource();
-        }
-        if (url != null && url.toLowerCase(java.util.Locale.ROOT).startsWith("file://")) {
-            return null; // Native loading
-        }
+    Boolean ad = mLoadedUrls.get(url);
+    if (ad == null) {
+      boolean isAd = AdBlocker.isAd(url);
+      mLoadedUrls.put(url, isAd);
+      ad = isAd;
+    }
+    return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, url);
+  }
 
-        if (!mAdBlockEnabled) {
-            return super.shouldInterceptRequest(view, url);
-        }
-
-        Boolean ad = mLoadedUrls.get(url);
-        if (ad == null) {
-            boolean isAd = AdBlocker.isAd(url);
-            mLoadedUrls.put(url, isAd);
-            ad = isAd;
-        }
-        return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, url);
+  @Nullable
+  @Override
+  public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+    String url = request.getUrl().toString();
+    if (isInvalidFileAccess(view, url)) {
+      return AdBlocker.createEmptyResource();
+    }
+    if (url != null && url.toLowerCase(java.util.Locale.ROOT).startsWith("file://")) {
+      return null; // Native loading
     }
 
-    @Nullable
-    @Override
-    public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
-        String url = request.getUrl().toString();
-        if (isInvalidFileAccess(view, url)) {
-            return AdBlocker.createEmptyResource();
-        }
-        if (url != null && url.toLowerCase(java.util.Locale.ROOT).startsWith("file://")) {
-            return null; // Native loading
-        }
-
-        if (!mAdBlockEnabled) {
-            return super.shouldInterceptRequest(view, request);
-        }
-
-        Boolean ad = mLoadedUrls.get(url);
-        if (ad == null) {
-            boolean isAd = AdBlocker.isAd(url);
-            mLoadedUrls.put(url, isAd);
-            ad = isAd;
-        }
-        return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, request);
+    if (!mAdBlockEnabled) {
+      return super.shouldInterceptRequest(view, request);
     }
+
+    Boolean ad = mLoadedUrls.get(url);
+    if (ad == null) {
+      boolean isAd = AdBlocker.isAd(url);
+      mLoadedUrls.put(url, isAd);
+      ad = isAd;
+    }
+    return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, request);
+  }
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
@@ -17,14 +17,16 @@
 package io.github.sheepdestroyer.materialisheep.widget;
 
 import android.annotation.TargetApi;
+import android.net.Uri;
 import android.os.Build;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
-import java.util.HashMap;
+import java.io.File;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import androidx.annotation.Nullable;
 import io.github.sheepdestroyer.materialisheep.AdBlocker;
@@ -32,23 +34,53 @@ import io.github.sheepdestroyer.materialisheep.AdBlocker;
 @SuppressWarnings("deprecation") // TODO: Uses deprecated WebResourceRequest API
 public class AdBlockWebViewClient extends WebViewClient {
     private final boolean mAdBlockEnabled;
-    private final Map<String, Boolean> mLoadedUrls = new HashMap<>();
+    private final Map<String, Boolean> mLoadedUrls = new ConcurrentHashMap<>();
 
     public AdBlockWebViewClient(boolean adBlockEnabled) {
         mAdBlockEnabled = adBlockEnabled;
     }
 
+    private boolean isInvalidFileAccess(WebView view, String url) {
+        if (url == null) return false;
+        String lowerUrl = url.toLowerCase(java.util.Locale.ROOT);
+        if (!lowerUrl.startsWith("file://")) {
+            return false;
+        }
+        try {
+            String decodedPath = Uri.parse(url).getPath();
+            if (decodedPath == null) return true;
+
+            if (lowerUrl.startsWith("file:///android_asset/")) {
+                return decodedPath.contains("..");
+            }
+
+            File file = new File(decodedPath);
+            String canonicalPath = file.getCanonicalPath();
+            String cacheDirPath = view.getContext().getCacheDir().getCanonicalPath() + File.separator;
+            return !canonicalPath.startsWith(cacheDirPath);
+        } catch (Exception e) {
+            return true;
+        }
+    }
+
     @Override
     public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
+        if (isInvalidFileAccess(view, url)) {
+            return AdBlocker.createEmptyResource();
+        }
+        if (url != null && url.toLowerCase(java.util.Locale.ROOT).startsWith("file://")) {
+            return null; // Native loading
+        }
+
         if (!mAdBlockEnabled) {
             return super.shouldInterceptRequest(view, url);
         }
-        boolean ad;
-        if (!mLoadedUrls.containsKey(url)) {
-            ad = AdBlocker.isAd(url);
-            mLoadedUrls.put(url, ad);
-        } else {
-            ad = mLoadedUrls.get(url);
+
+        Boolean ad = mLoadedUrls.get(url);
+        if (ad == null) {
+            boolean isAd = AdBlocker.isAd(url);
+            mLoadedUrls.put(url, isAd);
+            ad = isAd;
         }
         return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, url);
     }
@@ -56,16 +88,23 @@ public class AdBlockWebViewClient extends WebViewClient {
     @Nullable
     @Override
     public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+        String url = request.getUrl().toString();
+        if (isInvalidFileAccess(view, url)) {
+            return AdBlocker.createEmptyResource();
+        }
+        if (url != null && url.toLowerCase(java.util.Locale.ROOT).startsWith("file://")) {
+            return null; // Native loading
+        }
+
         if (!mAdBlockEnabled) {
             return super.shouldInterceptRequest(view, request);
         }
-        boolean ad;
-        String url = request.getUrl().toString();
-        if (!mLoadedUrls.containsKey(url)) {
-            ad = AdBlocker.isAd(url);
-            mLoadedUrls.put(url, ad);
-        } else {
-            ad = mLoadedUrls.get(url);
+
+        Boolean ad = mLoadedUrls.get(url);
+        if (ad == null) {
+            boolean isAd = AdBlocker.isAd(url);
+            mLoadedUrls.put(url, isAd);
+            ad = isAd;
         }
         return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, request);
     }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The custom `AdBlockWebViewClient` failed to intercept and restrict `file://` URLs, leaving `CacheableWebView` instances vulnerable to Local File Inclusion (LFI) via path traversal (e.g. `file:///android_asset/../../../../data/...`). Additionally, `mLoadedUrls` used an unsafe `HashMap` inside `shouldInterceptRequest`, which runs on a background thread.
🎯 Impact: Attackers could potentially read sensitive local databases or shared preferences. A race condition could also cause a denial of service (ConcurrentModificationException or infinite loop) in the application.
🔧 Fix: Added strict path canonicalization checks to block malicious `file://` access while preserving legitimate cache loading, and switched `mLoadedUrls` to a thread-safe `ConcurrentHashMap`.
✅ Verification: Pass `./gradlew clean lint testDebugUnitTest` and manual source code review.

---
*PR created automatically by Jules for task [10226699645031705077](https://jules.google.com/task/10226699645031705077) started by @sheepdestroyer*

## Summary by Sourcery

Harden AdBlockWebViewClient against unsafe local file access while making its URL cache thread-safe.

Bug Fixes:
- Block malicious file:// URL access in WebView by validating canonical paths, preventing path traversal and unintended reads outside the app cache directory.
- Return empty WebResourceResponse for invalid local file access attempts instead of allowing native loading.

Enhancements:
- Switch the URL ad-detection cache in AdBlockWebViewClient to a ConcurrentHashMap to avoid race conditions when accessed from background threads.
- Record the security fix and associated learnings in the Sentinel security log documentation.