### PR TITLE
⚡ Bolt: Pre-compile regular expressions to prevent dynamic compilation overhead

### DIFF
--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/ComposeActivity.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/ComposeActivity.java
@@ -33,6 +33,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import java.lang.ref.WeakReference;
+import java.util.regex.Pattern;
 
 import javax.inject.Inject;
 
@@ -49,7 +50,7 @@ public class ComposeActivity extends ThemedActivity {
     private static final String HN_FORMAT_DOC_URL = "https://news.ycombinator.com/formatdoc";
     private static final String FORMAT_QUOTE = "> %s\n\n";
     private static final String PARAGRAPH_QUOTE = "\n\n> ";
-    private static final String PARAGRAPH_BREAK_REGEX = "[\\n]{2,}";
+    private static final Pattern PATTERN_PARAGRAPH_BREAK = Pattern.compile("[\\n]{2,}");
     @Inject
     UserServices mUserServices;
     @Inject
@@ -247,10 +248,9 @@ public class ComposeActivity extends ThemedActivity {
 
     private String createQuote() {
         if (mQuoteText == null) {
-            mQuoteText = String.format(FORMAT_QUOTE, AppUtils.fromHtml(mParentText)
+            mQuoteText = String.format(FORMAT_QUOTE, PATTERN_PARAGRAPH_BREAK.matcher(AppUtils.fromHtml(mParentText)
                     .toString()
-                    .trim()
-                    .replaceAll(PARAGRAPH_BREAK_REGEX, PARAGRAPH_QUOTE));
+                    .trim()).replaceAll(PARAGRAPH_QUOTE));
         }
         return mQuoteText;
     }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/SubmitActivity.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/SubmitActivity.java
@@ -53,7 +53,7 @@ public class SubmitActivity extends ThemedActivity {
     private static final String STATE_SUBJECT = "state:subject";
     private static final String STATE_TEXT = "state:text";
     // matching title url without any trailing text
-    private static final String REGEX_FUZZY_URL = "(.*)((http|https)://[^\\s]*)$";
+    private static final Pattern PATTERN_FUZZY_URL = Pattern.compile("(.*)((http|https)://[^\\s]*)$");
     @Inject
     UserServices mUserServices;
     @Inject
@@ -271,7 +271,7 @@ public class SubmitActivity extends ThemedActivity {
     }
 
     private void extractUrl(String text) {
-        Matcher matcher = Pattern.compile(REGEX_FUZZY_URL).matcher(text);
+        Matcher matcher = PATTERN_FUZZY_URL.matcher(text);
         if (matcher.find() && matcher.groupCount() >= 3) { // group 1: title, group 2: url, group 3: scheme
             mTitleEditText.setText(trimTitle(matcher.group(1).trim()));
             mContentEditText.setText(matcher.group(2));

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/accounts/UserServicesClient.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/accounts/UserServicesClient.java
@@ -70,9 +70,10 @@ public class UserServicesClient implements UserServices {
     private static final String CREATING_TRUE = "t";
     private static final String DEFAULT_FNOP = "submit-page";
     private static final String DEFAULT_SUBMIT_REDIRECT = "newest";
-    private static final String REGEX_INPUT = "<\\s*input[^>]*>";
-    private static final String REGEX_VALUE = "value[^\"]*\"([^\"]*)\"";
-    private static final String REGEX_CREATE_ERROR_BODY = "<body>([^<]*)";
+    private static final Pattern PATTERN_INPUT = Pattern.compile("<\\s*input[^>]*>");
+    private static final Pattern PATTERN_VALUE = Pattern.compile("value[^\"]*\"([^\"]*)\"");
+    private static final Pattern PATTERN_CREATE_ERROR_BODY = Pattern.compile("<body>([^<]*)");
+    private static final Pattern PATTERN_WHITESPACE = Pattern.compile("\\n|\\r|\\t|\\s+");
     private static final String HEADER_LOCATION = "location";
     private static final String HEADER_COOKIE = "cookie";
     private static final String HEADER_SET_COOKIE = "set-cookie";
@@ -331,12 +332,12 @@ public class UserServicesClient implements UserServices {
 
     private String getInputValue(String html, String name) {
         // extract <input ... >
-        Matcher matcherInput = Pattern.compile(REGEX_INPUT).matcher(html);
+        Matcher matcherInput = PATTERN_INPUT.matcher(html);
         while (matcherInput.find()) {
             String input = matcherInput.group();
             if (input.contains(name)) {
                 // extract value="..."
-                Matcher matcher = Pattern.compile(REGEX_VALUE).matcher(input);
+                Matcher matcher = PATTERN_VALUE.matcher(input);
                 return matcher.find() ? matcher.group(1) : null; // return first match if any
             }
         }
@@ -345,8 +346,8 @@ public class UserServicesClient implements UserServices {
 
     private String parseLoginError(Response response) {
         try {
-            Matcher matcher = Pattern.compile(REGEX_CREATE_ERROR_BODY).matcher(response.body().string());
-            return matcher.find() ? matcher.group(1).replaceAll("\\n|\\r|\\t|\\s+", " ").trim() : null;
+            Matcher matcher = PATTERN_CREATE_ERROR_BODY.matcher(response.body().string());
+            return matcher.find() ? PATTERN_WHITESPACE.matcher(matcher.group(1)).replaceAll(" ").trim() : null;
         } catch (IOException e) {
             return null;
         }


### PR DESCRIPTION
### 💡 What
Refactored inline regular expressions in `SubmitActivity`, `UserServicesClient`, and `ComposeActivity` into pre-compiled `private static final Pattern` constants.
* `SubmitActivity`: Pre-compiled `REGEX_FUZZY_URL`.
* `UserServicesClient`: Pre-compiled `REGEX_INPUT`, `REGEX_VALUE`, `REGEX_CREATE_ERROR_BODY`, and introduced `PATTERN_WHITESPACE` for an inline `String.replaceAll()`.
* `ComposeActivity`: Pre-compiled `PARAGRAPH_BREAK_REGEX`.

### 🎯 Why
In Java, both `Pattern.compile()` and `String.replaceAll()` (which implicitly compiles the regex string) are expensive operations. When called inside methods or loops (like `getInputValue` traversing HTML inputs), they add significant CPU and GC overhead. `Pattern` objects are thread-safe and immutable, making them ideal candidates for `static final` constants, allowing them to be compiled only once upon class loading.

### 📊 Impact
* **Faster Method Execution:** Avoids repeated regex parsing and compilation during form parsing and HTML manipulation.
* **Reduced Memory Churn:** Eliminates the garbage collection overhead associated with instantiating a new `Pattern` object on every method call.

### 🔬 Measurement
Run `./gradlew clean lint testDebugUnitTest --no-daemon` to verify all tests continue to pass and no functionality was broken by the refactoring.

---
*PR created automatically by Jules for task [8985167193065138492](https://jules.google.com/task/8985167193065138492) started by @sheepdestroyer*

## Summary by Sourcery

Enhancements:
- Replace string-based regex usage in UserServicesClient, ComposeActivity, and SubmitActivity with shared pre-compiled Pattern constants to improve performance and reduce allocation overhead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized pattern matching performance across quote generation, URL extraction, and login error parsing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sheepdestroyer/materialisheep/pull/219)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->