### PR TITLE
🧹 [code health improvement] Update post-submit navigation to user profile

### DIFF
--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/SubmitActivity.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/SubmitActivity.java
@@ -19,6 +19,13 @@ package io.github.sheepdestroyer.materialisheep;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+
+import androidx.activity.OnBackPressedCallback;
+import androidx.annotation.NonNull;
+import com.google.android.material.textfield.TextInputLayout;
+import androidx.core.content.ContextCompat;
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.widget.Toolbar;
 import android.text.TextUtils;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -26,305 +33,302 @@ import android.webkit.WebChromeClient;
 import android.webkit.WebView;
 import android.widget.TextView;
 import android.widget.Toast;
-import androidx.activity.OnBackPressedCallback;
-import androidx.annotation.NonNull;
-import androidx.appcompat.app.ActionBar;
-import androidx.appcompat.widget.Toolbar;
-import androidx.core.content.ContextCompat;
-import com.google.android.material.textfield.TextInputLayout;
-import io.github.sheepdestroyer.materialisheep.accounts.UserServices;
-import io.github.sheepdestroyer.materialisheep.annotation.Synthetic;
+
 import java.lang.ref.WeakReference;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import javax.inject.Inject;
 
-/** An activity that allows users to submit a new story. */
+import io.github.sheepdestroyer.materialisheep.accounts.UserServices;
+import io.github.sheepdestroyer.materialisheep.annotation.Synthetic;
+import io.github.sheepdestroyer.materialisheep.Preferences;
+import io.github.sheepdestroyer.materialisheep.UserActivity;
+
+/**
+ * An activity that allows users to submit a new story.
+ */
 public class SubmitActivity extends ThemedActivity {
-  private static final String HN_GUIDELINES_URL =
-      "https://news.ycombinator.com/newsguidelines.html";
-  private static final String STATE_SUBJECT = "state:subject";
-  private static final String STATE_TEXT = "state:text";
-  // matching title url without any trailing text
-  private static final String REGEX_FUZZY_URL = "(.*)((http|https)://[^\\s]*)$";
-  @Inject UserServices mUserServices;
-  @Inject AlertDialogBuilder mAlertDialogBuilder;
-  @Synthetic TextView mTitleEditText;
-  private TextView mContentEditText;
-  private TextInputLayout mTitleLayout;
-  private TextInputLayout mContentLayout;
-  private boolean mSending;
-  private final OnBackPressedCallback mOnBackPressedCallback =
-      new OnBackPressedCallback(true) {
+    private static final String HN_GUIDELINES_URL = "https://news.ycombinator.com/newsguidelines.html";
+    private static final String STATE_SUBJECT = "state:subject";
+    private static final String STATE_TEXT = "state:text";
+    // matching title url without any trailing text
+    private static final String REGEX_FUZZY_URL = "(.*)((http|https)://[^\\s]*)$";
+    @Inject
+    UserServices mUserServices;
+    @Inject
+    AlertDialogBuilder mAlertDialogBuilder;
+    @Synthetic
+    TextView mTitleEditText;
+    private TextView mContentEditText;
+    private TextInputLayout mTitleLayout;
+    private TextInputLayout mContentLayout;
+    private boolean mSending;
+    private final OnBackPressedCallback mOnBackPressedCallback = new OnBackPressedCallback(true) {
         @Override
         public void handleOnBackPressed() {
-          setEnabled(false);
-          mAlertDialogBuilder
-              .init(SubmitActivity.this)
-              .setMessage(mSending ? R.string.confirm_no_waiting : R.string.confirm_no_submit)
-              .setNegativeButton(android.R.string.cancel, (dialog, which) -> setEnabled(true))
-              .setPositiveButton(
-                  android.R.string.ok,
-                  (dialog, which) -> {
-                    getOnBackPressedDispatcher().onBackPressed();
-                  })
-              .setOnCancelListener(dialog -> setEnabled(true))
-              .show();
+            setEnabled(false);
+            mAlertDialogBuilder
+                    .init(SubmitActivity.this)
+                    .setMessage(mSending ? R.string.confirm_no_waiting : R.string.confirm_no_submit)
+                    .setNegativeButton(android.R.string.cancel, (dialog, which) -> setEnabled(true))
+                    .setPositiveButton(android.R.string.ok,
+                            (dialog, which) -> {
+                                getOnBackPressedDispatcher().onBackPressed();
+                            })
+                    .setOnCancelListener(dialog -> setEnabled(true))
+                    .show();
         }
-      };
+    };
 
-  /**
-   * Called when the activity is first created.
-   *
-   * @param savedInstanceState If the activity is being re-initialized after previously being shut
-   *     down then this Bundle contains the data it most recently supplied in {@link
-   *     #onSaveInstanceState(Bundle)}. Otherwise it is null.
-   */
-  @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    ((MaterialisticApplication) getApplication()).applicationComponent.inject(this);
-    AppUtils.setStatusBarColor(getWindow(), ContextCompat.getColor(this, R.color.blackT12));
-    setContentView(R.layout.activity_submit);
-    setSupportActionBar((Toolbar) findViewById(R.id.toolbar));
-    // noinspection ConstantConditions
-    getSupportActionBar()
-        .setDisplayOptions(
-            ActionBar.DISPLAY_SHOW_HOME
-                | ActionBar.DISPLAY_SHOW_TITLE
-                | ActionBar.DISPLAY_HOME_AS_UP);
-    mTitleLayout = (TextInputLayout) findViewById(R.id.textinput_title);
-    mContentLayout = (TextInputLayout) findViewById(R.id.textinput_content);
-    mTitleEditText = (TextView) findViewById(R.id.edittext_title);
-    mContentEditText = (TextView) findViewById(R.id.edittext_content);
-    String text, subject;
-    if (savedInstanceState == null) {
-      subject = getIntent().getStringExtra(Intent.EXTRA_SUBJECT);
-      text = getIntent().getStringExtra(Intent.EXTRA_TEXT);
-    } else {
-      subject = savedInstanceState.getString(STATE_SUBJECT);
-      text = savedInstanceState.getString(STATE_TEXT);
+    /**
+     * Called when the activity is first created.
+     *
+     * @param savedInstanceState If the activity is being re-initialized after
+     *                           previously being shut down then this Bundle
+     *                           contains the data it most
+     *                           recently supplied in
+     *                           {@link #onSaveInstanceState(Bundle)}.
+     *                           Otherwise it is null.
+     */
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        ((MaterialisticApplication) getApplication()).applicationComponent.inject(this);
+        AppUtils.setStatusBarColor(getWindow(), ContextCompat.getColor(this, R.color.blackT12));
+        setContentView(R.layout.activity_submit);
+        setSupportActionBar((Toolbar) findViewById(R.id.toolbar));
+        // noinspection ConstantConditions
+        getSupportActionBar().setDisplayOptions(ActionBar.DISPLAY_SHOW_HOME |
+                ActionBar.DISPLAY_SHOW_TITLE | ActionBar.DISPLAY_HOME_AS_UP);
+        mTitleLayout = (TextInputLayout) findViewById(R.id.textinput_title);
+        mContentLayout = (TextInputLayout) findViewById(R.id.textinput_content);
+        mTitleEditText = (TextView) findViewById(R.id.edittext_title);
+        mContentEditText = (TextView) findViewById(R.id.edittext_content);
+        String text, subject;
+        if (savedInstanceState == null) {
+            subject = getIntent().getStringExtra(Intent.EXTRA_SUBJECT);
+            text = getIntent().getStringExtra(Intent.EXTRA_TEXT);
+        } else {
+            subject = savedInstanceState.getString(STATE_SUBJECT);
+            text = savedInstanceState.getString(STATE_TEXT);
+        }
+        mTitleEditText.setText(subject);
+        mContentEditText.setText(text);
+        if (TextUtils.isEmpty(subject)) {
+            if (isUrl(text)) {
+                WebView webView = new WebView(this);
+                webView.setWebChromeClient(new WebChromeClient() {
+                    @Override
+                    public void onReceivedTitle(WebView view, String title) {
+                        if (mTitleEditText.length() == 0) {
+                            mTitleEditText.setText(title);
+                        }
+                    }
+                });
+                webView.loadUrl(text);
+            } else if (!TextUtils.isEmpty(text)) {
+                extractUrl(text);
+            }
+        }
+        getOnBackPressedDispatcher().addCallback(this, mOnBackPressedCallback);
     }
-    mTitleEditText.setText(subject);
-    mContentEditText.setText(text);
-    if (TextUtils.isEmpty(subject)) {
-      if (isUrl(text)) {
-        WebView webView = new WebView(this);
-        webView.setWebChromeClient(
-            new WebChromeClient() {
-              @Override
-              public void onReceivedTitle(WebView view, String title) {
-                if (mTitleEditText.length() == 0) {
-                  mTitleEditText.setText(title);
-                }
-              }
-            });
-        webView.loadUrl(text);
-      } else if (!TextUtils.isEmpty(text)) {
-        extractUrl(text);
-      }
+
+    /**
+     * Initialize the contents of the Activity's standard options menu.
+     *
+     * @param menu The options menu in which you place your items.
+     * @return You must return true for the menu to be displayed;
+     *         if you return false it will not be shown.
+     */
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        getMenuInflater().inflate(R.menu.menu_submit, menu);
+        return super.onCreateOptionsMenu(menu);
     }
-    getOnBackPressedDispatcher().addCallback(this, mOnBackPressedCallback);
-  }
 
-  /**
-   * Initialize the contents of the Activity's standard options menu.
-   *
-   * @param menu The options menu in which you place your items.
-   * @return You must return true for the menu to be displayed; if you return false it will not be
-   *     shown.
-   */
-  @Override
-  public boolean onCreateOptionsMenu(Menu menu) {
-    getMenuInflater().inflate(R.menu.menu_submit, menu);
-    return super.onCreateOptionsMenu(menu);
-  }
-
-  /**
-   * Prepare the Screen's standard options menu to be displayed.
-   *
-   * @param menu The options menu as last shown or first initialized by onCreateOptionsMenu().
-   * @return You must return true for the menu to be displayed; if you return false it will not be
-   *     shown.
-   */
-  @Override
-  public boolean onPrepareOptionsMenu(Menu menu) {
-    menu.findItem(R.id.menu_send).setEnabled(!mSending);
-    return super.onPrepareOptionsMenu(menu);
-  }
-
-  /**
-   * This hook is called whenever an item in your options menu is selected.
-   *
-   * @param item The menu item that was selected.
-   * @return boolean Return false to allow normal menu processing to proceed, true to consume it
-   *     here.
-   */
-  @Override
-  public boolean onOptionsItemSelected(MenuItem item) {
-    if (item.getItemId() == android.R.id.home) {
-      getOnBackPressedDispatcher().onBackPressed();
-      return true;
+    /**
+     * Prepare the Screen's standard options menu to be displayed.
+     *
+     * @param menu The options menu as last shown or first initialized by
+     *             onCreateOptionsMenu().
+     * @return You must return true for the menu to be displayed;
+     *         if you return false it will not be shown.
+     */
+    @Override
+    public boolean onPrepareOptionsMenu(Menu menu) {
+        menu.findItem(R.id.menu_send).setEnabled(!mSending);
+        return super.onPrepareOptionsMenu(menu);
     }
-    if (item.getItemId() == R.id.menu_send) {
-      if (!validate()) {
-        return true;
-      }
-      final boolean isUrl = isUrl(mContentEditText.getText().toString());
-      mAlertDialogBuilder
-          .init(SubmitActivity.this)
-          .setMessage(isUrl ? R.string.confirm_submit_url : R.string.confirm_submit_question)
-          .setPositiveButton(android.R.string.ok, (dialog, which) -> submit(isUrl))
-          .setNegativeButton(android.R.string.cancel, null)
-          .create()
-          .show();
-      return true;
-    }
-    if (item.getItemId() == R.id.menu_guidelines) {
-      WebView webView = new WebView(this);
-      webView.loadUrl(HN_GUIDELINES_URL);
-      mAlertDialogBuilder
-          .init(this)
-          .setView(webView)
-          .setPositiveButton(android.R.string.ok, null)
-          .create()
-          .show();
-    }
-    return super.onOptionsItemSelected(item);
-  }
 
-  /**
-   * Called to retrieve per-instance state from an activity before being killed so that the state
-   * can be restored in {@link #onCreate(Bundle)} or {@link #onRestoreInstanceState(Bundle)}.
-   *
-   * @param outState Bundle in which to place your saved state.
-   */
-  @Override
-  protected void onSaveInstanceState(Bundle outState) {
-    super.onSaveInstanceState(outState);
-    outState.putString(STATE_SUBJECT, mTitleEditText.getText().toString());
-    outState.putString(STATE_TEXT, mContentEditText.getText().toString());
-  }
-
-  private boolean validate() {
-    mTitleLayout.setErrorEnabled(false);
-    mContentLayout.setErrorEnabled(false);
-    if (mTitleEditText.length() == 0) {
-      mTitleLayout.setError(getString(R.string.title_required));
+    /**
+     * This hook is called whenever an item in your options menu is selected.
+     *
+     * @param item The menu item that was selected.
+     * @return boolean Return false to allow normal menu processing to
+     *         proceed, true to consume it here.
+     */
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == android.R.id.home) {
+            getOnBackPressedDispatcher().onBackPressed();
+            return true;
+        }
+        if (item.getItemId() == R.id.menu_send) {
+            if (!validate()) {
+                return true;
+            }
+            final boolean isUrl = isUrl(mContentEditText.getText().toString());
+            mAlertDialogBuilder
+                    .init(SubmitActivity.this)
+                    .setMessage(isUrl ? R.string.confirm_submit_url : R.string.confirm_submit_question)
+                    .setPositiveButton(android.R.string.ok, (dialog, which) -> submit(isUrl))
+                    .setNegativeButton(android.R.string.cancel, null)
+                    .create()
+                    .show();
+            return true;
+        }
+        if (item.getItemId() == R.id.menu_guidelines) {
+            WebView webView = new WebView(this);
+            webView.loadUrl(HN_GUIDELINES_URL);
+            mAlertDialogBuilder
+                    .init(this)
+                    .setView(webView)
+                    .setPositiveButton(android.R.string.ok, null)
+                    .create()
+                    .show();
+        }
+        return super.onOptionsItemSelected(item);
     }
-    if (mContentEditText.length() == 0) {
-      mContentLayout.setError(getString(R.string.url_text_required));
+
+    /**
+     * Called to retrieve per-instance state from an activity before being killed
+     * so that the state can be restored in {@link #onCreate(Bundle)} or
+     * {@link #onRestoreInstanceState(Bundle)}.
+     *
+     * @param outState Bundle in which to place your saved state.
+     */
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putString(STATE_SUBJECT, mTitleEditText.getText().toString());
+        outState.putString(STATE_TEXT, mContentEditText.getText().toString());
     }
-    return mTitleEditText.length() > 0 && mContentEditText.length() > 0;
-  }
 
-  private void submit(boolean isUrl) {
-    toggleControls(true);
-    Toast.makeText(this, R.string.sending, Toast.LENGTH_SHORT).show();
-    mUserServices.submit(
-        this,
-        mTitleEditText.getText().toString(),
-        mContentEditText.getText().toString(),
-        isUrl,
-        new SubmitCallback(this));
-  }
-
-  @Synthetic
-  void onSubmitted(Boolean successful) {
-    if (successful == null) {
-      toggleControls(false);
-      Toast.makeText(this, R.string.submit_failed, Toast.LENGTH_SHORT).show();
-    } else if (successful) {
-      Toast.makeText(this, R.string.submit_successful, Toast.LENGTH_SHORT).show();
-      if (!isDestroyed()) {
-        Intent intent = new Intent(this, UserActivity.class);
-        intent.putExtra(UserActivity.EXTRA_USERNAME, Preferences.getUsername(this));
-        intent.setFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
-        startActivity(intent);
-        finish();
-      }
-    } else if (!isDestroyed()) {
-      AppUtils.showLogin(this, mAlertDialogBuilder);
+    private boolean validate() {
+        mTitleLayout.setErrorEnabled(false);
+        mContentLayout.setErrorEnabled(false);
+        if (mTitleEditText.length() == 0) {
+            mTitleLayout.setError(getString(R.string.title_required));
+        }
+        if (mContentEditText.length() == 0) {
+            mContentLayout.setError(getString(R.string.url_text_required));
+        }
+        return mTitleEditText.length() > 0 && mContentEditText.length() > 0;
     }
-  }
 
-  @Synthetic
-  void onError(int message, Uri data) {
-    Toast.makeText(this, message, Toast.LENGTH_SHORT).show();
-    if (data != null) {
-      startActivity(new Intent(Intent.ACTION_VIEW).setData(data));
+    private void submit(boolean isUrl) {
+        toggleControls(true);
+        Toast.makeText(this, R.string.sending, Toast.LENGTH_SHORT).show();
+        mUserServices.submit(this, mTitleEditText.getText().toString(),
+                mContentEditText.getText().toString(), isUrl, new SubmitCallback(this));
     }
-  }
-
-  private boolean isUrl(String text) {
-    try {
-      new URL(text); // try parsing
-    } catch (MalformedURLException e) {
-      return false;
-    }
-    return true;
-  }
-
-  private void extractUrl(String text) {
-    Matcher matcher = Pattern.compile(REGEX_FUZZY_URL).matcher(text);
-    if (matcher.find()
-        && matcher.groupCount() >= 3) { // group 1: title, group 2: url, group 3: scheme
-      mTitleEditText.setText(trimTitle(matcher.group(1).trim()));
-      mContentEditText.setText(matcher.group(2));
-    }
-  }
-
-  @NonNull
-  private String trimTitle(String title) {
-    int lastIndex = title.length() - 1;
-    while (lastIndex >= 0) {
-      char c = title.charAt(lastIndex);
-      if (c == ' ' || c == ':' || c == '-') {
-        lastIndex--;
-      } else {
-        break;
-      }
-    }
-    return lastIndex >= 0 ? title.substring(0, lastIndex + 1) : "";
-  }
-
-  private void toggleControls(boolean sending) {
-    if (isDestroyed()) {
-      return;
-    }
-    mSending = sending;
-    mTitleEditText.setEnabled(!sending);
-    mContentEditText.setEnabled(!sending);
-    supportInvalidateOptionsMenu();
-  }
-
-  static class SubmitCallback extends UserServices.Callback {
-    private final WeakReference<SubmitActivity> mSubmitActivity;
 
     @Synthetic
-    SubmitCallback(SubmitActivity submitActivity) {
-      mSubmitActivity = new WeakReference<>(submitActivity);
-    }
-
-    @Override
-    public void onDone(boolean successful) {
-      if (mSubmitActivity.get() != null && !mSubmitActivity.get().isDestroyed()) {
-        mSubmitActivity.get().onSubmitted(successful);
-      }
-    }
-
-    @Override
-    public void onError(Throwable throwable) {
-      if (mSubmitActivity.get() != null && !mSubmitActivity.get().isDestroyed()) {
-        if (throwable instanceof UserServices.Exception) {
-          UserServices.Exception e = (UserServices.Exception) throwable;
-          mSubmitActivity.get().onError(e.message, e.data);
-        } else {
-          mSubmitActivity.get().onSubmitted(null);
+    void onSubmitted(Boolean successful) {
+        if (successful == null) {
+            toggleControls(false);
+            Toast.makeText(this, R.string.submit_failed, Toast.LENGTH_SHORT).show();
+        } else if (successful) {
+            Toast.makeText(this, R.string.submit_successful, Toast.LENGTH_SHORT).show();
+            if (!isDestroyed()) {
+                Intent intent = new Intent(this, UserActivity.class);
+                intent.putExtra(UserActivity.EXTRA_USERNAME, Preferences.getUsername(this));
+                intent.setFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+                startActivity(intent);
+                finish();
+            }
+        } else if (!isDestroyed()) {
+            AppUtils.showLogin(this, mAlertDialogBuilder);
         }
-      }
     }
-  }
+
+    @Synthetic
+    void onError(int message, Uri data) {
+        Toast.makeText(this, message, Toast.LENGTH_SHORT).show();
+        if (data != null) {
+            startActivity(new Intent(Intent.ACTION_VIEW).setData(data));
+        }
+    }
+
+    private boolean isUrl(String text) {
+        try {
+            new URL(text); // try parsing
+        } catch (MalformedURLException e) {
+            return false;
+        }
+        return true;
+    }
+
+    private void extractUrl(String text) {
+        Matcher matcher = Pattern.compile(REGEX_FUZZY_URL).matcher(text);
+        if (matcher.find() && matcher.groupCount() >= 3) { // group 1: title, group 2: url, group 3: scheme
+            mTitleEditText.setText(trimTitle(matcher.group(1).trim()));
+            mContentEditText.setText(matcher.group(2));
+        }
+    }
+
+    @NonNull
+    private String trimTitle(String title) {
+        int lastIndex = title.length() - 1;
+        while (lastIndex >= 0) {
+            char c = title.charAt(lastIndex);
+            if (c == ' ' || c == ':' || c == '-') {
+                lastIndex--;
+            } else {
+                break;
+            }
+        }
+        return lastIndex >= 0 ? title.substring(0, lastIndex + 1) : "";
+    }
+
+    private void toggleControls(boolean sending) {
+        if (isDestroyed()) {
+            return;
+        }
+        mSending = sending;
+        mTitleEditText.setEnabled(!sending);
+        mContentEditText.setEnabled(!sending);
+        supportInvalidateOptionsMenu();
+    }
+
+    static class SubmitCallback extends UserServices.Callback {
+        private final WeakReference<SubmitActivity> mSubmitActivity;
+
+        @Synthetic
+        SubmitCallback(SubmitActivity submitActivity) {
+            mSubmitActivity = new WeakReference<>(submitActivity);
+        }
+
+        @Override
+        public void onDone(boolean successful) {
+            if (mSubmitActivity.get() != null && !mSubmitActivity.get().isDestroyed()) {
+                mSubmitActivity.get().onSubmitted(successful);
+            }
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            if (mSubmitActivity.get() != null && !mSubmitActivity.get().isDestroyed()) {
+                if (throwable instanceof UserServices.Exception) {
+                    UserServices.Exception e = (UserServices.Exception) throwable;
+                    mSubmitActivity.get().onError(e.message, e.data);
+                } else {
+                    mSubmitActivity.get().onSubmitted(null);
+                }
+            }
+        }
+    }
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/SubmitActivity.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/SubmitActivity.java
@@ -44,6 +44,8 @@ import javax.inject.Inject;
 
 import io.github.sheepdestroyer.materialisheep.accounts.UserServices;
 import io.github.sheepdestroyer.materialisheep.annotation.Synthetic;
+import io.github.sheepdestroyer.materialisheep.Preferences;
+import io.github.sheepdestroyer.materialisheep.UserActivity;
 
 /**
  * An activity that allows users to submit a new story.
@@ -242,10 +244,10 @@ public class SubmitActivity extends ThemedActivity {
         } else if (successful) {
             Toast.makeText(this, R.string.submit_successful, Toast.LENGTH_SHORT).show();
             if (!isDestroyed()) {
-                Intent intent = new Intent(this, NewActivity.class);
-                intent.putExtra(NewActivity.EXTRA_REFRESH, true);
+                Intent intent = new Intent(this, UserActivity.class);
+                intent.putExtra(UserActivity.EXTRA_USERNAME, Preferences.getUsername(this));
                 intent.setFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
-                startActivity(intent); // TODO should go to profile instead?
+                startActivity(intent);
                 finish();
             }
         } else if (!isDestroyed()) {

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/SubmitActivity.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/SubmitActivity.java
@@ -19,13 +19,6 @@ package io.github.sheepdestroyer.materialisheep;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
-
-import androidx.activity.OnBackPressedCallback;
-import androidx.annotation.NonNull;
-import com.google.android.material.textfield.TextInputLayout;
-import androidx.core.content.ContextCompat;
-import androidx.appcompat.app.ActionBar;
-import androidx.appcompat.widget.Toolbar;
 import android.text.TextUtils;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -33,302 +26,305 @@ import android.webkit.WebChromeClient;
 import android.webkit.WebView;
 import android.widget.TextView;
 import android.widget.Toast;
-
+import androidx.activity.OnBackPressedCallback;
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.widget.Toolbar;
+import androidx.core.content.ContextCompat;
+import com.google.android.material.textfield.TextInputLayout;
+import io.github.sheepdestroyer.materialisheep.accounts.UserServices;
+import io.github.sheepdestroyer.materialisheep.annotation.Synthetic;
 import java.lang.ref.WeakReference;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import javax.inject.Inject;
 
-import io.github.sheepdestroyer.materialisheep.accounts.UserServices;
-import io.github.sheepdestroyer.materialisheep.annotation.Synthetic;
-import io.github.sheepdestroyer.materialisheep.Preferences;
-import io.github.sheepdestroyer.materialisheep.UserActivity;
-
-/**
- * An activity that allows users to submit a new story.
- */
+/** An activity that allows users to submit a new story. */
 public class SubmitActivity extends ThemedActivity {
-    private static final String HN_GUIDELINES_URL = "https://news.ycombinator.com/newsguidelines.html";
-    private static final String STATE_SUBJECT = "state:subject";
-    private static final String STATE_TEXT = "state:text";
-    // matching title url without any trailing text
-    private static final String REGEX_FUZZY_URL = "(.*)((http|https)://[^\\s]*)$";
-    @Inject
-    UserServices mUserServices;
-    @Inject
-    AlertDialogBuilder mAlertDialogBuilder;
-    @Synthetic
-    TextView mTitleEditText;
-    private TextView mContentEditText;
-    private TextInputLayout mTitleLayout;
-    private TextInputLayout mContentLayout;
-    private boolean mSending;
-    private final OnBackPressedCallback mOnBackPressedCallback = new OnBackPressedCallback(true) {
+  private static final String HN_GUIDELINES_URL =
+      "https://news.ycombinator.com/newsguidelines.html";
+  private static final String STATE_SUBJECT = "state:subject";
+  private static final String STATE_TEXT = "state:text";
+  // matching title url without any trailing text
+  private static final String REGEX_FUZZY_URL = "(.*)((http|https)://[^\\s]*)$";
+  @Inject UserServices mUserServices;
+  @Inject AlertDialogBuilder mAlertDialogBuilder;
+  @Synthetic TextView mTitleEditText;
+  private TextView mContentEditText;
+  private TextInputLayout mTitleLayout;
+  private TextInputLayout mContentLayout;
+  private boolean mSending;
+  private final OnBackPressedCallback mOnBackPressedCallback =
+      new OnBackPressedCallback(true) {
         @Override
         public void handleOnBackPressed() {
-            setEnabled(false);
-            mAlertDialogBuilder
-                    .init(SubmitActivity.this)
-                    .setMessage(mSending ? R.string.confirm_no_waiting : R.string.confirm_no_submit)
-                    .setNegativeButton(android.R.string.cancel, (dialog, which) -> setEnabled(true))
-                    .setPositiveButton(android.R.string.ok,
-                            (dialog, which) -> {
-                                getOnBackPressedDispatcher().onBackPressed();
-                            })
-                    .setOnCancelListener(dialog -> setEnabled(true))
-                    .show();
+          setEnabled(false);
+          mAlertDialogBuilder
+              .init(SubmitActivity.this)
+              .setMessage(mSending ? R.string.confirm_no_waiting : R.string.confirm_no_submit)
+              .setNegativeButton(android.R.string.cancel, (dialog, which) -> setEnabled(true))
+              .setPositiveButton(
+                  android.R.string.ok,
+                  (dialog, which) -> {
+                    getOnBackPressedDispatcher().onBackPressed();
+                  })
+              .setOnCancelListener(dialog -> setEnabled(true))
+              .show();
         }
-    };
+      };
 
-    /**
-     * Called when the activity is first created.
-     *
-     * @param savedInstanceState If the activity is being re-initialized after
-     *                           previously being shut down then this Bundle
-     *                           contains the data it most
-     *                           recently supplied in
-     *                           {@link #onSaveInstanceState(Bundle)}.
-     *                           Otherwise it is null.
-     */
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        ((MaterialisticApplication) getApplication()).applicationComponent.inject(this);
-        AppUtils.setStatusBarColor(getWindow(), ContextCompat.getColor(this, R.color.blackT12));
-        setContentView(R.layout.activity_submit);
-        setSupportActionBar((Toolbar) findViewById(R.id.toolbar));
-        // noinspection ConstantConditions
-        getSupportActionBar().setDisplayOptions(ActionBar.DISPLAY_SHOW_HOME |
-                ActionBar.DISPLAY_SHOW_TITLE | ActionBar.DISPLAY_HOME_AS_UP);
-        mTitleLayout = (TextInputLayout) findViewById(R.id.textinput_title);
-        mContentLayout = (TextInputLayout) findViewById(R.id.textinput_content);
-        mTitleEditText = (TextView) findViewById(R.id.edittext_title);
-        mContentEditText = (TextView) findViewById(R.id.edittext_content);
-        String text, subject;
-        if (savedInstanceState == null) {
-            subject = getIntent().getStringExtra(Intent.EXTRA_SUBJECT);
-            text = getIntent().getStringExtra(Intent.EXTRA_TEXT);
-        } else {
-            subject = savedInstanceState.getString(STATE_SUBJECT);
-            text = savedInstanceState.getString(STATE_TEXT);
-        }
-        mTitleEditText.setText(subject);
-        mContentEditText.setText(text);
-        if (TextUtils.isEmpty(subject)) {
-            if (isUrl(text)) {
-                WebView webView = new WebView(this);
-                webView.setWebChromeClient(new WebChromeClient() {
-                    @Override
-                    public void onReceivedTitle(WebView view, String title) {
-                        if (mTitleEditText.length() == 0) {
-                            mTitleEditText.setText(title);
-                        }
-                    }
-                });
-                webView.loadUrl(text);
-            } else if (!TextUtils.isEmpty(text)) {
-                extractUrl(text);
-            }
-        }
-        getOnBackPressedDispatcher().addCallback(this, mOnBackPressedCallback);
+  /**
+   * Called when the activity is first created.
+   *
+   * @param savedInstanceState If the activity is being re-initialized after previously being shut
+   *     down then this Bundle contains the data it most recently supplied in {@link
+   *     #onSaveInstanceState(Bundle)}. Otherwise it is null.
+   */
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    ((MaterialisticApplication) getApplication()).applicationComponent.inject(this);
+    AppUtils.setStatusBarColor(getWindow(), ContextCompat.getColor(this, R.color.blackT12));
+    setContentView(R.layout.activity_submit);
+    setSupportActionBar((Toolbar) findViewById(R.id.toolbar));
+    // noinspection ConstantConditions
+    getSupportActionBar()
+        .setDisplayOptions(
+            ActionBar.DISPLAY_SHOW_HOME
+                | ActionBar.DISPLAY_SHOW_TITLE
+                | ActionBar.DISPLAY_HOME_AS_UP);
+    mTitleLayout = (TextInputLayout) findViewById(R.id.textinput_title);
+    mContentLayout = (TextInputLayout) findViewById(R.id.textinput_content);
+    mTitleEditText = (TextView) findViewById(R.id.edittext_title);
+    mContentEditText = (TextView) findViewById(R.id.edittext_content);
+    String text, subject;
+    if (savedInstanceState == null) {
+      subject = getIntent().getStringExtra(Intent.EXTRA_SUBJECT);
+      text = getIntent().getStringExtra(Intent.EXTRA_TEXT);
+    } else {
+      subject = savedInstanceState.getString(STATE_SUBJECT);
+      text = savedInstanceState.getString(STATE_TEXT);
     }
-
-    /**
-     * Initialize the contents of the Activity's standard options menu.
-     *
-     * @param menu The options menu in which you place your items.
-     * @return You must return true for the menu to be displayed;
-     *         if you return false it will not be shown.
-     */
-    @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
-        getMenuInflater().inflate(R.menu.menu_submit, menu);
-        return super.onCreateOptionsMenu(menu);
-    }
-
-    /**
-     * Prepare the Screen's standard options menu to be displayed.
-     *
-     * @param menu The options menu as last shown or first initialized by
-     *             onCreateOptionsMenu().
-     * @return You must return true for the menu to be displayed;
-     *         if you return false it will not be shown.
-     */
-    @Override
-    public boolean onPrepareOptionsMenu(Menu menu) {
-        menu.findItem(R.id.menu_send).setEnabled(!mSending);
-        return super.onPrepareOptionsMenu(menu);
-    }
-
-    /**
-     * This hook is called whenever an item in your options menu is selected.
-     *
-     * @param item The menu item that was selected.
-     * @return boolean Return false to allow normal menu processing to
-     *         proceed, true to consume it here.
-     */
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        if (item.getItemId() == android.R.id.home) {
-            getOnBackPressedDispatcher().onBackPressed();
-            return true;
-        }
-        if (item.getItemId() == R.id.menu_send) {
-            if (!validate()) {
-                return true;
-            }
-            final boolean isUrl = isUrl(mContentEditText.getText().toString());
-            mAlertDialogBuilder
-                    .init(SubmitActivity.this)
-                    .setMessage(isUrl ? R.string.confirm_submit_url : R.string.confirm_submit_question)
-                    .setPositiveButton(android.R.string.ok, (dialog, which) -> submit(isUrl))
-                    .setNegativeButton(android.R.string.cancel, null)
-                    .create()
-                    .show();
-            return true;
-        }
-        if (item.getItemId() == R.id.menu_guidelines) {
-            WebView webView = new WebView(this);
-            webView.loadUrl(HN_GUIDELINES_URL);
-            mAlertDialogBuilder
-                    .init(this)
-                    .setView(webView)
-                    .setPositiveButton(android.R.string.ok, null)
-                    .create()
-                    .show();
-        }
-        return super.onOptionsItemSelected(item);
-    }
-
-    /**
-     * Called to retrieve per-instance state from an activity before being killed
-     * so that the state can be restored in {@link #onCreate(Bundle)} or
-     * {@link #onRestoreInstanceState(Bundle)}.
-     *
-     * @param outState Bundle in which to place your saved state.
-     */
-    @Override
-    protected void onSaveInstanceState(Bundle outState) {
-        super.onSaveInstanceState(outState);
-        outState.putString(STATE_SUBJECT, mTitleEditText.getText().toString());
-        outState.putString(STATE_TEXT, mContentEditText.getText().toString());
-    }
-
-    private boolean validate() {
-        mTitleLayout.setErrorEnabled(false);
-        mContentLayout.setErrorEnabled(false);
-        if (mTitleEditText.length() == 0) {
-            mTitleLayout.setError(getString(R.string.title_required));
-        }
-        if (mContentEditText.length() == 0) {
-            mContentLayout.setError(getString(R.string.url_text_required));
-        }
-        return mTitleEditText.length() > 0 && mContentEditText.length() > 0;
-    }
-
-    private void submit(boolean isUrl) {
-        toggleControls(true);
-        Toast.makeText(this, R.string.sending, Toast.LENGTH_SHORT).show();
-        mUserServices.submit(this, mTitleEditText.getText().toString(),
-                mContentEditText.getText().toString(), isUrl, new SubmitCallback(this));
-    }
-
-    @Synthetic
-    void onSubmitted(Boolean successful) {
-        if (successful == null) {
-            toggleControls(false);
-            Toast.makeText(this, R.string.submit_failed, Toast.LENGTH_SHORT).show();
-        } else if (successful) {
-            Toast.makeText(this, R.string.submit_successful, Toast.LENGTH_SHORT).show();
-            if (!isDestroyed()) {
-                Intent intent = new Intent(this, UserActivity.class);
-                intent.putExtra(UserActivity.EXTRA_USERNAME, Preferences.getUsername(this));
-                intent.setFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
-                startActivity(intent);
-                finish();
-            }
-        } else if (!isDestroyed()) {
-            AppUtils.showLogin(this, mAlertDialogBuilder);
-        }
-    }
-
-    @Synthetic
-    void onError(int message, Uri data) {
-        Toast.makeText(this, message, Toast.LENGTH_SHORT).show();
-        if (data != null) {
-            startActivity(new Intent(Intent.ACTION_VIEW).setData(data));
-        }
-    }
-
-    private boolean isUrl(String text) {
-        try {
-            new URL(text); // try parsing
-        } catch (MalformedURLException e) {
-            return false;
-        }
-        return true;
-    }
-
-    private void extractUrl(String text) {
-        Matcher matcher = Pattern.compile(REGEX_FUZZY_URL).matcher(text);
-        if (matcher.find() && matcher.groupCount() >= 3) { // group 1: title, group 2: url, group 3: scheme
-            mTitleEditText.setText(trimTitle(matcher.group(1).trim()));
-            mContentEditText.setText(matcher.group(2));
-        }
-    }
-
-    @NonNull
-    private String trimTitle(String title) {
-        int lastIndex = title.length() - 1;
-        while (lastIndex >= 0) {
-            char c = title.charAt(lastIndex);
-            if (c == ' ' || c == ':' || c == '-') {
-                lastIndex--;
-            } else {
-                break;
-            }
-        }
-        return lastIndex >= 0 ? title.substring(0, lastIndex + 1) : "";
-    }
-
-    private void toggleControls(boolean sending) {
-        if (isDestroyed()) {
-            return;
-        }
-        mSending = sending;
-        mTitleEditText.setEnabled(!sending);
-        mContentEditText.setEnabled(!sending);
-        supportInvalidateOptionsMenu();
-    }
-
-    static class SubmitCallback extends UserServices.Callback {
-        private final WeakReference<SubmitActivity> mSubmitActivity;
-
-        @Synthetic
-        SubmitCallback(SubmitActivity submitActivity) {
-            mSubmitActivity = new WeakReference<>(submitActivity);
-        }
-
-        @Override
-        public void onDone(boolean successful) {
-            if (mSubmitActivity.get() != null && !mSubmitActivity.get().isDestroyed()) {
-                mSubmitActivity.get().onSubmitted(successful);
-            }
-        }
-
-        @Override
-        public void onError(Throwable throwable) {
-            if (mSubmitActivity.get() != null && !mSubmitActivity.get().isDestroyed()) {
-                if (throwable instanceof UserServices.Exception) {
-                    UserServices.Exception e = (UserServices.Exception) throwable;
-                    mSubmitActivity.get().onError(e.message, e.data);
-                } else {
-                    mSubmitActivity.get().onSubmitted(null);
+    mTitleEditText.setText(subject);
+    mContentEditText.setText(text);
+    if (TextUtils.isEmpty(subject)) {
+      if (isUrl(text)) {
+        WebView webView = new WebView(this);
+        webView.setWebChromeClient(
+            new WebChromeClient() {
+              @Override
+              public void onReceivedTitle(WebView view, String title) {
+                if (mTitleEditText.length() == 0) {
+                  mTitleEditText.setText(title);
                 }
-            }
-        }
+              }
+            });
+        webView.loadUrl(text);
+      } else if (!TextUtils.isEmpty(text)) {
+        extractUrl(text);
+      }
     }
+    getOnBackPressedDispatcher().addCallback(this, mOnBackPressedCallback);
+  }
+
+  /**
+   * Initialize the contents of the Activity's standard options menu.
+   *
+   * @param menu The options menu in which you place your items.
+   * @return You must return true for the menu to be displayed; if you return false it will not be
+   *     shown.
+   */
+  @Override
+  public boolean onCreateOptionsMenu(Menu menu) {
+    getMenuInflater().inflate(R.menu.menu_submit, menu);
+    return super.onCreateOptionsMenu(menu);
+  }
+
+  /**
+   * Prepare the Screen's standard options menu to be displayed.
+   *
+   * @param menu The options menu as last shown or first initialized by onCreateOptionsMenu().
+   * @return You must return true for the menu to be displayed; if you return false it will not be
+   *     shown.
+   */
+  @Override
+  public boolean onPrepareOptionsMenu(Menu menu) {
+    menu.findItem(R.id.menu_send).setEnabled(!mSending);
+    return super.onPrepareOptionsMenu(menu);
+  }
+
+  /**
+   * This hook is called whenever an item in your options menu is selected.
+   *
+   * @param item The menu item that was selected.
+   * @return boolean Return false to allow normal menu processing to proceed, true to consume it
+   *     here.
+   */
+  @Override
+  public boolean onOptionsItemSelected(MenuItem item) {
+    if (item.getItemId() == android.R.id.home) {
+      getOnBackPressedDispatcher().onBackPressed();
+      return true;
+    }
+    if (item.getItemId() == R.id.menu_send) {
+      if (!validate()) {
+        return true;
+      }
+      final boolean isUrl = isUrl(mContentEditText.getText().toString());
+      mAlertDialogBuilder
+          .init(SubmitActivity.this)
+          .setMessage(isUrl ? R.string.confirm_submit_url : R.string.confirm_submit_question)
+          .setPositiveButton(android.R.string.ok, (dialog, which) -> submit(isUrl))
+          .setNegativeButton(android.R.string.cancel, null)
+          .create()
+          .show();
+      return true;
+    }
+    if (item.getItemId() == R.id.menu_guidelines) {
+      WebView webView = new WebView(this);
+      webView.loadUrl(HN_GUIDELINES_URL);
+      mAlertDialogBuilder
+          .init(this)
+          .setView(webView)
+          .setPositiveButton(android.R.string.ok, null)
+          .create()
+          .show();
+    }
+    return super.onOptionsItemSelected(item);
+  }
+
+  /**
+   * Called to retrieve per-instance state from an activity before being killed so that the state
+   * can be restored in {@link #onCreate(Bundle)} or {@link #onRestoreInstanceState(Bundle)}.
+   *
+   * @param outState Bundle in which to place your saved state.
+   */
+  @Override
+  protected void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    outState.putString(STATE_SUBJECT, mTitleEditText.getText().toString());
+    outState.putString(STATE_TEXT, mContentEditText.getText().toString());
+  }
+
+  private boolean validate() {
+    mTitleLayout.setErrorEnabled(false);
+    mContentLayout.setErrorEnabled(false);
+    if (mTitleEditText.length() == 0) {
+      mTitleLayout.setError(getString(R.string.title_required));
+    }
+    if (mContentEditText.length() == 0) {
+      mContentLayout.setError(getString(R.string.url_text_required));
+    }
+    return mTitleEditText.length() > 0 && mContentEditText.length() > 0;
+  }
+
+  private void submit(boolean isUrl) {
+    toggleControls(true);
+    Toast.makeText(this, R.string.sending, Toast.LENGTH_SHORT).show();
+    mUserServices.submit(
+        this,
+        mTitleEditText.getText().toString(),
+        mContentEditText.getText().toString(),
+        isUrl,
+        new SubmitCallback(this));
+  }
+
+  @Synthetic
+  void onSubmitted(Boolean successful) {
+    if (successful == null) {
+      toggleControls(false);
+      Toast.makeText(this, R.string.submit_failed, Toast.LENGTH_SHORT).show();
+    } else if (successful) {
+      Toast.makeText(this, R.string.submit_successful, Toast.LENGTH_SHORT).show();
+      if (!isDestroyed()) {
+        Intent intent = new Intent(this, UserActivity.class);
+        intent.putExtra(UserActivity.EXTRA_USERNAME, Preferences.getUsername(this));
+        intent.setFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+        startActivity(intent);
+        finish();
+      }
+    } else if (!isDestroyed()) {
+      AppUtils.showLogin(this, mAlertDialogBuilder);
+    }
+  }
+
+  @Synthetic
+  void onError(int message, Uri data) {
+    Toast.makeText(this, message, Toast.LENGTH_SHORT).show();
+    if (data != null) {
+      startActivity(new Intent(Intent.ACTION_VIEW).setData(data));
+    }
+  }
+
+  private boolean isUrl(String text) {
+    try {
+      new URL(text); // try parsing
+    } catch (MalformedURLException e) {
+      return false;
+    }
+    return true;
+  }
+
+  private void extractUrl(String text) {
+    Matcher matcher = Pattern.compile(REGEX_FUZZY_URL).matcher(text);
+    if (matcher.find()
+        && matcher.groupCount() >= 3) { // group 1: title, group 2: url, group 3: scheme
+      mTitleEditText.setText(trimTitle(matcher.group(1).trim()));
+      mContentEditText.setText(matcher.group(2));
+    }
+  }
+
+  @NonNull
+  private String trimTitle(String title) {
+    int lastIndex = title.length() - 1;
+    while (lastIndex >= 0) {
+      char c = title.charAt(lastIndex);
+      if (c == ' ' || c == ':' || c == '-') {
+        lastIndex--;
+      } else {
+        break;
+      }
+    }
+    return lastIndex >= 0 ? title.substring(0, lastIndex + 1) : "";
+  }
+
+  private void toggleControls(boolean sending) {
+    if (isDestroyed()) {
+      return;
+    }
+    mSending = sending;
+    mTitleEditText.setEnabled(!sending);
+    mContentEditText.setEnabled(!sending);
+    supportInvalidateOptionsMenu();
+  }
+
+  static class SubmitCallback extends UserServices.Callback {
+    private final WeakReference<SubmitActivity> mSubmitActivity;
+
+    @Synthetic
+    SubmitCallback(SubmitActivity submitActivity) {
+      mSubmitActivity = new WeakReference<>(submitActivity);
+    }
+
+    @Override
+    public void onDone(boolean successful) {
+      if (mSubmitActivity.get() != null && !mSubmitActivity.get().isDestroyed()) {
+        mSubmitActivity.get().onSubmitted(successful);
+      }
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+      if (mSubmitActivity.get() != null && !mSubmitActivity.get().isDestroyed()) {
+        if (throwable instanceof UserServices.Exception) {
+          UserServices.Exception e = (UserServices.Exception) throwable;
+          mSubmitActivity.get().onError(e.message, e.data);
+        } else {
+          mSubmitActivity.get().onSubmitted(null);
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
🎯 **What:** 
Updated post-submit navigation in `SubmitActivity` to navigate to the user's profile (`UserActivity`) instead of the `NewActivity` after a successful submission. Also removed the "TODO should go to profile instead?" comment.

💡 **Why:** 
This addresses a "Questionable post-submit navigation" code health issue. By navigating to the user's profile, the app aligns with the intended and more logical UX flow, satisfying the longstanding TODO comment and improving the maintainability of the codebase by removing an outdated code path.

✅ **Verification:** 
- Used `git diff --staged` to manually review the intent creation and extras.
- Ran the test suite via `./gradlew testDebugUnitTest --no-daemon` to ensure no tests were broken.
- Requested and received positive code review indicating the fix was complete and correct.

✨ **Result:** 
The application correctly directs the user to their profile view upon a successful submission, providing a more coherent user experience.

---
*PR created automatically by Jules for task [7321373625599686346](https://jules.google.com/task/7321373625599686346) started by @sheepdestroyer*

## Summary by Sourcery

Update post-submit navigation to direct users to their profile screen after a successful submission.

New Features:
- Navigate to the user's profile (UserActivity) after a successful submission instead of opening the new content screen.

Enhancements:
- Clean up outdated TODO and align navigation flow with the intended user experience after submission.