### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Local File Inclusion in WebViews

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-14 - Fix Local File Inclusion (LFI) via setAllowFileAccess in CacheableWebView
+**Vulnerability:** CacheableWebView sets `setAllowFileAccess(true)` globally while using an interceptor (AdBlockWebViewClient) that could still potentially allow path traversal and other file:// attacks. This is a severe Local File Inclusion (LFI) vulnerability.
+**Learning:** `setAllowFileAccess(false)` natively blocks most dangerous file:// access but preserves necessary internal `file:///android_asset/` access on newer versions. Custom file caching must be intercepted properly using a `WebResourceResponse` while checking the canonical path to prevent path traversal (`..`).
+**Prevention:** Always disable `setAllowFileAccess` on Android WebViews. Explicitly manage any allowed offline/cached file paths using `shouldInterceptRequest` with canonical path verification within the app's cache directory.

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
@@ -16,89 +16,89 @@
 
 package io.github.sheepdestroyer.materialisheep.widget;
 
-import android.annotation.TargetApi;
-import android.os.Build;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
-
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.Map;
-
 import androidx.annotation.Nullable;
 import io.github.sheepdestroyer.materialisheep.AdBlocker;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 @SuppressWarnings("deprecation") // TODO: Uses deprecated WebResourceRequest API
 public class AdBlockWebViewClient extends WebViewClient {
-    private final boolean mAdBlockEnabled;
-    private final Map<String, Boolean> mLoadedUrls = new ConcurrentHashMap<>();
+  private final boolean mAdBlockEnabled;
+  private final Map<String, Boolean> mLoadedUrls = new ConcurrentHashMap<>();
 
-    public AdBlockWebViewClient(boolean adBlockEnabled) {
-        mAdBlockEnabled = adBlockEnabled;
-    }
+  public AdBlockWebViewClient(boolean adBlockEnabled) {
+    mAdBlockEnabled = adBlockEnabled;
+  }
 
-    @Override
-    public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
-        if (url != null && url.toLowerCase(java.util.Locale.ROOT).startsWith("file://")) {
-            try {
-                String decodedPath = android.net.Uri.parse(url).getPath();
-                if (decodedPath != null && !decodedPath.contains("..")) {
-                    java.io.File file = new java.io.File(decodedPath);
-                    String canonicalPath = file.getCanonicalPath();
-                    java.io.File cacheDir = view.getContext().getCacheDir();
-                    if (canonicalPath.startsWith(cacheDir.getCanonicalPath() + java.io.File.separator) && canonicalPath.endsWith(".mht")) {
-                        return new WebResourceResponse("application/x-mimearchive", "UTF-8", new java.io.FileInputStream(file));
-                    }
-                }
-            } catch (java.io.IOException e) {
-                // Ignore
-            }
-            return null;
+  @Override
+  public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
+    if (url != null && url.toLowerCase(java.util.Locale.ROOT).startsWith("file://")) {
+      try {
+        String decodedPath = android.net.Uri.parse(url).getPath();
+        if (decodedPath != null && !decodedPath.contains("..")) {
+          java.io.File file = new java.io.File(decodedPath);
+          String canonicalPath = file.getCanonicalPath();
+          java.io.File cacheDir = view.getContext().getCacheDir();
+          if (canonicalPath.startsWith(cacheDir.getCanonicalPath() + java.io.File.separator)
+              && canonicalPath.endsWith(".mht")) {
+            return new WebResourceResponse(
+                "application/x-mimearchive", "UTF-8", new java.io.FileInputStream(file));
+          }
         }
-        if (!mAdBlockEnabled) {
-            return super.shouldInterceptRequest(view, url);
-        }
-        boolean ad;
-        if (!mLoadedUrls.containsKey(url)) {
-            ad = AdBlocker.isAd(url);
-            mLoadedUrls.put(url, ad);
-        } else {
-            ad = mLoadedUrls.get(url);
-        }
-        return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, url);
+      } catch (java.io.IOException e) {
+        // Ignore
+      }
+      return null;
     }
+    if (!mAdBlockEnabled) {
+      return super.shouldInterceptRequest(view, url);
+    }
+    boolean ad;
+    if (!mLoadedUrls.containsKey(url)) {
+      ad = AdBlocker.isAd(url);
+      mLoadedUrls.put(url, ad);
+    } else {
+      ad = mLoadedUrls.get(url);
+    }
+    return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, url);
+  }
 
-    @Nullable
-    @Override
-    public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
-        String url = request.getUrl().toString();
-        if (url.toLowerCase(java.util.Locale.ROOT).startsWith("file://")) {
-            try {
-                String decodedPath = request.getUrl().getPath();
-                if (decodedPath != null && !decodedPath.contains("..")) {
-                    java.io.File file = new java.io.File(decodedPath);
-                    String canonicalPath = file.getCanonicalPath();
-                    java.io.File cacheDir = view.getContext().getCacheDir();
-                    if (canonicalPath.startsWith(cacheDir.getCanonicalPath() + java.io.File.separator) && canonicalPath.endsWith(".mht")) {
-                        return new WebResourceResponse("application/x-mimearchive", "UTF-8", new java.io.FileInputStream(file));
-                    }
-                }
-            } catch (java.io.IOException e) {
-                // Ignore
-            }
-            return null;
+  @Nullable
+  @Override
+  public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+    String url = request.getUrl().toString();
+    if (url.toLowerCase(java.util.Locale.ROOT).startsWith("file://")) {
+      try {
+        String decodedPath = request.getUrl().getPath();
+        if (decodedPath != null && !decodedPath.contains("..")) {
+          java.io.File file = new java.io.File(decodedPath);
+          String canonicalPath = file.getCanonicalPath();
+          java.io.File cacheDir = view.getContext().getCacheDir();
+          if (canonicalPath.startsWith(cacheDir.getCanonicalPath() + java.io.File.separator)
+              && canonicalPath.endsWith(".mht")) {
+            return new WebResourceResponse(
+                "application/x-mimearchive", "UTF-8", new java.io.FileInputStream(file));
+          }
         }
-        if (!mAdBlockEnabled) {
-            return super.shouldInterceptRequest(view, request);
-        }
-        boolean ad;
-        if (!mLoadedUrls.containsKey(url)) {
-            ad = AdBlocker.isAd(url);
-            mLoadedUrls.put(url, ad);
-        } else {
-            ad = mLoadedUrls.get(url);
-        }
-        return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, request);
+      } catch (java.io.IOException e) {
+        // Ignore
+      }
+      return null;
     }
+    if (!mAdBlockEnabled) {
+      return super.shouldInterceptRequest(view, request);
+    }
+    boolean ad;
+    if (!mLoadedUrls.containsKey(url)) {
+      ad = AdBlocker.isAd(url);
+      mLoadedUrls.put(url, ad);
+    } else {
+      ad = mLoadedUrls.get(url);
+    }
+    return ad ? AdBlocker.createEmptyResource() : super.shouldInterceptRequest(view, request);
+  }
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/AdBlockWebViewClient.java
@@ -23,7 +23,7 @@ import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
-import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.Map;
 
 import androidx.annotation.Nullable;
@@ -32,7 +32,7 @@ import io.github.sheepdestroyer.materialisheep.AdBlocker;
 @SuppressWarnings("deprecation") // TODO: Uses deprecated WebResourceRequest API
 public class AdBlockWebViewClient extends WebViewClient {
     private final boolean mAdBlockEnabled;
-    private final Map<String, Boolean> mLoadedUrls = new HashMap<>();
+    private final Map<String, Boolean> mLoadedUrls = new ConcurrentHashMap<>();
 
     public AdBlockWebViewClient(boolean adBlockEnabled) {
         mAdBlockEnabled = adBlockEnabled;
@@ -40,6 +40,22 @@ public class AdBlockWebViewClient extends WebViewClient {
 
     @Override
     public final WebResourceResponse shouldInterceptRequest(WebView view, String url) {
+        if (url != null && url.toLowerCase(java.util.Locale.ROOT).startsWith("file://")) {
+            try {
+                String decodedPath = android.net.Uri.parse(url).getPath();
+                if (decodedPath != null && !decodedPath.contains("..")) {
+                    java.io.File file = new java.io.File(decodedPath);
+                    String canonicalPath = file.getCanonicalPath();
+                    java.io.File cacheDir = view.getContext().getCacheDir();
+                    if (canonicalPath.startsWith(cacheDir.getCanonicalPath() + java.io.File.separator) && canonicalPath.endsWith(".mht")) {
+                        return new WebResourceResponse("application/x-mimearchive", "UTF-8", new java.io.FileInputStream(file));
+                    }
+                }
+            } catch (java.io.IOException e) {
+                // Ignore
+            }
+            return null;
+        }
         if (!mAdBlockEnabled) {
             return super.shouldInterceptRequest(view, url);
         }
@@ -56,11 +72,27 @@ public class AdBlockWebViewClient extends WebViewClient {
     @Nullable
     @Override
     public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+        String url = request.getUrl().toString();
+        if (url.toLowerCase(java.util.Locale.ROOT).startsWith("file://")) {
+            try {
+                String decodedPath = request.getUrl().getPath();
+                if (decodedPath != null && !decodedPath.contains("..")) {
+                    java.io.File file = new java.io.File(decodedPath);
+                    String canonicalPath = file.getCanonicalPath();
+                    java.io.File cacheDir = view.getContext().getCacheDir();
+                    if (canonicalPath.startsWith(cacheDir.getCanonicalPath() + java.io.File.separator) && canonicalPath.endsWith(".mht")) {
+                        return new WebResourceResponse("application/x-mimearchive", "UTF-8", new java.io.FileInputStream(file));
+                    }
+                }
+            } catch (java.io.IOException e) {
+                // Ignore
+            }
+            return null;
+        }
         if (!mAdBlockEnabled) {
             return super.shouldInterceptRequest(view, request);
         }
         boolean ad;
-        String url = request.getUrl().toString();
         if (!mLoadedUrls.containsKey(url)) {
             ad = AdBlocker.isAd(url);
             mLoadedUrls.put(url, ad);

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/CacheableWebView.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/CacheableWebView.java
@@ -92,7 +92,7 @@ public class CacheableWebView extends WebView {
 
     private void enableCache() {
         WebSettings webSettings = getSettings();
-        webSettings.setAllowFileAccess(true);
+        webSettings.setAllowFileAccess(false);
         setCacheModeInternal();
     }
 

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/CacheableWebView.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/CacheableWebView.java
@@ -19,149 +19,145 @@ package io.github.sheepdestroyer.materialisheep.widget;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.net.Uri;
-
-import androidx.annotation.CallSuper;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
 import android.webkit.WebViewClient;
-
+import androidx.annotation.CallSuper;
+import io.github.sheepdestroyer.materialisheep.AppUtils;
 import java.io.File;
 import java.util.Map;
 
-import io.github.sheepdestroyer.materialisheep.AppUtils;
-
 public class CacheableWebView extends WebView {
-    private static final String CACHE_PREFIX = "webarchive-";
-    private static final String CACHE_EXTENSION = ".mht";
-    private ArchiveClient mArchiveClient = new ArchiveClient();
+  private static final String CACHE_PREFIX = "webarchive-";
+  private static final String CACHE_EXTENSION = ".mht";
+  private ArchiveClient mArchiveClient = new ArchiveClient();
 
-    public CacheableWebView(Context context) {
-        this(context, null);
+  public CacheableWebView(Context context) {
+    this(context, null);
+  }
+
+  public CacheableWebView(Context context, AttributeSet attrs) {
+    this(context, attrs, 0);
+  }
+
+  public CacheableWebView(Context context, AttributeSet attrs, int defStyleAttr) {
+    super(context, attrs, defStyleAttr);
+    init();
+  }
+
+  @Override
+  public void reloadUrl(String url) {
+    super.reloadUrl(getCacheableUrl(url));
+  }
+
+  @Override
+  public void loadUrl(String url) {
+    if (TextUtils.isEmpty(url)) {
+      return;
     }
+    mArchiveClient.lastProgress = 0;
+    super.loadUrl(getCacheableUrl(url));
+  }
 
-    public CacheableWebView(Context context, AttributeSet attrs) {
-        this(context, attrs, 0);
+  @Override
+  public void loadUrl(String url, Map<String, String> additionalHttpHeaders) {
+    if (TextUtils.isEmpty(url)) {
+      return;
     }
+    mArchiveClient.lastProgress = 0;
+    super.loadUrl(getCacheableUrl(url), additionalHttpHeaders);
+  }
 
-    public CacheableWebView(Context context, AttributeSet attrs, int defStyleAttr) {
-        super(context, attrs, defStyleAttr);
-        init();
+  @Override
+  public void setWebChromeClient(WebChromeClient client) {
+    if (!(client instanceof ArchiveClient)) {
+      throw new IllegalArgumentException(
+          "client should be an instance of " + ArchiveClient.class.getName());
     }
+    mArchiveClient = (ArchiveClient) client;
+    super.setWebChromeClient(mArchiveClient);
+  }
 
+  private void init() {
+    enableCache();
+    setLoadSettings();
+    setWebViewClient(new WebViewClient());
+    setWebChromeClient(mArchiveClient);
+  }
+
+  private void enableCache() {
+    WebSettings webSettings = getSettings();
+    webSettings.setAllowFileAccess(false);
+    setCacheModeInternal();
+  }
+
+  private void setCacheModeInternal() {
+    getSettings().setCacheMode(WebSettings.LOAD_CACHE_ELSE_NETWORK);
+  }
+
+  @SuppressLint("SetJavaScriptEnabled")
+  private void setLoadSettings() {
+    WebSettings webSettings = getSettings();
+    webSettings.setLoadWithOverviewMode(true);
+    webSettings.setUseWideViewPort(true);
+    webSettings.setJavaScriptEnabled(true);
+  }
+
+  private String getCacheableUrl(String url) {
+    if (TextUtils.equals(url, BLANK) || TextUtils.equals(url, FILE)) {
+      mArchiveClient.cacheFileName = null;
+      return url;
+    }
+    mArchiveClient.cacheFileName = generateCacheFilename(url);
+    setCacheModeInternal();
+    File cacheFile = new File(mArchiveClient.cacheFileName);
+    if (cacheFile.exists() && !AppUtils.hasConnection(getContext())) {
+      getSettings().setCacheMode(WebSettings.LOAD_CACHE_ONLY);
+      return Uri.fromFile(cacheFile).toString();
+    }
+    return url;
+  }
+
+  private String generateCacheFilename(String url) {
+    String name;
+    try {
+      java.security.MessageDigest digest = java.security.MessageDigest.getInstance("SHA-256");
+      byte[] hash = digest.digest(url.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+      StringBuilder hexString = new StringBuilder();
+      for (byte b : hash) {
+        String hex = Integer.toHexString(0xff & b);
+        if (hex.length() == 1) {
+          hexString.append('0');
+        }
+        hexString.append(hex);
+      }
+      name = hexString.toString();
+    } catch (java.security.NoSuchAlgorithmException e) {
+      name = String.valueOf(url.hashCode());
+    }
+    return getContext().getApplicationContext().getCacheDir().getAbsolutePath()
+        + File.separator
+        + CACHE_PREFIX
+        + name
+        + CACHE_EXTENSION;
+  }
+
+  public static class ArchiveClient extends WebChromeClient {
+    int lastProgress = 0;
+    String cacheFileName = null;
+
+    @CallSuper
     @Override
-    public void reloadUrl(String url) {
-        super.reloadUrl(getCacheableUrl(url));
+    public void onProgressChanged(android.webkit.WebView view, int newProgress) {
+      if (view.getSettings().getCacheMode() == WebSettings.LOAD_CACHE_ONLY) {
+        return;
+      }
+      if (cacheFileName != null && lastProgress != 100 && newProgress == 100) {
+        lastProgress = newProgress;
+        view.saveWebArchive(cacheFileName);
+      }
     }
-
-    @Override
-    public void loadUrl(String url) {
-        if (TextUtils.isEmpty(url)) {
-            return;
-        }
-        mArchiveClient.lastProgress = 0;
-        super.loadUrl(getCacheableUrl(url));
-    }
-
-    @Override
-    public void loadUrl(String url, Map<String, String> additionalHttpHeaders) {
-        if (TextUtils.isEmpty(url)) {
-            return;
-        }
-        mArchiveClient.lastProgress = 0;
-        super.loadUrl(getCacheableUrl(url), additionalHttpHeaders);
-    }
-
-    @Override
-    public void setWebChromeClient(WebChromeClient client) {
-        if (!(client instanceof ArchiveClient)) {
-            throw new IllegalArgumentException("client should be an instance of " +
-                    ArchiveClient.class.getName());
-        }
-        mArchiveClient = (ArchiveClient) client;
-        super.setWebChromeClient(mArchiveClient);
-    }
-
-    private void init() {
-        enableCache();
-        setLoadSettings();
-        setWebViewClient(new WebViewClient());
-        setWebChromeClient(mArchiveClient);
-    }
-
-    private void enableCache() {
-        WebSettings webSettings = getSettings();
-        webSettings.setAllowFileAccess(false);
-        setCacheModeInternal();
-    }
-
-    private void setCacheModeInternal() {
-        getSettings().setCacheMode(WebSettings.LOAD_CACHE_ELSE_NETWORK);
-    }
-
-    @SuppressLint("SetJavaScriptEnabled")
-    private void setLoadSettings() {
-        WebSettings webSettings = getSettings();
-        webSettings.setLoadWithOverviewMode(true);
-        webSettings.setUseWideViewPort(true);
-        webSettings.setJavaScriptEnabled(true);
-    }
-
-    private String getCacheableUrl(String url) {
-        if (TextUtils.equals(url, BLANK) || TextUtils.equals(url, FILE)) {
-            mArchiveClient.cacheFileName = null;
-            return url;
-        }
-        mArchiveClient.cacheFileName = generateCacheFilename(url);
-        setCacheModeInternal();
-        File cacheFile = new File(mArchiveClient.cacheFileName);
-        if (cacheFile.exists() && !AppUtils.hasConnection(getContext())) {
-            getSettings().setCacheMode(WebSettings.LOAD_CACHE_ONLY);
-            return Uri.fromFile(cacheFile).toString();
-        }
-        return url;
-    }
-
-    private String generateCacheFilename(String url) {
-        String name;
-        try {
-            java.security.MessageDigest digest = java.security.MessageDigest.getInstance("SHA-256");
-            byte[] hash = digest.digest(url.getBytes(java.nio.charset.StandardCharsets.UTF_8));
-            StringBuilder hexString = new StringBuilder();
-            for (byte b : hash) {
-                String hex = Integer.toHexString(0xff & b);
-                if (hex.length() == 1) {
-                    hexString.append('0');
-                }
-                hexString.append(hex);
-            }
-            name = hexString.toString();
-        } catch (java.security.NoSuchAlgorithmException e) {
-            name = String.valueOf(url.hashCode());
-        }
-        return getContext().getApplicationContext().getCacheDir().getAbsolutePath() +
-                File.separator +
-                CACHE_PREFIX +
-                name +
-                CACHE_EXTENSION;
-    }
-
-    public static class ArchiveClient extends WebChromeClient {
-        int lastProgress = 0;
-        String cacheFileName = null;
-
-        @CallSuper
-        @Override
-        public void onProgressChanged(android.webkit.WebView view, int newProgress) {
-            if (view.getSettings().getCacheMode() == WebSettings.LOAD_CACHE_ONLY) {
-                return;
-            }
-            if (cacheFileName != null && lastProgress != 100 && newProgress == 100) {
-                lastProgress = newProgress;
-                view.saveWebArchive(cacheFileName);
-            }
-        }
-
-    }
+  }
 }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: CacheableWebView globally allows file access while using an interceptor that fails to block path traversal natively.
🎯 Impact: Severe Local File Inclusion (LFI) vulnerability enabling access to local app files.
🔧 Fix: Set `setAllowFileAccess(false)` natively and safely intercept allowed cache files via canonical path validation in `AdBlockWebViewClient`.
✅ Verification: Run `testDebugUnitTest` and compile tasks.

---
*PR created automatically by Jules for task [10787362344109831894](https://jules.google.com/task/10787362344109831894) started by @sheepdestroyer*

## Summary by Sourcery

Mitigate a critical local file inclusion vulnerability in WebViews by restricting file access and safely handling cached file loading.

Bug Fixes:
- Block arbitrary file:// access in CacheableWebView by disabling general file access in WebSettings.
- Restrict WebView file:// interceptions to canonical, cache-directory .mht files with basic path traversal protections.

Enhancements:
- Use a thread-safe ConcurrentHashMap for tracking previously evaluated URLs in AdBlockWebViewClient.

Documentation:
- Add a Sentinel security note documenting the LFI vulnerability, fix rationale, and prevention guidance.