### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix thread safety vulnerability in AdBlockWebViewClient

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - [Concurrency Bug in WebViewClient]
+**Vulnerability:** `ConcurrentModificationException` risk in `AdBlockWebViewClient.mLoadedUrls`.
+**Learning:** Android `WebViewClient` methods like `shouldInterceptRequest` are called on multiple background threads. Using a non-synchronized `HashMap` for shared state can lead to race conditions or application freezes.
+**Prevention:** Always use `ConcurrentHashMap` for shared state accessed within `WebViewClient` lifecycle methods.

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
@@ -16,57 +16,52 @@
 
 package io.github.sheepdestroyer.materialisheep.widget;
 
-import android.annotation.TargetApi;
-import android.os.Build;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
-
-import java.util.HashMap;
-import java.util.Map;
-
 import androidx.annotation.Nullable;
 import io.github.sheepdestroyer.materialisheep.AdBlocker;
+import java.util.Map;
 
 @SuppressWarnings("deprecation") // TODO: Uses deprecated WebResourceRequest API
 public class AdBlockWebViewClient extends WebViewClient {
-    private final boolean mAdBlockEnabled;
-    private final Map<String, Boolean> mLoadedUrls = new java.util.concurrent.ConcurrentHashMap<>();
+  private final boolean mAdBlockEnabled;
+  private final Map<String, Boolean> mLoadedUrls = new java.util.concurrent.ConcurrentHashMap<>();
 
-    public AdBlockWebViewClient(boolean adBlockEnabled) {
-        mAdBlockEnabled = adBlockEnabled;
-    }
+  public AdBlockWebViewClient(boolean adBlockEnabled) {
+    mAdBlockEnabled = adBlockEnabled;
+  }
 
-    @Override
-    public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
-        if (!mAdBlockEnabled) {
-            return super.shouldInterceptRequest(view, url);
-        }
-        boolean ad;
-        if (!mLoadedUrls.containsKey(url)) {
-            ad = AdBlocker.isAd(url);
-            mLoadedUrls.put(url, ad);
-        } else {
-            ad = mLoadedUrls.get(url);
-        }
-        return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, url);
+  @Override
+  public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
+    if (!mAdBlockEnabled) {
+      return super.shouldInterceptRequest(view, url);
     }
+    boolean ad;
+    if (!mLoadedUrls.containsKey(url)) {
+      ad = AdBlocker.isAd(url);
+      mLoadedUrls.put(url, ad);
+    } else {
+      ad = mLoadedUrls.get(url);
+    }
+    return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, url);
+  }
 
-    @Nullable
-    @Override
-    public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
-        if (!mAdBlockEnabled) {
-            return super.shouldInterceptRequest(view, request);
-        }
-        boolean ad;
-        String url = request.getUrl().toString();
-        if (!mLoadedUrls.containsKey(url)) {
-            ad = AdBlocker.isAd(url);
-            mLoadedUrls.put(url, ad);
-        } else {
-            ad = mLoadedUrls.get(url);
-        }
-        return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, request);
+  @Nullable
+  @Override
+  public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+    if (!mAdBlockEnabled) {
+      return super.shouldInterceptRequest(view, request);
     }
+    boolean ad;
+    String url = request.getUrl().toString();
+    if (!mLoadedUrls.containsKey(url)) {
+      ad = AdBlocker.isAd(url);
+      mLoadedUrls.put(url, ad);
+    } else {
+      ad = mLoadedUrls.get(url);
+    }
+    return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, request);
+  }
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
@@ -32,7 +32,7 @@ import io.github.sheepdestroyer.materialisheep.AdBlocker;
 @SuppressWarnings("deprecation") // TODO: Uses deprecated WebResourceRequest API
 public class AdBlockWebViewClient extends WebViewClient {
     private final boolean mAdBlockEnabled;
-    private final Map<String, Boolean> mLoadedUrls = new HashMap<>();
+    private final Map<String, Boolean> mLoadedUrls = new java.util.concurrent.ConcurrentHashMap<>();
 
     public AdBlockWebViewClient(boolean adBlockEnabled) {
         mAdBlockEnabled = adBlockEnabled;


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Potential `ConcurrentModificationException` or application freezes due to a race condition. Android's `WebViewClient.shouldInterceptRequest` is called on multiple background threads, but `AdBlockWebViewClient` was using a non-synchronized `HashMap` (`mLoadedUrls`) for shared state.
🎯 Impact: This could result in random crashes or Denial of Service (app freeze) if multiple threads accessed and modified the map simultaneously.
🔧 Fix: Changed `HashMap` to `ConcurrentHashMap` for `mLoadedUrls` to ensure thread-safe operations across all background threads.
✅ Verification: Ran `git diff` to verify the targeted change. Ran `./gradlew clean lint testDebugUnitTest --no-daemon` to ensure the build completes successfully with zero regressions.

---
*PR created automatically by Jules for task [1952327803756675228](https://jules.google.com/task/1952327803756675228) started by @sheepdestroyer*

## Summary by Sourcery

Ensure thread-safe URL tracking in AdBlockWebViewClient and document the identified concurrency vulnerability and its mitigation.

Bug Fixes:
- Prevent potential ConcurrentModificationException and race conditions in AdBlockWebViewClient by using a thread-safe map for loaded URLs.

Documentation:
- Add Sentinel note documenting the WebViewClient concurrency vulnerability, its cause, and the recommended use of ConcurrentHashMap for shared state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a potential concurrency issue in ad blocking that could cause application crashes when multiple threads access the ad decision cache simultaneously.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->