### PR TITLE
Refactor: Migrate deprecated getExtraLayoutSpace API to calculateExtraLayoutSpace

### DIFF
--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/SnappyLinearLayoutManager.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/SnappyLinearLayoutManager.java
@@ -29,7 +29,6 @@ import io.github.sheepdestroyer.materialisheep.AppUtils;
  * to
  * always snap to start
  */
-@SuppressWarnings("deprecation") // TODO: Uses deprecated getExtraLayoutSpace API
 public class SnappyLinearLayoutManager extends LinearLayoutManager {
 
     private final int mExtraSpace;
@@ -60,7 +59,11 @@ public class SnappyLinearLayoutManager extends LinearLayoutManager {
     }
 
     @Override
-    protected int getExtraLayoutSpace(RecyclerView.State state) {
-        return mExtraSpace == 0 ? super.getExtraLayoutSpace(state) : mExtraSpace;
+    protected void calculateExtraLayoutSpace(RecyclerView.State state, int[] extraLayoutSpace) {
+        super.calculateExtraLayoutSpace(state, extraLayoutSpace);
+        if (mExtraSpace != 0) {
+            extraLayoutSpace[0] = mExtraSpace;
+            extraLayoutSpace[1] = mExtraSpace;
+        }
     }
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/SnappyLinearLayoutManager.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/SnappyLinearLayoutManager.java
@@ -21,49 +21,46 @@ import android.graphics.PointF;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.LinearSmoothScroller;
 import androidx.recyclerview.widget.RecyclerView;
-
 import io.github.sheepdestroyer.materialisheep.AppUtils;
 
 /**
- * Light extension to {@link LinearLayoutManager} that overrides smooth scroller
- * to
- * always snap to start
+ * Light extension to {@link LinearLayoutManager} that overrides smooth scroller to always snap to
+ * start
  */
 public class SnappyLinearLayoutManager extends LinearLayoutManager {
 
-    private final int mExtraSpace;
+  private final int mExtraSpace;
 
-    public SnappyLinearLayoutManager(Context context, boolean preload) {
-        super(context);
-        mExtraSpace = preload ? AppUtils.getDisplayHeight(context) : 0;
-    }
+  public SnappyLinearLayoutManager(Context context, boolean preload) {
+    super(context);
+    mExtraSpace = preload ? AppUtils.getDisplayHeight(context) : 0;
+  }
 
-    @Override
-    public void smoothScrollToPosition(RecyclerView recyclerView,
-            RecyclerView.State state,
-            int position) {
-        RecyclerView.SmoothScroller smoothScroller = new LinearSmoothScroller(recyclerView.getContext()) {
-            @Override
-            public PointF computeScrollVectorForPosition(int targetPosition) {
-                return SnappyLinearLayoutManager.this
-                        .computeScrollVectorForPosition(targetPosition);
-            }
+  @Override
+  public void smoothScrollToPosition(
+      RecyclerView recyclerView, RecyclerView.State state, int position) {
+    RecyclerView.SmoothScroller smoothScroller =
+        new LinearSmoothScroller(recyclerView.getContext()) {
+          @Override
+          public PointF computeScrollVectorForPosition(int targetPosition) {
+            return SnappyLinearLayoutManager.this.computeScrollVectorForPosition(targetPosition);
+          }
 
-            @Override
-            protected int getVerticalSnapPreference() {
-                return SNAP_TO_START; // override base class behavior
-            }
+          @Override
+          protected int getVerticalSnapPreference() {
+            return SNAP_TO_START; // override base class behavior
+          }
         };
-        smoothScroller.setTargetPosition(position);
-        startSmoothScroll(smoothScroller);
-    }
+    smoothScroller.setTargetPosition(position);
+    startSmoothScroll(smoothScroller);
+  }
 
-    @Override
-    protected void calculateExtraLayoutSpace(RecyclerView.State state, int[] extraLayoutSpace) {
-        super.calculateExtraLayoutSpace(state, extraLayoutSpace);
-        if (mExtraSpace != 0) {
-            extraLayoutSpace[0] = mExtraSpace;
-            extraLayoutSpace[1] = mExtraSpace;
-        }
+  @Override
+  protected void calculateExtraLayoutSpace(RecyclerView.State state, int[] extraLayoutSpace) {
+    super.calculateExtraLayoutSpace(state, extraLayoutSpace);
+    if (mExtraSpace != 0) {
+      extraLayoutSpace[0] = mExtraSpace;
+      extraLayoutSpace[1] = mExtraSpace;
     }
+  }
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/SnappyLinearLayoutManager.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/SnappyLinearLayoutManager.java
@@ -21,46 +21,49 @@ import android.graphics.PointF;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.LinearSmoothScroller;
 import androidx.recyclerview.widget.RecyclerView;
+
 import io.github.sheepdestroyer.materialisheep.AppUtils;
 
 /**
- * Light extension to {@link LinearLayoutManager} that overrides smooth scroller to always snap to
- * start
+ * Light extension to {@link LinearLayoutManager} that overrides smooth scroller
+ * to
+ * always snap to start
  */
 public class SnappyLinearLayoutManager extends LinearLayoutManager {
 
-  private final int mExtraSpace;
+    private final int mExtraSpace;
 
-  public SnappyLinearLayoutManager(Context context, boolean preload) {
-    super(context);
-    mExtraSpace = preload ? AppUtils.getDisplayHeight(context) : 0;
-  }
-
-  @Override
-  public void smoothScrollToPosition(
-      RecyclerView recyclerView, RecyclerView.State state, int position) {
-    RecyclerView.SmoothScroller smoothScroller =
-        new LinearSmoothScroller(recyclerView.getContext()) {
-          @Override
-          public PointF computeScrollVectorForPosition(int targetPosition) {
-            return SnappyLinearLayoutManager.this.computeScrollVectorForPosition(targetPosition);
-          }
-
-          @Override
-          protected int getVerticalSnapPreference() {
-            return SNAP_TO_START; // override base class behavior
-          }
-        };
-    smoothScroller.setTargetPosition(position);
-    startSmoothScroll(smoothScroller);
-  }
-
-  @Override
-  protected void calculateExtraLayoutSpace(RecyclerView.State state, int[] extraLayoutSpace) {
-    super.calculateExtraLayoutSpace(state, extraLayoutSpace);
-    if (mExtraSpace != 0) {
-      extraLayoutSpace[0] = mExtraSpace;
-      extraLayoutSpace[1] = mExtraSpace;
+    public SnappyLinearLayoutManager(Context context, boolean preload) {
+        super(context);
+        mExtraSpace = preload ? AppUtils.getDisplayHeight(context) : 0;
     }
-  }
+
+    @Override
+    public void smoothScrollToPosition(RecyclerView recyclerView,
+            RecyclerView.State state,
+            int position) {
+        RecyclerView.SmoothScroller smoothScroller = new LinearSmoothScroller(recyclerView.getContext()) {
+            @Override
+            public PointF computeScrollVectorForPosition(int targetPosition) {
+                return SnappyLinearLayoutManager.this
+                        .computeScrollVectorForPosition(targetPosition);
+            }
+
+            @Override
+            protected int getVerticalSnapPreference() {
+                return SNAP_TO_START; // override base class behavior
+            }
+        };
+        smoothScroller.setTargetPosition(position);
+        startSmoothScroll(smoothScroller);
+    }
+
+    @Override
+    protected void calculateExtraLayoutSpace(RecyclerView.State state, int[] extraLayoutSpace) {
+        super.calculateExtraLayoutSpace(state, extraLayoutSpace);
+        if (mExtraSpace != 0) {
+            extraLayoutSpace[0] = mExtraSpace;
+            extraLayoutSpace[1] = mExtraSpace;
+        }
+    }
 }


### PR DESCRIPTION
**What:**
Migrated the deprecated `getExtraLayoutSpace` API to `calculateExtraLayoutSpace` in `SnappyLinearLayoutManager`. Removed the `@SuppressWarnings("deprecation")` annotation.

**Why:**
To comply with the updated `LinearLayoutManager` API requirements and remove technical debt/deprecation warnings during the build process.

**Impact:**
No functional changes. The layout manager will continue to function exactly as before, correctly applying `mExtraSpace` to both ends of the layout when scrolling, ensuring snappy loading behaviour.

**Measurement:**
Verified through unit tests and successful project assembly that there are no regressions or compilation errors.

---
*PR created automatically by Jules for task [2023417237268094605](https://jules.google.com/task/2023417237268094605) started by @sheepdestroyer*

## Summary by Sourcery

Enhancements:
- Remove the deprecation suppression annotation now that the layout manager uses the updated extra layout space API.