### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Local File Inclusion (LFI) vulnerability in CacheableWebView

### DIFF
--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
@@ -23,7 +23,10 @@ import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
-import java.util.HashMap;
+import android.net.Uri;
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.Map;
 
 import androidx.annotation.Nullable;
@@ -32,14 +35,34 @@ import io.github.sheepdestroyer.materialisheep.AdBlocker;
 @SuppressWarnings("deprecation") // TODO: Uses deprecated WebResourceRequest API
 public class AdBlockWebViewClient extends WebViewClient {
     private final boolean mAdBlockEnabled;
-    private final Map<String, Boolean> mLoadedUrls = new HashMap<>();
+    private final Map<String, Boolean> mLoadedUrls = new ConcurrentHashMap<>();
 
     public AdBlockWebViewClient(boolean adBlockEnabled) {
         mAdBlockEnabled = adBlockEnabled;
     }
 
+    private WebResourceResponse handleFileRequest(WebView view, String url) {
+        try {
+            String decodedPath = Uri.parse(url).getPath();
+            if (decodedPath != null && !decodedPath.contains("..")) {
+                File file = new File(decodedPath);
+                String canonicalPath = file.getCanonicalPath();
+                String cacheDirPath = view.getContext().getCacheDir().getCanonicalPath() + File.separator;
+                if (canonicalPath.startsWith(cacheDirPath) && canonicalPath.endsWith(".mht")) {
+                    return new WebResourceResponse("application/x-mimearchive", "UTF-8", new FileInputStream(file));
+                }
+            }
+        } catch (Exception e) {
+            // Ignore exception and return null to deny access
+        }
+        return null;
+    }
+
     @Override
     public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
+        if (url != null && url.toLowerCase(java.util.Locale.ROOT).startsWith("file://")) {
+            return handleFileRequest(view, url);
+        }
         if (!mAdBlockEnabled) {
             return super.shouldInterceptRequest(view, url);
         }
@@ -56,11 +79,14 @@ public class AdBlockWebViewClient extends WebViewClient {
     @Nullable
     @Override
     public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+        String url = request.getUrl().toString();
+        if (url.toLowerCase(java.util.Locale.ROOT).startsWith("file://")) {
+            return handleFileRequest(view, url);
+        }
         if (!mAdBlockEnabled) {
             return super.shouldInterceptRequest(view, request);
         }
         boolean ad;
-        String url = request.getUrl().toString();
         if (!mLoadedUrls.containsKey(url)) {
             ad = AdBlocker.isAd(url);
             mLoadedUrls.put(url, ad);

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
@@ -16,83 +16,80 @@
 
 package io.github.sheepdestroyer.materialisheep.widget;
 
-import android.annotation.TargetApi;
-import android.os.Build;
+import android.net.Uri;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
-
-import android.net.Uri;
-import java.io.File;
-import java.io.FileInputStream;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.Map;
-
 import androidx.annotation.Nullable;
 import io.github.sheepdestroyer.materialisheep.AdBlocker;
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 @SuppressWarnings("deprecation") // TODO: Uses deprecated WebResourceRequest API
 public class AdBlockWebViewClient extends WebViewClient {
-    private final boolean mAdBlockEnabled;
-    private final Map<String, Boolean> mLoadedUrls = new ConcurrentHashMap<>();
+  private final boolean mAdBlockEnabled;
+  private final Map<String, Boolean> mLoadedUrls = new ConcurrentHashMap<>();
 
-    public AdBlockWebViewClient(boolean adBlockEnabled) {
-        mAdBlockEnabled = adBlockEnabled;
-    }
+  public AdBlockWebViewClient(boolean adBlockEnabled) {
+    mAdBlockEnabled = adBlockEnabled;
+  }
 
-    private WebResourceResponse handleFileRequest(WebView view, String url) {
-        try {
-            String decodedPath = Uri.parse(url).getPath();
-            if (decodedPath != null && !decodedPath.contains("..")) {
-                File file = new File(decodedPath);
-                String canonicalPath = file.getCanonicalPath();
-                String cacheDirPath = view.getContext().getCacheDir().getCanonicalPath() + File.separator;
-                if (canonicalPath.startsWith(cacheDirPath) && canonicalPath.endsWith(".mht")) {
-                    return new WebResourceResponse("application/x-mimearchive", "UTF-8", new FileInputStream(file));
-                }
-            }
-        } catch (Exception e) {
-            // Ignore exception and return null to deny access
+  private WebResourceResponse handleFileRequest(WebView view, String url) {
+    try {
+      String decodedPath = Uri.parse(url).getPath();
+      if (decodedPath != null && !decodedPath.contains("..")) {
+        File file = new File(decodedPath);
+        String canonicalPath = file.getCanonicalPath();
+        String cacheDirPath = view.getContext().getCacheDir().getCanonicalPath() + File.separator;
+        if (canonicalPath.startsWith(cacheDirPath) && canonicalPath.endsWith(".mht")) {
+          return new WebResourceResponse(
+              "application/x-mimearchive", "UTF-8", new FileInputStream(file));
         }
-        return null;
+      }
+    } catch (Exception e) {
+      // Ignore exception and return null to deny access
     }
+    return null;
+  }
 
-    @Override
-    public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
-        if (url != null && url.toLowerCase(java.util.Locale.ROOT).startsWith("file://")) {
-            return handleFileRequest(view, url);
-        }
-        if (!mAdBlockEnabled) {
-            return super.shouldInterceptRequest(view, url);
-        }
-        boolean ad;
-        if (!mLoadedUrls.containsKey(url)) {
-            ad = AdBlocker.isAd(url);
-            mLoadedUrls.put(url, ad);
-        } else {
-            ad = mLoadedUrls.get(url);
-        }
-        return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, url);
+  @Override
+  public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
+    if (url != null && url.toLowerCase(java.util.Locale.ROOT).startsWith("file://")) {
+      return handleFileRequest(view, url);
     }
+    if (!mAdBlockEnabled) {
+      return super.shouldInterceptRequest(view, url);
+    }
+    boolean ad;
+    if (!mLoadedUrls.containsKey(url)) {
+      ad = AdBlocker.isAd(url);
+      mLoadedUrls.put(url, ad);
+    } else {
+      ad = mLoadedUrls.get(url);
+    }
+    return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, url);
+  }
 
-    @Nullable
-    @Override
-    public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
-        String url = request.getUrl().toString();
-        if (url.toLowerCase(java.util.Locale.ROOT).startsWith("file://")) {
-            return handleFileRequest(view, url);
-        }
-        if (!mAdBlockEnabled) {
-            return super.shouldInterceptRequest(view, request);
-        }
-        boolean ad;
-        if (!mLoadedUrls.containsKey(url)) {
-            ad = AdBlocker.isAd(url);
-            mLoadedUrls.put(url, ad);
-        } else {
-            ad = mLoadedUrls.get(url);
-        }
-        return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, request);
+  @Nullable
+  @Override
+  public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+    String url = request.getUrl().toString();
+    if (url.toLowerCase(java.util.Locale.ROOT).startsWith("file://")) {
+      return handleFileRequest(view, url);
     }
+    if (!mAdBlockEnabled) {
+      return super.shouldInterceptRequest(view, request);
+    }
+    boolean ad;
+    if (!mLoadedUrls.containsKey(url)) {
+      ad = AdBlocker.isAd(url);
+      mLoadedUrls.put(url, ad);
+    } else {
+      ad = mLoadedUrls.get(url);
+    }
+    return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, request);
+  }
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/CacheableWebView.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/CacheableWebView.java
@@ -92,7 +92,7 @@ public class CacheableWebView extends WebView {
 
     private void enableCache() {
         WebSettings webSettings = getSettings();
-        webSettings.setAllowFileAccess(true);
+        webSettings.setAllowFileAccess(false);
         setCacheModeInternal();
     }
 

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/CacheableWebView.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/CacheableWebView.java
@@ -19,149 +19,145 @@ package io.github.sheepdestroyer.materialisheep.widget;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.net.Uri;
-
-import androidx.annotation.CallSuper;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
 import android.webkit.WebViewClient;
-
+import androidx.annotation.CallSuper;
+import io.github.sheepdestroyer.materialisheep.AppUtils;
 import java.io.File;
 import java.util.Map;
 
-import io.github.sheepdestroyer.materialisheep.AppUtils;
-
 public class CacheableWebView extends WebView {
-    private static final String CACHE_PREFIX = "webarchive-";
-    private static final String CACHE_EXTENSION = ".mht";
-    private ArchiveClient mArchiveClient = new ArchiveClient();
+  private static final String CACHE_PREFIX = "webarchive-";
+  private static final String CACHE_EXTENSION = ".mht";
+  private ArchiveClient mArchiveClient = new ArchiveClient();
 
-    public CacheableWebView(Context context) {
-        this(context, null);
+  public CacheableWebView(Context context) {
+    this(context, null);
+  }
+
+  public CacheableWebView(Context context, AttributeSet attrs) {
+    this(context, attrs, 0);
+  }
+
+  public CacheableWebView(Context context, AttributeSet attrs, int defStyleAttr) {
+    super(context, attrs, defStyleAttr);
+    init();
+  }
+
+  @Override
+  public void reloadUrl(String url) {
+    super.reloadUrl(getCacheableUrl(url));
+  }
+
+  @Override
+  public void loadUrl(String url) {
+    if (TextUtils.isEmpty(url)) {
+      return;
     }
+    mArchiveClient.lastProgress = 0;
+    super.loadUrl(getCacheableUrl(url));
+  }
 
-    public CacheableWebView(Context context, AttributeSet attrs) {
-        this(context, attrs, 0);
+  @Override
+  public void loadUrl(String url, Map<String, String> additionalHttpHeaders) {
+    if (TextUtils.isEmpty(url)) {
+      return;
     }
+    mArchiveClient.lastProgress = 0;
+    super.loadUrl(getCacheableUrl(url), additionalHttpHeaders);
+  }
 
-    public CacheableWebView(Context context, AttributeSet attrs, int defStyleAttr) {
-        super(context, attrs, defStyleAttr);
-        init();
+  @Override
+  public void setWebChromeClient(WebChromeClient client) {
+    if (!(client instanceof ArchiveClient)) {
+      throw new IllegalArgumentException(
+          "client should be an instance of " + ArchiveClient.class.getName());
     }
+    mArchiveClient = (ArchiveClient) client;
+    super.setWebChromeClient(mArchiveClient);
+  }
 
+  private void init() {
+    enableCache();
+    setLoadSettings();
+    setWebViewClient(new WebViewClient());
+    setWebChromeClient(mArchiveClient);
+  }
+
+  private void enableCache() {
+    WebSettings webSettings = getSettings();
+    webSettings.setAllowFileAccess(false);
+    setCacheModeInternal();
+  }
+
+  private void setCacheModeInternal() {
+    getSettings().setCacheMode(WebSettings.LOAD_CACHE_ELSE_NETWORK);
+  }
+
+  @SuppressLint("SetJavaScriptEnabled")
+  private void setLoadSettings() {
+    WebSettings webSettings = getSettings();
+    webSettings.setLoadWithOverviewMode(true);
+    webSettings.setUseWideViewPort(true);
+    webSettings.setJavaScriptEnabled(true);
+  }
+
+  private String getCacheableUrl(String url) {
+    if (TextUtils.equals(url, BLANK) || TextUtils.equals(url, FILE)) {
+      mArchiveClient.cacheFileName = null;
+      return url;
+    }
+    mArchiveClient.cacheFileName = generateCacheFilename(url);
+    setCacheModeInternal();
+    File cacheFile = new File(mArchiveClient.cacheFileName);
+    if (cacheFile.exists() && !AppUtils.hasConnection(getContext())) {
+      getSettings().setCacheMode(WebSettings.LOAD_CACHE_ONLY);
+      return Uri.fromFile(cacheFile).toString();
+    }
+    return url;
+  }
+
+  private String generateCacheFilename(String url) {
+    String name;
+    try {
+      java.security.MessageDigest digest = java.security.MessageDigest.getInstance("SHA-256");
+      byte[] hash = digest.digest(url.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+      StringBuilder hexString = new StringBuilder();
+      for (byte b : hash) {
+        String hex = Integer.toHexString(0xff & b);
+        if (hex.length() == 1) {
+          hexString.append('0');
+        }
+        hexString.append(hex);
+      }
+      name = hexString.toString();
+    } catch (java.security.NoSuchAlgorithmException e) {
+      name = String.valueOf(url.hashCode());
+    }
+    return getContext().getApplicationContext().getCacheDir().getAbsolutePath()
+        + File.separator
+        + CACHE_PREFIX
+        + name
+        + CACHE_EXTENSION;
+  }
+
+  public static class ArchiveClient extends WebChromeClient {
+    int lastProgress = 0;
+    String cacheFileName = null;
+
+    @CallSuper
     @Override
-    public void reloadUrl(String url) {
-        super.reloadUrl(getCacheableUrl(url));
+    public void onProgressChanged(android.webkit.WebView view, int newProgress) {
+      if (view.getSettings().getCacheMode() == WebSettings.LOAD_CACHE_ONLY) {
+        return;
+      }
+      if (cacheFileName != null && lastProgress != 100 && newProgress == 100) {
+        lastProgress = newProgress;
+        view.saveWebArchive(cacheFileName);
+      }
     }
-
-    @Override
-    public void loadUrl(String url) {
-        if (TextUtils.isEmpty(url)) {
-            return;
-        }
-        mArchiveClient.lastProgress = 0;
-        super.loadUrl(getCacheableUrl(url));
-    }
-
-    @Override
-    public void loadUrl(String url, Map<String, String> additionalHttpHeaders) {
-        if (TextUtils.isEmpty(url)) {
-            return;
-        }
-        mArchiveClient.lastProgress = 0;
-        super.loadUrl(getCacheableUrl(url), additionalHttpHeaders);
-    }
-
-    @Override
-    public void setWebChromeClient(WebChromeClient client) {
-        if (!(client instanceof ArchiveClient)) {
-            throw new IllegalArgumentException("client should be an instance of " +
-                    ArchiveClient.class.getName());
-        }
-        mArchiveClient = (ArchiveClient) client;
-        super.setWebChromeClient(mArchiveClient);
-    }
-
-    private void init() {
-        enableCache();
-        setLoadSettings();
-        setWebViewClient(new WebViewClient());
-        setWebChromeClient(mArchiveClient);
-    }
-
-    private void enableCache() {
-        WebSettings webSettings = getSettings();
-        webSettings.setAllowFileAccess(false);
-        setCacheModeInternal();
-    }
-
-    private void setCacheModeInternal() {
-        getSettings().setCacheMode(WebSettings.LOAD_CACHE_ELSE_NETWORK);
-    }
-
-    @SuppressLint("SetJavaScriptEnabled")
-    private void setLoadSettings() {
-        WebSettings webSettings = getSettings();
-        webSettings.setLoadWithOverviewMode(true);
-        webSettings.setUseWideViewPort(true);
-        webSettings.setJavaScriptEnabled(true);
-    }
-
-    private String getCacheableUrl(String url) {
-        if (TextUtils.equals(url, BLANK) || TextUtils.equals(url, FILE)) {
-            mArchiveClient.cacheFileName = null;
-            return url;
-        }
-        mArchiveClient.cacheFileName = generateCacheFilename(url);
-        setCacheModeInternal();
-        File cacheFile = new File(mArchiveClient.cacheFileName);
-        if (cacheFile.exists() && !AppUtils.hasConnection(getContext())) {
-            getSettings().setCacheMode(WebSettings.LOAD_CACHE_ONLY);
-            return Uri.fromFile(cacheFile).toString();
-        }
-        return url;
-    }
-
-    private String generateCacheFilename(String url) {
-        String name;
-        try {
-            java.security.MessageDigest digest = java.security.MessageDigest.getInstance("SHA-256");
-            byte[] hash = digest.digest(url.getBytes(java.nio.charset.StandardCharsets.UTF_8));
-            StringBuilder hexString = new StringBuilder();
-            for (byte b : hash) {
-                String hex = Integer.toHexString(0xff & b);
-                if (hex.length() == 1) {
-                    hexString.append('0');
-                }
-                hexString.append(hex);
-            }
-            name = hexString.toString();
-        } catch (java.security.NoSuchAlgorithmException e) {
-            name = String.valueOf(url.hashCode());
-        }
-        return getContext().getApplicationContext().getCacheDir().getAbsolutePath() +
-                File.separator +
-                CACHE_PREFIX +
-                name +
-                CACHE_EXTENSION;
-    }
-
-    public static class ArchiveClient extends WebChromeClient {
-        int lastProgress = 0;
-        String cacheFileName = null;
-
-        @CallSuper
-        @Override
-        public void onProgressChanged(android.webkit.WebView view, int newProgress) {
-            if (view.getSettings().getCacheMode() == WebSettings.LOAD_CACHE_ONLY) {
-                return;
-            }
-            if (cacheFileName != null && lastProgress != 100 && newProgress == 100) {
-                lastProgress = newProgress;
-                view.saveWebArchive(cacheFileName);
-            }
-        }
-
-    }
+  }
 }


### PR DESCRIPTION
**🚨 Severity:** CRITICAL

**💡 Vulnerability:** 
Local File Inclusion (LFI) vulnerability present due to globally enabled file access (`setAllowFileAccess(true)`) within `CacheableWebView`. Any maliciously crafted web content loaded in this view could potentially read local files across the application's sandbox.

**🎯 Impact:** 
Malicious sites or XSS payloads could exfiltrate sensitive local user data, cache files, or configuration assets belonging to the application. 

**🔧 Fix:**
1. Disabled global file access by setting `webSettings.setAllowFileAccess(false)` in `CacheableWebView`.
2. To retain offline cache viewing functionality without compromising security, introduced manual request interception in `AdBlockWebViewClient`. `file://` requests are carefully checked to ensure they strictly target expected `.mht` files residing inside the authorized application cache directory, safely returning them via `WebResourceResponse` while blocking all other local file accesses.
3. Switched `mLoadedUrls` map to `ConcurrentHashMap` since WebView request interception executes concurrently on background threads.

**✅ Verification:**
Ran `./gradlew clean lint testDebugUnitTest --no-daemon` successfully. Verified LFI fixes compile properly and pass existing test suites.

---
*PR created automatically by Jules for task [9947214572417065647](https://jules.google.com/task/9947214572417065647) started by @sheepdestroyer*

## Summary by Sourcery

Mitigate a local file inclusion vulnerability in CacheableWebView while preserving safe offline cache access and ensuring thread-safe URL tracking in the ad-blocking WebView client.

Bug Fixes:
- Disable generic file access in CacheableWebView to prevent arbitrary local file inclusion via WebView content.
- Restrict file:// request handling in AdBlockWebViewClient to only serve .mht files from the app cache directory, blocking other local file access.

Enhancements:
- Switch the URL tracking map in AdBlockWebViewClient to ConcurrentHashMap to support concurrent WebView request interception safely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security for file access with path traversal protection
  * Disabled file access by default for improved WebView safety
  * Improved thread safety for ad-blocking cache operations

* **New Features**
  * Added support for web archive (.mht) files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->