### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Local File Inclusion (LFI) via WebView

### DIFF
--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
@@ -16,91 +16,90 @@
 
 package io.github.sheepdestroyer.materialisheep.widget;
 
-import android.annotation.TargetApi;
-import android.os.Build;
+import android.net.Uri;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
-
+import androidx.annotation.Nullable;
+import io.github.sheepdestroyer.materialisheep.AdBlocker;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import android.net.Uri;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.Map;
-
-import androidx.annotation.Nullable;
-import io.github.sheepdestroyer.materialisheep.AdBlocker;
+import java.util.concurrent.ConcurrentHashMap;
 
 @SuppressWarnings("deprecation") // TODO: Uses deprecated WebResourceRequest API
 public class AdBlockWebViewClient extends WebViewClient {
-    private final boolean mAdBlockEnabled;
-    private final Map<String, Boolean> mLoadedUrls = new ConcurrentHashMap<>();
+  private final boolean mAdBlockEnabled;
+  private final Map<String, Boolean> mLoadedUrls = new ConcurrentHashMap<>();
 
-    public AdBlockWebViewClient(boolean adBlockEnabled) {
-        mAdBlockEnabled = adBlockEnabled;
+  public AdBlockWebViewClient(boolean adBlockEnabled) {
+    mAdBlockEnabled = adBlockEnabled;
+  }
+
+  private WebResourceResponse handleFileRequest(WebView view, String url) {
+    if (url != null && url.toLowerCase(java.util.Locale.ROOT).startsWith("file://")) {
+      String decodedPath = Uri.parse(url).getPath();
+      if (decodedPath != null && !decodedPath.contains("..")) {
+        File file = new File(decodedPath);
+        try {
+          String canonicalPath = file.getCanonicalPath();
+          String cacheDirCanonicalPath =
+              view.getContext().getApplicationContext().getCacheDir().getCanonicalPath()
+                  + File.separator;
+          if (canonicalPath.startsWith(cacheDirCanonicalPath) && canonicalPath.endsWith(".mht")) {
+            return new WebResourceResponse(
+                "application/x-mimearchive", "UTF-8", new FileInputStream(file));
+          }
+        } catch (IOException e) {
+          // Ignore and block
+        }
+      }
+      return AdBlocker.createEmptyResource();
+    }
+    return null;
+  }
+
+  @Override
+  public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
+    WebResourceResponse fileResponse = handleFileRequest(view, url);
+    if (fileResponse != null) {
+      return fileResponse;
     }
 
-    private WebResourceResponse handleFileRequest(WebView view, String url) {
-        if (url != null && url.toLowerCase(java.util.Locale.ROOT).startsWith("file://")) {
-            String decodedPath = Uri.parse(url).getPath();
-            if (decodedPath != null && !decodedPath.contains("..")) {
-                File file = new File(decodedPath);
-                try {
-                    String canonicalPath = file.getCanonicalPath();
-                    String cacheDirCanonicalPath = view.getContext().getApplicationContext().getCacheDir().getCanonicalPath() + File.separator;
-                    if (canonicalPath.startsWith(cacheDirCanonicalPath) && canonicalPath.endsWith(".mht")) {
-                        return new WebResourceResponse("application/x-mimearchive", "UTF-8", new FileInputStream(file));
-                    }
-                } catch (IOException e) {
-                    // Ignore and block
-                }
-            }
-            return AdBlocker.createEmptyResource();
-        }
-        return null;
+    if (!mAdBlockEnabled) {
+      return super.shouldInterceptRequest(view, url);
+    }
+    boolean ad;
+    if (!mLoadedUrls.containsKey(url)) {
+      ad = AdBlocker.isAd(url);
+      mLoadedUrls.put(url, ad);
+    } else {
+      ad = mLoadedUrls.get(url);
+    }
+    return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, url);
+  }
+
+  @Nullable
+  @Override
+  public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+    String url = request.getUrl().toString();
+    WebResourceResponse fileResponse = handleFileRequest(view, url);
+    if (fileResponse != null) {
+      return fileResponse;
     }
 
-    @Override
-    public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
-        WebResourceResponse fileResponse = handleFileRequest(view, url);
-        if (fileResponse != null) {
-            return fileResponse;
-        }
-
-        if (!mAdBlockEnabled) {
-            return super.shouldInterceptRequest(view, url);
-        }
-        boolean ad;
-        if (!mLoadedUrls.containsKey(url)) {
-            ad = AdBlocker.isAd(url);
-            mLoadedUrls.put(url, ad);
-        } else {
-            ad = mLoadedUrls.get(url);
-        }
-        return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, url);
+    if (!mAdBlockEnabled) {
+      return super.shouldInterceptRequest(view, request);
     }
-
-    @Nullable
-    @Override
-    public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
-        String url = request.getUrl().toString();
-        WebResourceResponse fileResponse = handleFileRequest(view, url);
-        if (fileResponse != null) {
-            return fileResponse;
-        }
-
-        if (!mAdBlockEnabled) {
-            return super.shouldInterceptRequest(view, request);
-        }
-        boolean ad;
-        if (!mLoadedUrls.containsKey(url)) {
-            ad = AdBlocker.isAd(url);
-            mLoadedUrls.put(url, ad);
-        } else {
-            ad = mLoadedUrls.get(url);
-        }
-        return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, request);
+    boolean ad;
+    if (!mLoadedUrls.containsKey(url)) {
+      ad = AdBlocker.isAd(url);
+      mLoadedUrls.put(url, ad);
+    } else {
+      ad = mLoadedUrls.get(url);
     }
+    return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, request);
+  }
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
@@ -23,7 +23,11 @@ import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
-import java.util.HashMap;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import android.net.Uri;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.Map;
 
 import androidx.annotation.Nullable;
@@ -32,14 +36,39 @@ import io.github.sheepdestroyer.materialisheep.AdBlocker;
 @SuppressWarnings("deprecation") // TODO: Uses deprecated WebResourceRequest API
 public class AdBlockWebViewClient extends WebViewClient {
     private final boolean mAdBlockEnabled;
-    private final Map<String, Boolean> mLoadedUrls = new HashMap<>();
+    private final Map<String, Boolean> mLoadedUrls = new ConcurrentHashMap<>();
 
     public AdBlockWebViewClient(boolean adBlockEnabled) {
         mAdBlockEnabled = adBlockEnabled;
     }
 
+    private WebResourceResponse handleFileRequest(WebView view, String url) {
+        if (url != null && url.toLowerCase(java.util.Locale.ROOT).startsWith("file://")) {
+            String decodedPath = Uri.parse(url).getPath();
+            if (decodedPath != null && !decodedPath.contains("..")) {
+                File file = new File(decodedPath);
+                try {
+                    String canonicalPath = file.getCanonicalPath();
+                    String cacheDirCanonicalPath = view.getContext().getApplicationContext().getCacheDir().getCanonicalPath() + File.separator;
+                    if (canonicalPath.startsWith(cacheDirCanonicalPath) && canonicalPath.endsWith(".mht")) {
+                        return new WebResourceResponse("application/x-mimearchive", "UTF-8", new FileInputStream(file));
+                    }
+                } catch (IOException e) {
+                    // Ignore and block
+                }
+            }
+            return AdBlocker.createEmptyResource();
+        }
+        return null;
+    }
+
     @Override
     public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
+        WebResourceResponse fileResponse = handleFileRequest(view, url);
+        if (fileResponse != null) {
+            return fileResponse;
+        }
+
         if (!mAdBlockEnabled) {
             return super.shouldInterceptRequest(view, url);
         }
@@ -56,11 +85,16 @@ public class AdBlockWebViewClient extends WebViewClient {
     @Nullable
     @Override
     public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+        String url = request.getUrl().toString();
+        WebResourceResponse fileResponse = handleFileRequest(view, url);
+        if (fileResponse != null) {
+            return fileResponse;
+        }
+
         if (!mAdBlockEnabled) {
             return super.shouldInterceptRequest(view, request);
         }
         boolean ad;
-        String url = request.getUrl().toString();
         if (!mLoadedUrls.containsKey(url)) {
             ad = AdBlocker.isAd(url);
             mLoadedUrls.put(url, ad);

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/CacheableWebView.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/CacheableWebView.java
@@ -92,7 +92,7 @@ public class CacheableWebView extends WebView {
 
     private void enableCache() {
         WebSettings webSettings = getSettings();
-        webSettings.setAllowFileAccess(true);
+        webSettings.setAllowFileAccess(false);
         setCacheModeInternal();
     }
 

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/CacheableWebView.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/CacheableWebView.java
@@ -19,149 +19,145 @@ package io.github.sheepdestroyer.materialisheep.widget;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.net.Uri;
-
-import androidx.annotation.CallSuper;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
 import android.webkit.WebViewClient;
-
+import androidx.annotation.CallSuper;
+import io.github.sheepdestroyer.materialisheep.AppUtils;
 import java.io.File;
 import java.util.Map;
 
-import io.github.sheepdestroyer.materialisheep.AppUtils;
-
 public class CacheableWebView extends WebView {
-    private static final String CACHE_PREFIX = "webarchive-";
-    private static final String CACHE_EXTENSION = ".mht";
-    private ArchiveClient mArchiveClient = new ArchiveClient();
+  private static final String CACHE_PREFIX = "webarchive-";
+  private static final String CACHE_EXTENSION = ".mht";
+  private ArchiveClient mArchiveClient = new ArchiveClient();
 
-    public CacheableWebView(Context context) {
-        this(context, null);
+  public CacheableWebView(Context context) {
+    this(context, null);
+  }
+
+  public CacheableWebView(Context context, AttributeSet attrs) {
+    this(context, attrs, 0);
+  }
+
+  public CacheableWebView(Context context, AttributeSet attrs, int defStyleAttr) {
+    super(context, attrs, defStyleAttr);
+    init();
+  }
+
+  @Override
+  public void reloadUrl(String url) {
+    super.reloadUrl(getCacheableUrl(url));
+  }
+
+  @Override
+  public void loadUrl(String url) {
+    if (TextUtils.isEmpty(url)) {
+      return;
     }
+    mArchiveClient.lastProgress = 0;
+    super.loadUrl(getCacheableUrl(url));
+  }
 
-    public CacheableWebView(Context context, AttributeSet attrs) {
-        this(context, attrs, 0);
+  @Override
+  public void loadUrl(String url, Map<String, String> additionalHttpHeaders) {
+    if (TextUtils.isEmpty(url)) {
+      return;
     }
+    mArchiveClient.lastProgress = 0;
+    super.loadUrl(getCacheableUrl(url), additionalHttpHeaders);
+  }
 
-    public CacheableWebView(Context context, AttributeSet attrs, int defStyleAttr) {
-        super(context, attrs, defStyleAttr);
-        init();
+  @Override
+  public void setWebChromeClient(WebChromeClient client) {
+    if (!(client instanceof ArchiveClient)) {
+      throw new IllegalArgumentException(
+          "client should be an instance of " + ArchiveClient.class.getName());
     }
+    mArchiveClient = (ArchiveClient) client;
+    super.setWebChromeClient(mArchiveClient);
+  }
 
+  private void init() {
+    enableCache();
+    setLoadSettings();
+    setWebViewClient(new WebViewClient());
+    setWebChromeClient(mArchiveClient);
+  }
+
+  private void enableCache() {
+    WebSettings webSettings = getSettings();
+    webSettings.setAllowFileAccess(false);
+    setCacheModeInternal();
+  }
+
+  private void setCacheModeInternal() {
+    getSettings().setCacheMode(WebSettings.LOAD_CACHE_ELSE_NETWORK);
+  }
+
+  @SuppressLint("SetJavaScriptEnabled")
+  private void setLoadSettings() {
+    WebSettings webSettings = getSettings();
+    webSettings.setLoadWithOverviewMode(true);
+    webSettings.setUseWideViewPort(true);
+    webSettings.setJavaScriptEnabled(true);
+  }
+
+  private String getCacheableUrl(String url) {
+    if (TextUtils.equals(url, BLANK) || TextUtils.equals(url, FILE)) {
+      mArchiveClient.cacheFileName = null;
+      return url;
+    }
+    mArchiveClient.cacheFileName = generateCacheFilename(url);
+    setCacheModeInternal();
+    File cacheFile = new File(mArchiveClient.cacheFileName);
+    if (cacheFile.exists() && !AppUtils.hasConnection(getContext())) {
+      getSettings().setCacheMode(WebSettings.LOAD_CACHE_ONLY);
+      return Uri.fromFile(cacheFile).toString();
+    }
+    return url;
+  }
+
+  private String generateCacheFilename(String url) {
+    String name;
+    try {
+      java.security.MessageDigest digest = java.security.MessageDigest.getInstance("SHA-256");
+      byte[] hash = digest.digest(url.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+      StringBuilder hexString = new StringBuilder();
+      for (byte b : hash) {
+        String hex = Integer.toHexString(0xff & b);
+        if (hex.length() == 1) {
+          hexString.append('0');
+        }
+        hexString.append(hex);
+      }
+      name = hexString.toString();
+    } catch (java.security.NoSuchAlgorithmException e) {
+      name = String.valueOf(url.hashCode());
+    }
+    return getContext().getApplicationContext().getCacheDir().getAbsolutePath()
+        + File.separator
+        + CACHE_PREFIX
+        + name
+        + CACHE_EXTENSION;
+  }
+
+  public static class ArchiveClient extends WebChromeClient {
+    int lastProgress = 0;
+    String cacheFileName = null;
+
+    @CallSuper
     @Override
-    public void reloadUrl(String url) {
-        super.reloadUrl(getCacheableUrl(url));
+    public void onProgressChanged(android.webkit.WebView view, int newProgress) {
+      if (view.getSettings().getCacheMode() == WebSettings.LOAD_CACHE_ONLY) {
+        return;
+      }
+      if (cacheFileName != null && lastProgress != 100 && newProgress == 100) {
+        lastProgress = newProgress;
+        view.saveWebArchive(cacheFileName);
+      }
     }
-
-    @Override
-    public void loadUrl(String url) {
-        if (TextUtils.isEmpty(url)) {
-            return;
-        }
-        mArchiveClient.lastProgress = 0;
-        super.loadUrl(getCacheableUrl(url));
-    }
-
-    @Override
-    public void loadUrl(String url, Map<String, String> additionalHttpHeaders) {
-        if (TextUtils.isEmpty(url)) {
-            return;
-        }
-        mArchiveClient.lastProgress = 0;
-        super.loadUrl(getCacheableUrl(url), additionalHttpHeaders);
-    }
-
-    @Override
-    public void setWebChromeClient(WebChromeClient client) {
-        if (!(client instanceof ArchiveClient)) {
-            throw new IllegalArgumentException("client should be an instance of " +
-                    ArchiveClient.class.getName());
-        }
-        mArchiveClient = (ArchiveClient) client;
-        super.setWebChromeClient(mArchiveClient);
-    }
-
-    private void init() {
-        enableCache();
-        setLoadSettings();
-        setWebViewClient(new WebViewClient());
-        setWebChromeClient(mArchiveClient);
-    }
-
-    private void enableCache() {
-        WebSettings webSettings = getSettings();
-        webSettings.setAllowFileAccess(false);
-        setCacheModeInternal();
-    }
-
-    private void setCacheModeInternal() {
-        getSettings().setCacheMode(WebSettings.LOAD_CACHE_ELSE_NETWORK);
-    }
-
-    @SuppressLint("SetJavaScriptEnabled")
-    private void setLoadSettings() {
-        WebSettings webSettings = getSettings();
-        webSettings.setLoadWithOverviewMode(true);
-        webSettings.setUseWideViewPort(true);
-        webSettings.setJavaScriptEnabled(true);
-    }
-
-    private String getCacheableUrl(String url) {
-        if (TextUtils.equals(url, BLANK) || TextUtils.equals(url, FILE)) {
-            mArchiveClient.cacheFileName = null;
-            return url;
-        }
-        mArchiveClient.cacheFileName = generateCacheFilename(url);
-        setCacheModeInternal();
-        File cacheFile = new File(mArchiveClient.cacheFileName);
-        if (cacheFile.exists() && !AppUtils.hasConnection(getContext())) {
-            getSettings().setCacheMode(WebSettings.LOAD_CACHE_ONLY);
-            return Uri.fromFile(cacheFile).toString();
-        }
-        return url;
-    }
-
-    private String generateCacheFilename(String url) {
-        String name;
-        try {
-            java.security.MessageDigest digest = java.security.MessageDigest.getInstance("SHA-256");
-            byte[] hash = digest.digest(url.getBytes(java.nio.charset.StandardCharsets.UTF_8));
-            StringBuilder hexString = new StringBuilder();
-            for (byte b : hash) {
-                String hex = Integer.toHexString(0xff & b);
-                if (hex.length() == 1) {
-                    hexString.append('0');
-                }
-                hexString.append(hex);
-            }
-            name = hexString.toString();
-        } catch (java.security.NoSuchAlgorithmException e) {
-            name = String.valueOf(url.hashCode());
-        }
-        return getContext().getApplicationContext().getCacheDir().getAbsolutePath() +
-                File.separator +
-                CACHE_PREFIX +
-                name +
-                CACHE_EXTENSION;
-    }
-
-    public static class ArchiveClient extends WebChromeClient {
-        int lastProgress = 0;
-        String cacheFileName = null;
-
-        @CallSuper
-        @Override
-        public void onProgressChanged(android.webkit.WebView view, int newProgress) {
-            if (view.getSettings().getCacheMode() == WebSettings.LOAD_CACHE_ONLY) {
-                return;
-            }
-            if (cacheFileName != null && lastProgress != 100 && newProgress == 100) {
-                lastProgress = newProgress;
-                view.saveWebArchive(cacheFileName);
-            }
-        }
-
-    }
+  }
 }


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Local File Inclusion (LFI) vulnerability due to globally enabled `setAllowFileAccess(true)` in `CacheableWebView` combined with insecure handling of `file://` scheme requests. An attacker could exploit this via an XSS attack to access and exfiltrate sensitive local files (e.g., shared preferences, internal databases).
🎯 **Impact:** Exfiltration of sensitive user data, potentially leading to complete account compromise or data theft.
🔧 **Fix:** 
1. Disabled global file access (`webSettings.setAllowFileAccess(false)`) in `CacheableWebView`.
2. Implemented a secure `handleFileRequest` interceptor in `AdBlockWebViewClient` to strictly allow access *only* to legitimate `.mht` cached web archives located within the application's internal cache directory.
3. Added path traversal protections (`..` checks and `getCanonicalPath()` verification).
4. Changed `mLoadedUrls` to a `ConcurrentHashMap` to fix an underlying thread safety issue since `shouldInterceptRequest` is called on background threads.
✅ **Verification:** Ran the full test suite and lint checks using `./gradlew clean lint testDebugUnitTest`. All tests pass successfully with no regressions.

---
*PR created automatically by Jules for task [10861060032756988325](https://jules.google.com/task/10861060032756988325) started by @sheepdestroyer*

## Summary by Sourcery

Mitigate a critical local file inclusion vulnerability in WebView file handling and improve thread safety in ad blocking URL tracking.

Bug Fixes:
- Disable general file access in CacheableWebView to prevent unauthorized local file reads.
- Restrict file:// request handling in AdBlockWebViewClient to only cached .mht files within the app cache directory, with path traversal protections.

Enhancements:
- Use a ConcurrentHashMap for tracking loaded URLs in AdBlockWebViewClient to ensure thread-safe access in background request interception.