### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Local File Inclusion (LFI)

### DIFF
--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
@@ -16,93 +16,106 @@
 
 package io.github.sheepdestroyer.materialisheep.widget;
 
-import android.annotation.TargetApi;
-import android.os.Build;
+import android.net.Uri;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
-import android.net.Uri;
-
+import androidx.annotation.Nullable;
+import io.github.sheepdestroyer.materialisheep.AdBlocker;
 import java.io.File;
 import java.io.FileInputStream;
 import java.util.HashMap;
 import java.util.Map;
 
-import androidx.annotation.Nullable;
-import io.github.sheepdestroyer.materialisheep.AdBlocker;
-
 @SuppressWarnings("deprecation") // TODO: Uses deprecated WebResourceRequest API
 public class AdBlockWebViewClient extends WebViewClient {
-    private final boolean mAdBlockEnabled;
-    private final Map<String, Boolean> mLoadedUrls = new HashMap<>();
+  private final boolean mAdBlockEnabled;
+  private final Map<String, Boolean> mLoadedUrls = new HashMap<>();
 
-    public AdBlockWebViewClient(boolean adBlockEnabled) {
-        mAdBlockEnabled = adBlockEnabled;
-    }
+  public AdBlockWebViewClient(boolean adBlockEnabled) {
+    mAdBlockEnabled = adBlockEnabled;
+  }
 
-    private WebResourceResponse handleFileUrl(WebView view, String url) {
-        try {
-            Uri uri = Uri.parse(url);
-            String path = uri.getPath();
-            if (path == null || path.contains("..")) {
-                return AdBlocker.createEmptyResource();
-            }
-
-            File file = new File(path);
-            String canonicalPath = file.getCanonicalPath();
-            String cacheDirPath = view.getContext().getApplicationContext().getCacheDir().getCanonicalPath() + File.separator;
-
-            if (canonicalPath.startsWith(cacheDirPath)) {
-                FileInputStream is = new FileInputStream(file);
-                return new WebResourceResponse("application/x-mimearchive", "UTF-8", is);
-            }
-        } catch (Exception e) {
-            // Ignore
-        }
-
+  private WebResourceResponse handleFileUrl(WebView view, String url) {
+    try {
+      Uri uri = Uri.parse(url);
+      String path = uri.getPath();
+      if (path == null || path.contains("..")) {
         return AdBlocker.createEmptyResource();
+      }
+
+      File file = new File(path);
+      String canonicalPath = file.getCanonicalPath();
+      String cacheDirPath =
+          view.getContext().getApplicationContext().getCacheDir().getCanonicalPath()
+              + File.separator;
+
+      if (canonicalPath.startsWith(cacheDirPath)) {
+        FileInputStream is = new FileInputStream(file);
+        return new WebResourceResponse("application/x-mimearchive", "UTF-8", is);
+      }
+    } catch (Exception e) {
+      // Ignore
     }
 
-    @Override
-    public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
-        if (url != null && url.toLowerCase(java.util.Locale.ROOT).startsWith("file://") && !url.toLowerCase(java.util.Locale.ROOT).startsWith("file:///android_asset/") && !url.toLowerCase(java.util.Locale.ROOT).startsWith("file:///android_res/")) {
-            return handleFileUrl(view, url);
-        }
+    return AdBlocker.createEmptyResource();
+  }
 
-        if (!mAdBlockEnabled) {
-            return super.shouldInterceptRequest(view, url);
-        }
-
-        boolean ad;
-        if (!mLoadedUrls.containsKey(url)) {
-            ad = AdBlocker.isAd(url);
-            mLoadedUrls.put(url, ad);
-        } else {
-            ad = mLoadedUrls.get(url);
-        }
-        return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, url);
+  @Override
+  public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
+    if (url != null
+        && url.toLowerCase(java.util.Locale.ROOT).startsWith("file://")
+        && !url.toLowerCase(java.util.Locale.ROOT).startsWith("file:///android_asset/")
+        && !url.toLowerCase(java.util.Locale.ROOT).startsWith("file:///android_res/")) {
+      return handleFileUrl(view, url);
     }
 
-    @Nullable
-    @Override
-    public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
-        if (request != null && request.getUrl() != null && request.getUrl().toString().toLowerCase(java.util.Locale.ROOT).startsWith("file://") && !request.getUrl().toString().toLowerCase(java.util.Locale.ROOT).startsWith("file:///android_asset/") && !request.getUrl().toString().toLowerCase(java.util.Locale.ROOT).startsWith("file:///android_res/")) {
-            return handleFileUrl(view, request.getUrl().toString());
-        }
-
-        if (!mAdBlockEnabled) {
-            return super.shouldInterceptRequest(view, request);
-        }
-
-        boolean ad;
-        String url = request.getUrl().toString();
-        if (!mLoadedUrls.containsKey(url)) {
-            ad = AdBlocker.isAd(url);
-            mLoadedUrls.put(url, ad);
-        } else {
-            ad = mLoadedUrls.get(url);
-        }
-        return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, request);
+    if (!mAdBlockEnabled) {
+      return super.shouldInterceptRequest(view, url);
     }
+
+    boolean ad;
+    if (!mLoadedUrls.containsKey(url)) {
+      ad = AdBlocker.isAd(url);
+      mLoadedUrls.put(url, ad);
+    } else {
+      ad = mLoadedUrls.get(url);
+    }
+    return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, url);
+  }
+
+  @Nullable
+  @Override
+  public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+    if (request != null
+        && request.getUrl() != null
+        && request.getUrl().toString().toLowerCase(java.util.Locale.ROOT).startsWith("file://")
+        && !request
+            .getUrl()
+            .toString()
+            .toLowerCase(java.util.Locale.ROOT)
+            .startsWith("file:///android_asset/")
+        && !request
+            .getUrl()
+            .toString()
+            .toLowerCase(java.util.Locale.ROOT)
+            .startsWith("file:///android_res/")) {
+      return handleFileUrl(view, request.getUrl().toString());
+    }
+
+    if (!mAdBlockEnabled) {
+      return super.shouldInterceptRequest(view, request);
+    }
+
+    boolean ad;
+    String url = request.getUrl().toString();
+    if (!mLoadedUrls.containsKey(url)) {
+      ad = AdBlocker.isAd(url);
+      mLoadedUrls.put(url, ad);
+    } else {
+      ad = mLoadedUrls.get(url);
+    }
+    return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, request);
+  }
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
@@ -22,7 +22,10 @@ import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
+import android.net.Uri;
 
+import java.io.File;
+import java.io.FileInputStream;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -38,11 +41,39 @@ public class AdBlockWebViewClient extends WebViewClient {
         mAdBlockEnabled = adBlockEnabled;
     }
 
+    private WebResourceResponse handleFileUrl(WebView view, String url) {
+        try {
+            Uri uri = Uri.parse(url);
+            String path = uri.getPath();
+            if (path == null || path.contains("..")) {
+                return AdBlocker.createEmptyResource();
+            }
+
+            File file = new File(path);
+            String canonicalPath = file.getCanonicalPath();
+            String cacheDirPath = view.getContext().getApplicationContext().getCacheDir().getCanonicalPath() + File.separator;
+
+            if (canonicalPath.startsWith(cacheDirPath)) {
+                FileInputStream is = new FileInputStream(file);
+                return new WebResourceResponse("application/x-mimearchive", "UTF-8", is);
+            }
+        } catch (Exception e) {
+            // Ignore
+        }
+
+        return AdBlocker.createEmptyResource();
+    }
+
     @Override
     public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
+        if (url != null && url.toLowerCase(java.util.Locale.ROOT).startsWith("file://") && !url.toLowerCase(java.util.Locale.ROOT).startsWith("file:///android_asset/") && !url.toLowerCase(java.util.Locale.ROOT).startsWith("file:///android_res/")) {
+            return handleFileUrl(view, url);
+        }
+
         if (!mAdBlockEnabled) {
             return super.shouldInterceptRequest(view, url);
         }
+
         boolean ad;
         if (!mLoadedUrls.containsKey(url)) {
             ad = AdBlocker.isAd(url);
@@ -56,9 +87,14 @@ public class AdBlockWebViewClient extends WebViewClient {
     @Nullable
     @Override
     public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+        if (request != null && request.getUrl() != null && request.getUrl().toString().toLowerCase(java.util.Locale.ROOT).startsWith("file://") && !request.getUrl().toString().toLowerCase(java.util.Locale.ROOT).startsWith("file:///android_asset/") && !request.getUrl().toString().toLowerCase(java.util.Locale.ROOT).startsWith("file:///android_res/")) {
+            return handleFileUrl(view, request.getUrl().toString());
+        }
+
         if (!mAdBlockEnabled) {
             return super.shouldInterceptRequest(view, request);
         }
+
         boolean ad;
         String url = request.getUrl().toString();
         if (!mLoadedUrls.containsKey(url)) {

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/CacheableWebView.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/CacheableWebView.java
@@ -92,7 +92,7 @@ public class CacheableWebView extends WebView {
 
     private void enableCache() {
         WebSettings webSettings = getSettings();
-        webSettings.setAllowFileAccess(true);
+        webSettings.setAllowFileAccess(false);
         setCacheModeInternal();
     }
 

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/CacheableWebView.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/CacheableWebView.java
@@ -19,149 +19,145 @@ package io.github.sheepdestroyer.materialisheep.widget;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.net.Uri;
-
-import androidx.annotation.CallSuper;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
 import android.webkit.WebViewClient;
-
+import androidx.annotation.CallSuper;
+import io.github.sheepdestroyer.materialisheep.AppUtils;
 import java.io.File;
 import java.util.Map;
 
-import io.github.sheepdestroyer.materialisheep.AppUtils;
-
 public class CacheableWebView extends WebView {
-    private static final String CACHE_PREFIX = "webarchive-";
-    private static final String CACHE_EXTENSION = ".mht";
-    private ArchiveClient mArchiveClient = new ArchiveClient();
+  private static final String CACHE_PREFIX = "webarchive-";
+  private static final String CACHE_EXTENSION = ".mht";
+  private ArchiveClient mArchiveClient = new ArchiveClient();
 
-    public CacheableWebView(Context context) {
-        this(context, null);
+  public CacheableWebView(Context context) {
+    this(context, null);
+  }
+
+  public CacheableWebView(Context context, AttributeSet attrs) {
+    this(context, attrs, 0);
+  }
+
+  public CacheableWebView(Context context, AttributeSet attrs, int defStyleAttr) {
+    super(context, attrs, defStyleAttr);
+    init();
+  }
+
+  @Override
+  public void reloadUrl(String url) {
+    super.reloadUrl(getCacheableUrl(url));
+  }
+
+  @Override
+  public void loadUrl(String url) {
+    if (TextUtils.isEmpty(url)) {
+      return;
     }
+    mArchiveClient.lastProgress = 0;
+    super.loadUrl(getCacheableUrl(url));
+  }
 
-    public CacheableWebView(Context context, AttributeSet attrs) {
-        this(context, attrs, 0);
+  @Override
+  public void loadUrl(String url, Map<String, String> additionalHttpHeaders) {
+    if (TextUtils.isEmpty(url)) {
+      return;
     }
+    mArchiveClient.lastProgress = 0;
+    super.loadUrl(getCacheableUrl(url), additionalHttpHeaders);
+  }
 
-    public CacheableWebView(Context context, AttributeSet attrs, int defStyleAttr) {
-        super(context, attrs, defStyleAttr);
-        init();
+  @Override
+  public void setWebChromeClient(WebChromeClient client) {
+    if (!(client instanceof ArchiveClient)) {
+      throw new IllegalArgumentException(
+          "client should be an instance of " + ArchiveClient.class.getName());
     }
+    mArchiveClient = (ArchiveClient) client;
+    super.setWebChromeClient(mArchiveClient);
+  }
 
+  private void init() {
+    enableCache();
+    setLoadSettings();
+    setWebViewClient(new WebViewClient());
+    setWebChromeClient(mArchiveClient);
+  }
+
+  private void enableCache() {
+    WebSettings webSettings = getSettings();
+    webSettings.setAllowFileAccess(false);
+    setCacheModeInternal();
+  }
+
+  private void setCacheModeInternal() {
+    getSettings().setCacheMode(WebSettings.LOAD_CACHE_ELSE_NETWORK);
+  }
+
+  @SuppressLint("SetJavaScriptEnabled")
+  private void setLoadSettings() {
+    WebSettings webSettings = getSettings();
+    webSettings.setLoadWithOverviewMode(true);
+    webSettings.setUseWideViewPort(true);
+    webSettings.setJavaScriptEnabled(true);
+  }
+
+  private String getCacheableUrl(String url) {
+    if (TextUtils.equals(url, BLANK) || TextUtils.equals(url, FILE)) {
+      mArchiveClient.cacheFileName = null;
+      return url;
+    }
+    mArchiveClient.cacheFileName = generateCacheFilename(url);
+    setCacheModeInternal();
+    File cacheFile = new File(mArchiveClient.cacheFileName);
+    if (cacheFile.exists() && !AppUtils.hasConnection(getContext())) {
+      getSettings().setCacheMode(WebSettings.LOAD_CACHE_ONLY);
+      return Uri.fromFile(cacheFile).toString();
+    }
+    return url;
+  }
+
+  private String generateCacheFilename(String url) {
+    String name;
+    try {
+      java.security.MessageDigest digest = java.security.MessageDigest.getInstance("SHA-256");
+      byte[] hash = digest.digest(url.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+      StringBuilder hexString = new StringBuilder();
+      for (byte b : hash) {
+        String hex = Integer.toHexString(0xff & b);
+        if (hex.length() == 1) {
+          hexString.append('0');
+        }
+        hexString.append(hex);
+      }
+      name = hexString.toString();
+    } catch (java.security.NoSuchAlgorithmException e) {
+      name = String.valueOf(url.hashCode());
+    }
+    return getContext().getApplicationContext().getCacheDir().getAbsolutePath()
+        + File.separator
+        + CACHE_PREFIX
+        + name
+        + CACHE_EXTENSION;
+  }
+
+  public static class ArchiveClient extends WebChromeClient {
+    int lastProgress = 0;
+    String cacheFileName = null;
+
+    @CallSuper
     @Override
-    public void reloadUrl(String url) {
-        super.reloadUrl(getCacheableUrl(url));
+    public void onProgressChanged(android.webkit.WebView view, int newProgress) {
+      if (view.getSettings().getCacheMode() == WebSettings.LOAD_CACHE_ONLY) {
+        return;
+      }
+      if (cacheFileName != null && lastProgress != 100 && newProgress == 100) {
+        lastProgress = newProgress;
+        view.saveWebArchive(cacheFileName);
+      }
     }
-
-    @Override
-    public void loadUrl(String url) {
-        if (TextUtils.isEmpty(url)) {
-            return;
-        }
-        mArchiveClient.lastProgress = 0;
-        super.loadUrl(getCacheableUrl(url));
-    }
-
-    @Override
-    public void loadUrl(String url, Map<String, String> additionalHttpHeaders) {
-        if (TextUtils.isEmpty(url)) {
-            return;
-        }
-        mArchiveClient.lastProgress = 0;
-        super.loadUrl(getCacheableUrl(url), additionalHttpHeaders);
-    }
-
-    @Override
-    public void setWebChromeClient(WebChromeClient client) {
-        if (!(client instanceof ArchiveClient)) {
-            throw new IllegalArgumentException("client should be an instance of " +
-                    ArchiveClient.class.getName());
-        }
-        mArchiveClient = (ArchiveClient) client;
-        super.setWebChromeClient(mArchiveClient);
-    }
-
-    private void init() {
-        enableCache();
-        setLoadSettings();
-        setWebViewClient(new WebViewClient());
-        setWebChromeClient(mArchiveClient);
-    }
-
-    private void enableCache() {
-        WebSettings webSettings = getSettings();
-        webSettings.setAllowFileAccess(false);
-        setCacheModeInternal();
-    }
-
-    private void setCacheModeInternal() {
-        getSettings().setCacheMode(WebSettings.LOAD_CACHE_ELSE_NETWORK);
-    }
-
-    @SuppressLint("SetJavaScriptEnabled")
-    private void setLoadSettings() {
-        WebSettings webSettings = getSettings();
-        webSettings.setLoadWithOverviewMode(true);
-        webSettings.setUseWideViewPort(true);
-        webSettings.setJavaScriptEnabled(true);
-    }
-
-    private String getCacheableUrl(String url) {
-        if (TextUtils.equals(url, BLANK) || TextUtils.equals(url, FILE)) {
-            mArchiveClient.cacheFileName = null;
-            return url;
-        }
-        mArchiveClient.cacheFileName = generateCacheFilename(url);
-        setCacheModeInternal();
-        File cacheFile = new File(mArchiveClient.cacheFileName);
-        if (cacheFile.exists() && !AppUtils.hasConnection(getContext())) {
-            getSettings().setCacheMode(WebSettings.LOAD_CACHE_ONLY);
-            return Uri.fromFile(cacheFile).toString();
-        }
-        return url;
-    }
-
-    private String generateCacheFilename(String url) {
-        String name;
-        try {
-            java.security.MessageDigest digest = java.security.MessageDigest.getInstance("SHA-256");
-            byte[] hash = digest.digest(url.getBytes(java.nio.charset.StandardCharsets.UTF_8));
-            StringBuilder hexString = new StringBuilder();
-            for (byte b : hash) {
-                String hex = Integer.toHexString(0xff & b);
-                if (hex.length() == 1) {
-                    hexString.append('0');
-                }
-                hexString.append(hex);
-            }
-            name = hexString.toString();
-        } catch (java.security.NoSuchAlgorithmException e) {
-            name = String.valueOf(url.hashCode());
-        }
-        return getContext().getApplicationContext().getCacheDir().getAbsolutePath() +
-                File.separator +
-                CACHE_PREFIX +
-                name +
-                CACHE_EXTENSION;
-    }
-
-    public static class ArchiveClient extends WebChromeClient {
-        int lastProgress = 0;
-        String cacheFileName = null;
-
-        @CallSuper
-        @Override
-        public void onProgressChanged(android.webkit.WebView view, int newProgress) {
-            if (view.getSettings().getCacheMode() == WebSettings.LOAD_CACHE_ONLY) {
-                return;
-            }
-            if (cacheFileName != null && lastProgress != 100 && newProgress == 100) {
-                lastProgress = newProgress;
-                view.saveWebArchive(cacheFileName);
-            }
-        }
-
-    }
+  }
 }


### PR DESCRIPTION
🚨 **Severity:** CRITICAL

💡 **Vulnerability:**
The `CacheableWebView` globally enabled `setAllowFileAccess(true)`, which exposed the application to Local File Inclusion (LFI) attacks. Malicious scripts or users exploiting Cross-Site Scripting (XSS) could potentially read internal application data, shared preferences, or other sensitive files present on the device by issuing `file://` requests.

🎯 **Impact:**
Data exfiltration and unauthorized access to secure local files that are readable by the application process.

🔧 **Fix:**
1. Disabled global file access by setting `webSettings.setAllowFileAccess(false)` within `CacheableWebView`.
2. Maintained the ability to load valid offline web archives from the cache by introducing a secure manual fallback in `AdBlockWebViewClient.shouldInterceptRequest()`.
3. The fallback implements strict boundary checks by verifying the absolute canonical path of the file to ensure it resides solely within the application's designated cache directory, actively blocking `..` path traversal attempts.
4. Allowed native processing for safe app assets like `file:///android_asset/` and `file:///android_res/`.

✅ **Verification:**
1. Verified file handling logic blocks malicious traversals by parsing canonical paths.
2. Verified `AdBlockWebViewClient` processes legitimate local cache files (e.g. `.mht` web archives).
3. Ran `./gradlew clean lint testDebugUnitTest --no-daemon` to ensure tests passed successfully without regression.

---
*PR created automatically by Jules for task [4355001341613713790](https://jules.google.com/task/4355001341613713790) started by @sheepdestroyer*

## Summary by Sourcery

Harden WebView file handling to prevent local file inclusion while preserving access to safe cached content.

Bug Fixes:
- Disable global WebView file access in CacheableWebView to mitigate local file inclusion risk.
- Add strict handling of file:// requests in AdBlockWebViewClient that only serves files from the app cache directory and blocks path traversal and other local file access.

Enhancements:
- Allow safe passthrough of Android asset and resource URLs in WebView while intercepting other file:// traffic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Enhanced file URL interception with comprehensive path validation to prevent access to suspicious paths
  * Disabled direct file system access within the web view for improved security

* **Bug Fixes**
  * Improved ad-blocking functionality with optimized detection and result caching for better performance

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sheepdestroyer/materialisheep/pull/220)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->