### PR TITLE
Fix: Update deprecated Parcelable API usage in ThreadPreviewActivity

### DIFF
--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/ThreadPreviewActivity.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/ThreadPreviewActivity.java
@@ -16,160 +16,146 @@
 
 package io.github.sheepdestroyer.materialisheep;
 
+import static io.github.sheepdestroyer.materialisheep.DataModule.HN;
+
 import android.os.Bundle;
-import androidx.appcompat.app.ActionBar;
-import androidx.recyclerview.widget.RecyclerView;
-import androidx.appcompat.widget.Toolbar;
 import android.view.KeyEvent;
 import android.view.MenuItem;
 import android.view.Window;
-
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.widget.Toolbar;
 import androidx.core.content.IntentCompat;
-
-import javax.inject.Inject;
-import javax.inject.Named;
-
-import static io.github.sheepdestroyer.materialisheep.DataModule.HN;
+import androidx.recyclerview.widget.RecyclerView;
 import io.github.sheepdestroyer.materialisheep.data.Item;
 import io.github.sheepdestroyer.materialisheep.data.ItemManager;
 import io.github.sheepdestroyer.materialisheep.widget.CommentItemDecoration;
 import io.github.sheepdestroyer.materialisheep.widget.SnappyLinearLayoutManager;
 import io.github.sheepdestroyer.materialisheep.widget.ThreadPreviewRecyclerViewAdapter;
+import javax.inject.Inject;
+import javax.inject.Named;
 
-/**
- * An activity that displays a preview of a comment thread.
- */
+/** An activity that displays a preview of a comment thread. */
 public class ThreadPreviewActivity extends ThemedActivity {
-    public static final String EXTRA_ITEM = ThreadPreviewActivity.class.getName() + ".EXTRA_ITEM";
+  public static final String EXTRA_ITEM = ThreadPreviewActivity.class.getName() + ".EXTRA_ITEM";
 
-    @Inject
-    @Named(HN)
-    ItemManager mItemManager;
-    @Inject
-    KeyDelegate mKeyDelegate;
+  @Inject
+  @Named(HN)
+  ItemManager mItemManager;
 
-    /**
-     * Called when the activity is first created.
-     *
-     * @param savedInstanceState If the activity is being re-initialized after
-     *                           previously being shut down then this Bundle
-     *                           contains the data it most
-     *                           recently supplied in
-     *                           {@link #onSaveInstanceState(Bundle)}.
-     *                           Otherwise it is null.
-     */
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        ((MaterialisticApplication) getApplication()).applicationComponent.inject(this);
-        Item item = IntentCompat.getParcelableExtra(getIntent(), EXTRA_ITEM, Item.class);
-        if (item == null) {
-            finish();
-            return;
-        }
-        supportRequestWindowFeature(Window.FEATURE_NO_TITLE);
-        setContentView(R.layout.activity_thread_preview);
-        setSupportActionBar((Toolbar) findViewById(R.id.toolbar));
-        // noinspection ConstantConditions
-        getSupportActionBar().setDisplayOptions(ActionBar.DISPLAY_SHOW_HOME |
-                ActionBar.DISPLAY_SHOW_TITLE | ActionBar.DISPLAY_HOME_AS_UP);
-        RecyclerView recyclerView = (RecyclerView) findViewById(R.id.recycler_view);
-        recyclerView.setLayoutManager(new SnappyLinearLayoutManager(this, false));
-        recyclerView.addItemDecoration(new CommentItemDecoration(this));
-        recyclerView.setAdapter(new ThreadPreviewRecyclerViewAdapter(mItemManager, item));
-        mKeyDelegate.setScrollable(
-                new KeyDelegate.RecyclerViewHelper(recyclerView,
-                        KeyDelegate.RecyclerViewHelper.SCROLL_ITEM),
-                null);
+  @Inject KeyDelegate mKeyDelegate;
+
+  /**
+   * Called when the activity is first created.
+   *
+   * @param savedInstanceState If the activity is being re-initialized after previously being shut
+   *     down then this Bundle contains the data it most recently supplied in {@link
+   *     #onSaveInstanceState(Bundle)}. Otherwise it is null.
+   */
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    ((MaterialisticApplication) getApplication()).applicationComponent.inject(this);
+    Item item = IntentCompat.getParcelableExtra(getIntent(), EXTRA_ITEM, Item.class);
+    if (item == null) {
+      finish();
+      return;
     }
+    supportRequestWindowFeature(Window.FEATURE_NO_TITLE);
+    setContentView(R.layout.activity_thread_preview);
+    setSupportActionBar((Toolbar) findViewById(R.id.toolbar));
+    // noinspection ConstantConditions
+    getSupportActionBar()
+        .setDisplayOptions(
+            ActionBar.DISPLAY_SHOW_HOME
+                | ActionBar.DISPLAY_SHOW_TITLE
+                | ActionBar.DISPLAY_HOME_AS_UP);
+    RecyclerView recyclerView = (RecyclerView) findViewById(R.id.recycler_view);
+    recyclerView.setLayoutManager(new SnappyLinearLayoutManager(this, false));
+    recyclerView.addItemDecoration(new CommentItemDecoration(this));
+    recyclerView.setAdapter(new ThreadPreviewRecyclerViewAdapter(mItemManager, item));
+    mKeyDelegate.setScrollable(
+        new KeyDelegate.RecyclerViewHelper(
+            recyclerView, KeyDelegate.RecyclerViewHelper.SCROLL_ITEM),
+        null);
+  }
 
-    /**
-     * Called when the activity is becoming visible to the user.
-     */
-    @Override
-    protected void onStart() {
-        super.onStart();
-        mKeyDelegate.attach(this);
-    }
+  /** Called when the activity is becoming visible to the user. */
+  @Override
+  protected void onStart() {
+    super.onStart();
+    mKeyDelegate.attach(this);
+  }
 
-    /**
-     * This hook is called whenever an item in your options menu is selected.
-     *
-     * @param item The menu item that was selected.
-     * @return boolean Return false to allow normal menu processing to
-     *         proceed, true to consume it here.
-     */
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        if (item.getItemId() == android.R.id.home) {
-            finish();
-            return true;
-        }
-        return super.onOptionsItemSelected(item);
+  /**
+   * This hook is called whenever an item in your options menu is selected.
+   *
+   * @param item The menu item that was selected.
+   * @return boolean Return false to allow normal menu processing to proceed, true to consume it
+   *     here.
+   */
+  @Override
+  public boolean onOptionsItemSelected(MenuItem item) {
+    if (item.getItemId() == android.R.id.home) {
+      finish();
+      return true;
     }
+    return super.onOptionsItemSelected(item);
+  }
 
-    /**
-     * Called when the activity is no longer visible to the user.
-     */
-    @Override
-    protected void onStop() {
-        super.onStop();
-        mKeyDelegate.detach(this);
-    }
+  /** Called when the activity is no longer visible to the user. */
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mKeyDelegate.detach(this);
+  }
 
-    /**
-     * Called when a key was pressed down and not handled by any of the views
-     * inside of the activity.
-     *
-     * @param keyCode The value in {@link KeyEvent#getKeyCode()}.
-     * @param event   Description of the key event.
-     * @return If you handled the event, return true. If you want to allow the
-     *         event to be handled by the next receiver, return false.
-     */
-    @Override
-    public boolean onKeyDown(int keyCode, KeyEvent event) {
-        return mKeyDelegate.onKeyDown(keyCode, event) ||
-                super.onKeyDown(keyCode, event);
-    }
+  /**
+   * Called when a key was pressed down and not handled by any of the views inside of the activity.
+   *
+   * @param keyCode The value in {@link KeyEvent#getKeyCode()}.
+   * @param event Description of the key event.
+   * @return If you handled the event, return true. If you want to allow the event to be handled by
+   *     the next receiver, return false.
+   */
+  @Override
+  public boolean onKeyDown(int keyCode, KeyEvent event) {
+    return mKeyDelegate.onKeyDown(keyCode, event) || super.onKeyDown(keyCode, event);
+  }
 
-    /**
-     * Called when a key was released and not handled by any of the views
-     * inside of the activity.
-     *
-     * @param keyCode The value in {@link KeyEvent#getKeyCode()}.
-     * @param event   Description of the key event.
-     * @return If you handled the event, return true. If you want to allow the
-     *         event to be handled by the next receiver, return false.
-     */
-    @Override
-    public boolean onKeyUp(int keyCode, KeyEvent event) {
-        return mKeyDelegate.onKeyUp(keyCode, event) ||
-                super.onKeyUp(keyCode, event);
-    }
+  /**
+   * Called when a key was released and not handled by any of the views inside of the activity.
+   *
+   * @param keyCode The value in {@link KeyEvent#getKeyCode()}.
+   * @param event Description of the key event.
+   * @return If you handled the event, return true. If you want to allow the event to be handled by
+   *     the next receiver, return false.
+   */
+  @Override
+  public boolean onKeyUp(int keyCode, KeyEvent event) {
+    return mKeyDelegate.onKeyUp(keyCode, event) || super.onKeyUp(keyCode, event);
+  }
 
-    /**
-     * Called when a long press has occurred and not handled by any of the views
-     * inside of the activity.
-     *
-     * @param keyCode The value in {@link KeyEvent#getKeyCode()}.
-     * @param event   Description of the key event.
-     * @return If you handled the event, return true. If you want to allow the
-     *         event to be handled by the next receiver, return false.
-     */
-    @Override
-    public boolean onKeyLongPress(int keyCode, KeyEvent event) {
-        return mKeyDelegate.onKeyLongPress(keyCode, event) ||
-                super.onKeyLongPress(keyCode, event);
-    }
+  /**
+   * Called when a long press has occurred and not handled by any of the views inside of the
+   * activity.
+   *
+   * @param keyCode The value in {@link KeyEvent#getKeyCode()}.
+   * @param event Description of the key event.
+   * @return If you handled the event, return true. If you want to allow the event to be handled by
+   *     the next receiver, return false.
+   */
+  @Override
+  public boolean onKeyLongPress(int keyCode, KeyEvent event) {
+    return mKeyDelegate.onKeyLongPress(keyCode, event) || super.onKeyLongPress(keyCode, event);
+  }
 
-    /**
-     * Checks if the activity should be displayed as a dialog.
-     *
-     * @return True if the activity should be displayed as a dialog, false
-     *         otherwise.
-     */
-    @Override
-    protected boolean isDialogTheme() {
-        return true;
-    }
+  /**
+   * Checks if the activity should be displayed as a dialog.
+   *
+   * @return True if the activity should be displayed as a dialog, false otherwise.
+   */
+  @Override
+  protected boolean isDialogTheme() {
+    return true;
+  }
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/ThreadPreviewActivity.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/ThreadPreviewActivity.java
@@ -16,146 +16,160 @@
 
 package io.github.sheepdestroyer.materialisheep;
 
-import static io.github.sheepdestroyer.materialisheep.DataModule.HN;
-
 import android.os.Bundle;
+import androidx.appcompat.app.ActionBar;
+import androidx.recyclerview.widget.RecyclerView;
+import androidx.appcompat.widget.Toolbar;
 import android.view.KeyEvent;
 import android.view.MenuItem;
 import android.view.Window;
-import androidx.appcompat.app.ActionBar;
-import androidx.appcompat.widget.Toolbar;
+
 import androidx.core.content.IntentCompat;
-import androidx.recyclerview.widget.RecyclerView;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import static io.github.sheepdestroyer.materialisheep.DataModule.HN;
 import io.github.sheepdestroyer.materialisheep.data.Item;
 import io.github.sheepdestroyer.materialisheep.data.ItemManager;
 import io.github.sheepdestroyer.materialisheep.widget.CommentItemDecoration;
 import io.github.sheepdestroyer.materialisheep.widget.SnappyLinearLayoutManager;
 import io.github.sheepdestroyer.materialisheep.widget.ThreadPreviewRecyclerViewAdapter;
-import javax.inject.Inject;
-import javax.inject.Named;
 
-/** An activity that displays a preview of a comment thread. */
+/**
+ * An activity that displays a preview of a comment thread.
+ */
 public class ThreadPreviewActivity extends ThemedActivity {
-  public static final String EXTRA_ITEM = ThreadPreviewActivity.class.getName() + ".EXTRA_ITEM";
+    public static final String EXTRA_ITEM = ThreadPreviewActivity.class.getName() + ".EXTRA_ITEM";
 
-  @Inject
-  @Named(HN)
-  ItemManager mItemManager;
+    @Inject
+    @Named(HN)
+    ItemManager mItemManager;
+    @Inject
+    KeyDelegate mKeyDelegate;
 
-  @Inject KeyDelegate mKeyDelegate;
-
-  /**
-   * Called when the activity is first created.
-   *
-   * @param savedInstanceState If the activity is being re-initialized after previously being shut
-   *     down then this Bundle contains the data it most recently supplied in {@link
-   *     #onSaveInstanceState(Bundle)}. Otherwise it is null.
-   */
-  @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    ((MaterialisticApplication) getApplication()).applicationComponent.inject(this);
-    Item item = IntentCompat.getParcelableExtra(getIntent(), EXTRA_ITEM, Item.class);
-    if (item == null) {
-      finish();
-      return;
+    /**
+     * Called when the activity is first created.
+     *
+     * @param savedInstanceState If the activity is being re-initialized after
+     *                           previously being shut down then this Bundle
+     *                           contains the data it most
+     *                           recently supplied in
+     *                           {@link #onSaveInstanceState(Bundle)}.
+     *                           Otherwise it is null.
+     */
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        ((MaterialisticApplication) getApplication()).applicationComponent.inject(this);
+        Item item = IntentCompat.getParcelableExtra(getIntent(), EXTRA_ITEM, Item.class);
+        if (item == null) {
+            finish();
+            return;
+        }
+        supportRequestWindowFeature(Window.FEATURE_NO_TITLE);
+        setContentView(R.layout.activity_thread_preview);
+        setSupportActionBar((Toolbar) findViewById(R.id.toolbar));
+        // noinspection ConstantConditions
+        getSupportActionBar().setDisplayOptions(ActionBar.DISPLAY_SHOW_HOME |
+                ActionBar.DISPLAY_SHOW_TITLE | ActionBar.DISPLAY_HOME_AS_UP);
+        RecyclerView recyclerView = (RecyclerView) findViewById(R.id.recycler_view);
+        recyclerView.setLayoutManager(new SnappyLinearLayoutManager(this, false));
+        recyclerView.addItemDecoration(new CommentItemDecoration(this));
+        recyclerView.setAdapter(new ThreadPreviewRecyclerViewAdapter(mItemManager, item));
+        mKeyDelegate.setScrollable(
+                new KeyDelegate.RecyclerViewHelper(recyclerView,
+                        KeyDelegate.RecyclerViewHelper.SCROLL_ITEM),
+                null);
     }
-    supportRequestWindowFeature(Window.FEATURE_NO_TITLE);
-    setContentView(R.layout.activity_thread_preview);
-    setSupportActionBar((Toolbar) findViewById(R.id.toolbar));
-    // noinspection ConstantConditions
-    getSupportActionBar()
-        .setDisplayOptions(
-            ActionBar.DISPLAY_SHOW_HOME
-                | ActionBar.DISPLAY_SHOW_TITLE
-                | ActionBar.DISPLAY_HOME_AS_UP);
-    RecyclerView recyclerView = (RecyclerView) findViewById(R.id.recycler_view);
-    recyclerView.setLayoutManager(new SnappyLinearLayoutManager(this, false));
-    recyclerView.addItemDecoration(new CommentItemDecoration(this));
-    recyclerView.setAdapter(new ThreadPreviewRecyclerViewAdapter(mItemManager, item));
-    mKeyDelegate.setScrollable(
-        new KeyDelegate.RecyclerViewHelper(
-            recyclerView, KeyDelegate.RecyclerViewHelper.SCROLL_ITEM),
-        null);
-  }
 
-  /** Called when the activity is becoming visible to the user. */
-  @Override
-  protected void onStart() {
-    super.onStart();
-    mKeyDelegate.attach(this);
-  }
-
-  /**
-   * This hook is called whenever an item in your options menu is selected.
-   *
-   * @param item The menu item that was selected.
-   * @return boolean Return false to allow normal menu processing to proceed, true to consume it
-   *     here.
-   */
-  @Override
-  public boolean onOptionsItemSelected(MenuItem item) {
-    if (item.getItemId() == android.R.id.home) {
-      finish();
-      return true;
+    /**
+     * Called when the activity is becoming visible to the user.
+     */
+    @Override
+    protected void onStart() {
+        super.onStart();
+        mKeyDelegate.attach(this);
     }
-    return super.onOptionsItemSelected(item);
-  }
 
-  /** Called when the activity is no longer visible to the user. */
-  @Override
-  protected void onStop() {
-    super.onStop();
-    mKeyDelegate.detach(this);
-  }
+    /**
+     * This hook is called whenever an item in your options menu is selected.
+     *
+     * @param item The menu item that was selected.
+     * @return boolean Return false to allow normal menu processing to
+     *         proceed, true to consume it here.
+     */
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == android.R.id.home) {
+            finish();
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
 
-  /**
-   * Called when a key was pressed down and not handled by any of the views inside of the activity.
-   *
-   * @param keyCode The value in {@link KeyEvent#getKeyCode()}.
-   * @param event Description of the key event.
-   * @return If you handled the event, return true. If you want to allow the event to be handled by
-   *     the next receiver, return false.
-   */
-  @Override
-  public boolean onKeyDown(int keyCode, KeyEvent event) {
-    return mKeyDelegate.onKeyDown(keyCode, event) || super.onKeyDown(keyCode, event);
-  }
+    /**
+     * Called when the activity is no longer visible to the user.
+     */
+    @Override
+    protected void onStop() {
+        super.onStop();
+        mKeyDelegate.detach(this);
+    }
 
-  /**
-   * Called when a key was released and not handled by any of the views inside of the activity.
-   *
-   * @param keyCode The value in {@link KeyEvent#getKeyCode()}.
-   * @param event Description of the key event.
-   * @return If you handled the event, return true. If you want to allow the event to be handled by
-   *     the next receiver, return false.
-   */
-  @Override
-  public boolean onKeyUp(int keyCode, KeyEvent event) {
-    return mKeyDelegate.onKeyUp(keyCode, event) || super.onKeyUp(keyCode, event);
-  }
+    /**
+     * Called when a key was pressed down and not handled by any of the views
+     * inside of the activity.
+     *
+     * @param keyCode The value in {@link KeyEvent#getKeyCode()}.
+     * @param event   Description of the key event.
+     * @return If you handled the event, return true. If you want to allow the
+     *         event to be handled by the next receiver, return false.
+     */
+    @Override
+    public boolean onKeyDown(int keyCode, KeyEvent event) {
+        return mKeyDelegate.onKeyDown(keyCode, event) ||
+                super.onKeyDown(keyCode, event);
+    }
 
-  /**
-   * Called when a long press has occurred and not handled by any of the views inside of the
-   * activity.
-   *
-   * @param keyCode The value in {@link KeyEvent#getKeyCode()}.
-   * @param event Description of the key event.
-   * @return If you handled the event, return true. If you want to allow the event to be handled by
-   *     the next receiver, return false.
-   */
-  @Override
-  public boolean onKeyLongPress(int keyCode, KeyEvent event) {
-    return mKeyDelegate.onKeyLongPress(keyCode, event) || super.onKeyLongPress(keyCode, event);
-  }
+    /**
+     * Called when a key was released and not handled by any of the views
+     * inside of the activity.
+     *
+     * @param keyCode The value in {@link KeyEvent#getKeyCode()}.
+     * @param event   Description of the key event.
+     * @return If you handled the event, return true. If you want to allow the
+     *         event to be handled by the next receiver, return false.
+     */
+    @Override
+    public boolean onKeyUp(int keyCode, KeyEvent event) {
+        return mKeyDelegate.onKeyUp(keyCode, event) ||
+                super.onKeyUp(keyCode, event);
+    }
 
-  /**
-   * Checks if the activity should be displayed as a dialog.
-   *
-   * @return True if the activity should be displayed as a dialog, false otherwise.
-   */
-  @Override
-  protected boolean isDialogTheme() {
-    return true;
-  }
+    /**
+     * Called when a long press has occurred and not handled by any of the views
+     * inside of the activity.
+     *
+     * @param keyCode The value in {@link KeyEvent#getKeyCode()}.
+     * @param event   Description of the key event.
+     * @return If you handled the event, return true. If you want to allow the
+     *         event to be handled by the next receiver, return false.
+     */
+    @Override
+    public boolean onKeyLongPress(int keyCode, KeyEvent event) {
+        return mKeyDelegate.onKeyLongPress(keyCode, event) ||
+                super.onKeyLongPress(keyCode, event);
+    }
+
+    /**
+     * Checks if the activity should be displayed as a dialog.
+     *
+     * @return True if the activity should be displayed as a dialog, false
+     *         otherwise.
+     */
+    @Override
+    protected boolean isDialogTheme() {
+        return true;
+    }
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/ThreadPreviewActivity.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/ThreadPreviewActivity.java
@@ -24,6 +24,8 @@ import android.view.KeyEvent;
 import android.view.MenuItem;
 import android.view.Window;
 
+import androidx.core.content.IntentCompat;
+
 import javax.inject.Inject;
 import javax.inject.Named;
 
@@ -37,7 +39,6 @@ import io.github.sheepdestroyer.materialisheep.widget.ThreadPreviewRecyclerViewA
 /**
  * An activity that displays a preview of a comment thread.
  */
-@SuppressWarnings("deprecation") // TODO: Uses deprecated Parcelable API
 public class ThreadPreviewActivity extends ThemedActivity {
     public static final String EXTRA_ITEM = ThreadPreviewActivity.class.getName() + ".EXTRA_ITEM";
 
@@ -61,7 +62,7 @@ public class ThreadPreviewActivity extends ThemedActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ((MaterialisticApplication) getApplication()).applicationComponent.inject(this);
-        Item item = getIntent().getParcelableExtra(EXTRA_ITEM);
+        Item item = IntentCompat.getParcelableExtra(getIntent(), EXTRA_ITEM, Item.class);
         if (item == null) {
             finish();
             return;


### PR DESCRIPTION
**What**: Replaced deprecated `getParcelableExtra` with backward-compatible `IntentCompat.getParcelableExtra`. Removed the `@SuppressWarnings("deprecation")` annotation.
**Why**: Addressed deprecation warning and ensured standard modern implementation using `IntentCompat`.
**Impact**: Low. The app maintains backward compatibility and functions exactly the same.
**Measurement**: Execution of local tests (`./gradlew testDebugUnitTest`) showed no regressions.

---
*PR created automatically by Jules for task [7754776322385356397](https://jules.google.com/task/7754776322385356397) started by @sheepdestroyer*

## Summary by Sourcery

Enhancements:
- Replace deprecated getParcelableExtra usage with IntentCompat.getParcelableExtra in ThreadPreviewActivity and remove the associated deprecation suppression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal API usage to modern compatibility standards for improved code maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sheepdestroyer/materialisheep/pull/236?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->