### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Local File Inclusion in WebViews

### DIFF
--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
@@ -16,88 +16,86 @@
 
 package io.github.sheepdestroyer.materialisheep.widget;
 
-import android.annotation.TargetApi;
-import android.os.Build;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
-
+import androidx.annotation.Nullable;
+import io.github.sheepdestroyer.materialisheep.AdBlocker;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import androidx.annotation.Nullable;
-import io.github.sheepdestroyer.materialisheep.AdBlocker;
-
 @SuppressWarnings("deprecation") // TODO: Uses deprecated WebResourceRequest API
 public class AdBlockWebViewClient extends WebViewClient {
-    private final boolean mAdBlockEnabled;
-    private final Map<String, Boolean> mLoadedUrls = new ConcurrentHashMap<>();
+  private final boolean mAdBlockEnabled;
+  private final Map<String, Boolean> mLoadedUrls = new ConcurrentHashMap<>();
 
-    public AdBlockWebViewClient(boolean adBlockEnabled) {
-        mAdBlockEnabled = adBlockEnabled;
+  public AdBlockWebViewClient(boolean adBlockEnabled) {
+    mAdBlockEnabled = adBlockEnabled;
+  }
+
+  @Override
+  public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
+    if (url != null && url.toLowerCase(java.util.Locale.ROOT).startsWith("file://")) {
+      WebResourceResponse fileResponse = handleFileRequest(view, url);
+      if (fileResponse != null) {
+        return fileResponse;
+      }
+      return super.shouldInterceptRequest(view, url);
     }
-
-    @Override
-    public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
-        if (url != null && url.toLowerCase(java.util.Locale.ROOT).startsWith("file://")) {
-            WebResourceResponse fileResponse = handleFileRequest(view, url);
-            if (fileResponse != null) {
-                return fileResponse;
-            }
-            return super.shouldInterceptRequest(view, url);
-        }
-        if (!mAdBlockEnabled) {
-            return super.shouldInterceptRequest(view, url);
-        }
-        boolean ad;
-        if (!mLoadedUrls.containsKey(url)) {
-            ad = AdBlocker.isAd(url);
-            mLoadedUrls.put(url, ad);
-        } else {
-            ad = mLoadedUrls.get(url);
-        }
-        return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, url);
+    if (!mAdBlockEnabled) {
+      return super.shouldInterceptRequest(view, url);
     }
-
-    @Nullable
-    @Override
-    public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
-        String url = request.getUrl().toString();
-        if (url != null && url.toLowerCase(java.util.Locale.ROOT).startsWith("file://")) {
-            WebResourceResponse fileResponse = handleFileRequest(view, url);
-            if (fileResponse != null) {
-                return fileResponse;
-            }
-            return super.shouldInterceptRequest(view, request);
-        }
-        if (!mAdBlockEnabled) {
-            return super.shouldInterceptRequest(view, request);
-        }
-        boolean ad;
-        if (!mLoadedUrls.containsKey(url)) {
-            ad = AdBlocker.isAd(url);
-            mLoadedUrls.put(url, ad);
-        } else {
-            ad = mLoadedUrls.get(url);
-        }
-        return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, request);
+    boolean ad;
+    if (!mLoadedUrls.containsKey(url)) {
+      ad = AdBlocker.isAd(url);
+      mLoadedUrls.put(url, ad);
+    } else {
+      ad = mLoadedUrls.get(url);
     }
+    return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, url);
+  }
 
-    private WebResourceResponse handleFileRequest(WebView view, String url) {
-        try {
-            String path = android.net.Uri.parse(url).getPath();
-            if (path == null || path.contains("..")) {
-                return null;
-            }
-            java.io.File file = new java.io.File(path);
-            java.io.File cacheDir = view.getContext().getApplicationContext().getCacheDir();
-            if (file.getCanonicalPath().startsWith(cacheDir.getCanonicalPath() + java.io.File.separator) && file.exists()) {
-                return new WebResourceResponse("application/x-mimearchive", "utf-8", new java.io.FileInputStream(file));
-            }
-        } catch (Exception e) {
-            // Ignore
-        }
+  @Nullable
+  @Override
+  public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+    String url = request.getUrl().toString();
+    if (url != null && url.toLowerCase(java.util.Locale.ROOT).startsWith("file://")) {
+      WebResourceResponse fileResponse = handleFileRequest(view, url);
+      if (fileResponse != null) {
+        return fileResponse;
+      }
+      return super.shouldInterceptRequest(view, request);
+    }
+    if (!mAdBlockEnabled) {
+      return super.shouldInterceptRequest(view, request);
+    }
+    boolean ad;
+    if (!mLoadedUrls.containsKey(url)) {
+      ad = AdBlocker.isAd(url);
+      mLoadedUrls.put(url, ad);
+    } else {
+      ad = mLoadedUrls.get(url);
+    }
+    return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, request);
+  }
+
+  private WebResourceResponse handleFileRequest(WebView view, String url) {
+    try {
+      String path = android.net.Uri.parse(url).getPath();
+      if (path == null || path.contains("..")) {
         return null;
+      }
+      java.io.File file = new java.io.File(path);
+      java.io.File cacheDir = view.getContext().getApplicationContext().getCacheDir();
+      if (file.getCanonicalPath().startsWith(cacheDir.getCanonicalPath() + java.io.File.separator)
+          && file.exists()) {
+        return new WebResourceResponse(
+            "application/x-mimearchive", "utf-8", new java.io.FileInputStream(file));
+      }
+    } catch (Exception e) {
+      // Ignore
     }
+    return null;
+  }
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
@@ -23,8 +23,8 @@ import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import androidx.annotation.Nullable;
 import io.github.sheepdestroyer.materialisheep.AdBlocker;
@@ -32,7 +32,7 @@ import io.github.sheepdestroyer.materialisheep.AdBlocker;
 @SuppressWarnings("deprecation") // TODO: Uses deprecated WebResourceRequest API
 public class AdBlockWebViewClient extends WebViewClient {
     private final boolean mAdBlockEnabled;
-    private final Map<String, Boolean> mLoadedUrls = new HashMap<>();
+    private final Map<String, Boolean> mLoadedUrls = new ConcurrentHashMap<>();
 
     public AdBlockWebViewClient(boolean adBlockEnabled) {
         mAdBlockEnabled = adBlockEnabled;
@@ -40,6 +40,13 @@ public class AdBlockWebViewClient extends WebViewClient {
 
     @Override
     public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
+        if (url != null && url.toLowerCase(java.util.Locale.ROOT).startsWith("file://")) {
+            WebResourceResponse fileResponse = handleFileRequest(view, url);
+            if (fileResponse != null) {
+                return fileResponse;
+            }
+            return super.shouldInterceptRequest(view, url);
+        }
         if (!mAdBlockEnabled) {
             return super.shouldInterceptRequest(view, url);
         }
@@ -56,11 +63,18 @@ public class AdBlockWebViewClient extends WebViewClient {
     @Nullable
     @Override
     public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+        String url = request.getUrl().toString();
+        if (url != null && url.toLowerCase(java.util.Locale.ROOT).startsWith("file://")) {
+            WebResourceResponse fileResponse = handleFileRequest(view, url);
+            if (fileResponse != null) {
+                return fileResponse;
+            }
+            return super.shouldInterceptRequest(view, request);
+        }
         if (!mAdBlockEnabled) {
             return super.shouldInterceptRequest(view, request);
         }
         boolean ad;
-        String url = request.getUrl().toString();
         if (!mLoadedUrls.containsKey(url)) {
             ad = AdBlocker.isAd(url);
             mLoadedUrls.put(url, ad);
@@ -68,5 +82,22 @@ public class AdBlockWebViewClient extends WebViewClient {
             ad = mLoadedUrls.get(url);
         }
         return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, request);
+    }
+
+    private WebResourceResponse handleFileRequest(WebView view, String url) {
+        try {
+            String path = android.net.Uri.parse(url).getPath();
+            if (path == null || path.contains("..")) {
+                return null;
+            }
+            java.io.File file = new java.io.File(path);
+            java.io.File cacheDir = view.getContext().getApplicationContext().getCacheDir();
+            if (file.getCanonicalPath().startsWith(cacheDir.getCanonicalPath() + java.io.File.separator) && file.exists()) {
+                return new WebResourceResponse("application/x-mimearchive", "utf-8", new java.io.FileInputStream(file));
+            }
+        } catch (Exception e) {
+            // Ignore
+        }
+        return null;
     }
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/CacheableWebView.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/CacheableWebView.java
@@ -92,7 +92,7 @@ public class CacheableWebView extends WebView {
 
     private void enableCache() {
         WebSettings webSettings = getSettings();
-        webSettings.setAllowFileAccess(true);
+        webSettings.setAllowFileAccess(false);
         setCacheModeInternal();
     }
 

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/CacheableWebView.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/CacheableWebView.java
@@ -19,149 +19,145 @@ package io.github.sheepdestroyer.materialisheep.widget;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.net.Uri;
-
-import androidx.annotation.CallSuper;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
 import android.webkit.WebViewClient;
-
+import androidx.annotation.CallSuper;
+import io.github.sheepdestroyer.materialisheep.AppUtils;
 import java.io.File;
 import java.util.Map;
 
-import io.github.sheepdestroyer.materialisheep.AppUtils;
-
 public class CacheableWebView extends WebView {
-    private static final String CACHE_PREFIX = "webarchive-";
-    private static final String CACHE_EXTENSION = ".mht";
-    private ArchiveClient mArchiveClient = new ArchiveClient();
+  private static final String CACHE_PREFIX = "webarchive-";
+  private static final String CACHE_EXTENSION = ".mht";
+  private ArchiveClient mArchiveClient = new ArchiveClient();
 
-    public CacheableWebView(Context context) {
-        this(context, null);
+  public CacheableWebView(Context context) {
+    this(context, null);
+  }
+
+  public CacheableWebView(Context context, AttributeSet attrs) {
+    this(context, attrs, 0);
+  }
+
+  public CacheableWebView(Context context, AttributeSet attrs, int defStyleAttr) {
+    super(context, attrs, defStyleAttr);
+    init();
+  }
+
+  @Override
+  public void reloadUrl(String url) {
+    super.reloadUrl(getCacheableUrl(url));
+  }
+
+  @Override
+  public void loadUrl(String url) {
+    if (TextUtils.isEmpty(url)) {
+      return;
     }
+    mArchiveClient.lastProgress = 0;
+    super.loadUrl(getCacheableUrl(url));
+  }
 
-    public CacheableWebView(Context context, AttributeSet attrs) {
-        this(context, attrs, 0);
+  @Override
+  public void loadUrl(String url, Map<String, String> additionalHttpHeaders) {
+    if (TextUtils.isEmpty(url)) {
+      return;
     }
+    mArchiveClient.lastProgress = 0;
+    super.loadUrl(getCacheableUrl(url), additionalHttpHeaders);
+  }
 
-    public CacheableWebView(Context context, AttributeSet attrs, int defStyleAttr) {
-        super(context, attrs, defStyleAttr);
-        init();
+  @Override
+  public void setWebChromeClient(WebChromeClient client) {
+    if (!(client instanceof ArchiveClient)) {
+      throw new IllegalArgumentException(
+          "client should be an instance of " + ArchiveClient.class.getName());
     }
+    mArchiveClient = (ArchiveClient) client;
+    super.setWebChromeClient(mArchiveClient);
+  }
 
+  private void init() {
+    enableCache();
+    setLoadSettings();
+    setWebViewClient(new WebViewClient());
+    setWebChromeClient(mArchiveClient);
+  }
+
+  private void enableCache() {
+    WebSettings webSettings = getSettings();
+    webSettings.setAllowFileAccess(false);
+    setCacheModeInternal();
+  }
+
+  private void setCacheModeInternal() {
+    getSettings().setCacheMode(WebSettings.LOAD_CACHE_ELSE_NETWORK);
+  }
+
+  @SuppressLint("SetJavaScriptEnabled")
+  private void setLoadSettings() {
+    WebSettings webSettings = getSettings();
+    webSettings.setLoadWithOverviewMode(true);
+    webSettings.setUseWideViewPort(true);
+    webSettings.setJavaScriptEnabled(true);
+  }
+
+  private String getCacheableUrl(String url) {
+    if (TextUtils.equals(url, BLANK) || TextUtils.equals(url, FILE)) {
+      mArchiveClient.cacheFileName = null;
+      return url;
+    }
+    mArchiveClient.cacheFileName = generateCacheFilename(url);
+    setCacheModeInternal();
+    File cacheFile = new File(mArchiveClient.cacheFileName);
+    if (cacheFile.exists() && !AppUtils.hasConnection(getContext())) {
+      getSettings().setCacheMode(WebSettings.LOAD_CACHE_ONLY);
+      return Uri.fromFile(cacheFile).toString();
+    }
+    return url;
+  }
+
+  private String generateCacheFilename(String url) {
+    String name;
+    try {
+      java.security.MessageDigest digest = java.security.MessageDigest.getInstance("SHA-256");
+      byte[] hash = digest.digest(url.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+      StringBuilder hexString = new StringBuilder();
+      for (byte b : hash) {
+        String hex = Integer.toHexString(0xff & b);
+        if (hex.length() == 1) {
+          hexString.append('0');
+        }
+        hexString.append(hex);
+      }
+      name = hexString.toString();
+    } catch (java.security.NoSuchAlgorithmException e) {
+      name = String.valueOf(url.hashCode());
+    }
+    return getContext().getApplicationContext().getCacheDir().getAbsolutePath()
+        + File.separator
+        + CACHE_PREFIX
+        + name
+        + CACHE_EXTENSION;
+  }
+
+  public static class ArchiveClient extends WebChromeClient {
+    int lastProgress = 0;
+    String cacheFileName = null;
+
+    @CallSuper
     @Override
-    public void reloadUrl(String url) {
-        super.reloadUrl(getCacheableUrl(url));
+    public void onProgressChanged(android.webkit.WebView view, int newProgress) {
+      if (view.getSettings().getCacheMode() == WebSettings.LOAD_CACHE_ONLY) {
+        return;
+      }
+      if (cacheFileName != null && lastProgress != 100 && newProgress == 100) {
+        lastProgress = newProgress;
+        view.saveWebArchive(cacheFileName);
+      }
     }
-
-    @Override
-    public void loadUrl(String url) {
-        if (TextUtils.isEmpty(url)) {
-            return;
-        }
-        mArchiveClient.lastProgress = 0;
-        super.loadUrl(getCacheableUrl(url));
-    }
-
-    @Override
-    public void loadUrl(String url, Map<String, String> additionalHttpHeaders) {
-        if (TextUtils.isEmpty(url)) {
-            return;
-        }
-        mArchiveClient.lastProgress = 0;
-        super.loadUrl(getCacheableUrl(url), additionalHttpHeaders);
-    }
-
-    @Override
-    public void setWebChromeClient(WebChromeClient client) {
-        if (!(client instanceof ArchiveClient)) {
-            throw new IllegalArgumentException("client should be an instance of " +
-                    ArchiveClient.class.getName());
-        }
-        mArchiveClient = (ArchiveClient) client;
-        super.setWebChromeClient(mArchiveClient);
-    }
-
-    private void init() {
-        enableCache();
-        setLoadSettings();
-        setWebViewClient(new WebViewClient());
-        setWebChromeClient(mArchiveClient);
-    }
-
-    private void enableCache() {
-        WebSettings webSettings = getSettings();
-        webSettings.setAllowFileAccess(false);
-        setCacheModeInternal();
-    }
-
-    private void setCacheModeInternal() {
-        getSettings().setCacheMode(WebSettings.LOAD_CACHE_ELSE_NETWORK);
-    }
-
-    @SuppressLint("SetJavaScriptEnabled")
-    private void setLoadSettings() {
-        WebSettings webSettings = getSettings();
-        webSettings.setLoadWithOverviewMode(true);
-        webSettings.setUseWideViewPort(true);
-        webSettings.setJavaScriptEnabled(true);
-    }
-
-    private String getCacheableUrl(String url) {
-        if (TextUtils.equals(url, BLANK) || TextUtils.equals(url, FILE)) {
-            mArchiveClient.cacheFileName = null;
-            return url;
-        }
-        mArchiveClient.cacheFileName = generateCacheFilename(url);
-        setCacheModeInternal();
-        File cacheFile = new File(mArchiveClient.cacheFileName);
-        if (cacheFile.exists() && !AppUtils.hasConnection(getContext())) {
-            getSettings().setCacheMode(WebSettings.LOAD_CACHE_ONLY);
-            return Uri.fromFile(cacheFile).toString();
-        }
-        return url;
-    }
-
-    private String generateCacheFilename(String url) {
-        String name;
-        try {
-            java.security.MessageDigest digest = java.security.MessageDigest.getInstance("SHA-256");
-            byte[] hash = digest.digest(url.getBytes(java.nio.charset.StandardCharsets.UTF_8));
-            StringBuilder hexString = new StringBuilder();
-            for (byte b : hash) {
-                String hex = Integer.toHexString(0xff & b);
-                if (hex.length() == 1) {
-                    hexString.append('0');
-                }
-                hexString.append(hex);
-            }
-            name = hexString.toString();
-        } catch (java.security.NoSuchAlgorithmException e) {
-            name = String.valueOf(url.hashCode());
-        }
-        return getContext().getApplicationContext().getCacheDir().getAbsolutePath() +
-                File.separator +
-                CACHE_PREFIX +
-                name +
-                CACHE_EXTENSION;
-    }
-
-    public static class ArchiveClient extends WebChromeClient {
-        int lastProgress = 0;
-        String cacheFileName = null;
-
-        @CallSuper
-        @Override
-        public void onProgressChanged(android.webkit.WebView view, int newProgress) {
-            if (view.getSettings().getCacheMode() == WebSettings.LOAD_CACHE_ONLY) {
-                return;
-            }
-            if (cacheFileName != null && lastProgress != 100 && newProgress == 100) {
-                lastProgress = newProgress;
-                view.saveWebArchive(cacheFileName);
-            }
-        }
-
-    }
+  }
 }


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** 
1. `CacheableWebView` globally enabled `setAllowFileAccess(true)`, allowing any loaded HTML to read local files via `file://` scheme (Local File Inclusion/Path Traversal).
2. `AdBlockWebViewClient` used an unsafe `HashMap` for caching `mLoadedUrls` which is accessed by `shouldInterceptRequest` on background threads.

🎯 **Impact:** 
1. Malicious JavaScript in an untrusted WebView could read private application data (like SharedPreferences or SQLite databases).
2. Concurrent accesses to `mLoadedUrls` could trigger a `ConcurrentModificationException` leading to app crashes or ANRs.

🔧 **Fix:** 
1. Changed `webSettings.setAllowFileAccess(true)` to `false` in `CacheableWebView`.
2. Securely handle authorized `file://` loads (for cached offline `.mht` files) inside `AdBlockWebViewClient.shouldInterceptRequest()` with a strict path-traversal check (`..` check and Canonical Path validation).
3. Migrated `HashMap` to `ConcurrentHashMap` in `AdBlockWebViewClient`.

✅ **Verification:** 
Ran `./gradlew clean lint testDebugUnitTest --no-daemon` to ensure the application compiles and passes tests. Reviewed with `git diff`.

---
*PR created automatically by Jules for task [3085934168589073134](https://jules.google.com/task/3085934168589073134) started by @sheepdestroyer*

## Summary by Sourcery

Mitigate WebView security and stability issues by tightening file access and hardening request handling.

Bug Fixes:
- Prevent WebViews from accessing local files by disabling file access in CacheableWebView.
- Restrict handling of file:// URLs to cached files within the app cache directory with path traversal safeguards in AdBlockWebViewClient.
- Avoid concurrent modification issues in AdBlockWebViewClient by using a thread-safe map for loaded URL caching.