### PR TITLE
Migrate deprecated onActivityCreated to onViewCreated

### DIFF
--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/PopupSettingsFragment.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/PopupSettingsFragment.java
@@ -35,7 +35,6 @@ import com.google.android.material.bottomsheet.BottomSheetDialog;
 /**
  * A dialog fragment that displays settings in a popup.
  */
-@SuppressWarnings("deprecation") // TODO: Uses deprecated Fragment APIs (instantiate, onActivityCreated)
 public class PopupSettingsFragment extends AppCompatDialogFragment {
     static final String EXTRA_TITLE = PopupSettingsFragment.class.getName() + ".EXTRA_TITLE";
     static final String EXTRA_SUMMARY = PopupSettingsFragment.class.getName() + ".EXTRA_SUMMARY";
@@ -79,15 +78,16 @@ public class PopupSettingsFragment extends AppCompatDialogFragment {
     }
 
     /**
-     * Called when the fragment's activity has been created and this
-     * fragment's view hierarchy instantiated.
+     * Called immediately after {@link #onCreateView(LayoutInflater, ViewGroup, Bundle)}
+     * has returned, but before any saved state has been restored in to the view.
      *
-     * @param savedInstanceState If the fragment is being re-created from
-     *                           a previous saved state, this is the state.
+     * @param view               The View returned by {@link #onCreateView(LayoutInflater, ViewGroup, Bundle)}.
+     * @param savedInstanceState If non-null, this fragment is being re-constructed
+     *                           from a previous saved state as given here.
      */
     @Override
-    public void onActivityCreated(Bundle savedInstanceState) {
-        super.onActivityCreated(savedInstanceState);
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
         if (savedInstanceState == null) {
             Fragment fragment = new PreferenceFragment();
             fragment.setArguments(getArguments());

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/PopupSettingsFragment.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/PopupSettingsFragment.java
@@ -19,111 +19,121 @@ package io.github.sheepdestroyer.materialisheep;
 import android.app.Dialog;
 import android.content.Context;
 import android.os.Bundle;
-import android.view.LayoutInflater;
-import android.view.View;
-import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StyleRes;
-import androidx.appcompat.app.AppCompatDialogFragment;
 import androidx.fragment.app.Fragment;
+import androidx.appcompat.app.AppCompatDialogFragment;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
 import com.google.android.material.bottomsheet.BottomSheetDialog;
 
-/** A dialog fragment that displays settings in a popup. */
+/**
+ * A dialog fragment that displays settings in a popup.
+ */
 public class PopupSettingsFragment extends AppCompatDialogFragment {
-  static final String EXTRA_TITLE = PopupSettingsFragment.class.getName() + ".EXTRA_TITLE";
-  static final String EXTRA_SUMMARY = PopupSettingsFragment.class.getName() + ".EXTRA_SUMMARY";
-  static final String EXTRA_XML_PREFERENCES =
-      PopupSettingsFragment.class.getName() + ".EXTRA_XML_PREFERENCES";
+    static final String EXTRA_TITLE = PopupSettingsFragment.class.getName() + ".EXTRA_TITLE";
+    static final String EXTRA_SUMMARY = PopupSettingsFragment.class.getName() + ".EXTRA_SUMMARY";
+    static final String EXTRA_XML_PREFERENCES = PopupSettingsFragment.class.getName() +
+            ".EXTRA_XML_PREFERENCES";
 
-  /**
-   * Called to have the fragment instantiate its user interface view.
-   *
-   * @param inflater The LayoutInflater object that can be used to inflate any views in the
-   *     fragment,
-   * @param container If non-null, this is the parent view that the fragment's UI should be attached
-   *     to. The fragment should not add the view itself, but this can be used to generate the
-   *     LayoutParams of the view.
-   * @param savedInstanceState If non-null, this fragment is being re-constructed from a previous
-   *     saved state as given here.
-   * @return Return the View for the fragment's UI, or null.
-   */
-  @Nullable
-  @Override
-  public View onCreateView(
-      LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-    return inflater.inflate(R.layout.fragment_popup_settings, container, false);
-  }
-
-  /**
-   * Override to build your own custom Dialog container.
-   *
-   * @param savedInstanceState The last saved instance state of the Fragment, or null if this is a
-   *     freshly created Fragment.
-   * @return Return a new Dialog instance to be displayed by the Fragment.
-   */
-  @NonNull
-  @Override
-  public Dialog onCreateDialog(Bundle savedInstanceState) {
-    return new BottomSheetDialog(getActivity(), getTheme());
-  }
-
-  /**
-   * Called immediately after {@link #onCreateView(LayoutInflater, ViewGroup, Bundle)} has returned,
-   * but before any saved state has been restored in to the view.
-   *
-   * @param view The View returned by {@link #onCreateView(LayoutInflater, ViewGroup, Bundle)}.
-   * @param savedInstanceState If non-null, this fragment is being re-constructed from a previous
-   *     saved state as given here.
-   */
-  @Override
-  public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
-    super.onViewCreated(view, savedInstanceState);
-    if (savedInstanceState == null) {
-      Fragment fragment = new PreferenceFragment();
-      fragment.setArguments(getArguments());
-      getChildFragmentManager().beginTransaction().add(R.id.content, fragment).commit();
-    }
-  }
-
-  public static class PreferenceFragment extends PreferenceFragmentCompat {
-
+    /**
+     * Called to have the fragment instantiate its user interface view.
+     *
+     * @param inflater           The LayoutInflater object that can be used to
+     *                           inflate
+     *                           any views in the fragment,
+     * @param container          If non-null, this is the parent view that the
+     *                           fragment's
+     *                           UI should be attached to. The fragment should not
+     *                           add the view itself,
+     *                           but this can be used to generate the LayoutParams
+     *                           of the view.
+     * @param savedInstanceState If non-null, this fragment is being re-constructed
+     *                           from a previous saved state as given here.
+     * @return Return the View for the fragment's UI, or null.
+     */
+    @Nullable
     @Override
-    public void onCreatePreferences(Bundle bundle, String s) {
-      addPreferencesFromResource(R.xml.preferences_category);
-      Preference category = findPreference(getString(R.string.pref_category));
-      int summary, title;
-      if ((title = getArguments().getInt(EXTRA_TITLE, 0)) != 0) {
-        category.setTitle(title);
-      }
-      if ((summary = getArguments().getInt(EXTRA_SUMMARY, 0)) != 0) {
-        category.setSummary(summary);
-      }
-      int[] preferences = getArguments().getIntArray(EXTRA_XML_PREFERENCES);
-      if (preferences != null) {
-        for (int preference : preferences) {
-          addPreferencesFromResource(preference);
+    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container,
+            @Nullable Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.fragment_popup_settings, container, false);
+    }
+
+    /**
+     * Override to build your own custom Dialog container.
+     *
+     * @param savedInstanceState The last saved instance state of the Fragment,
+     *                           or null if this is a freshly created Fragment.
+     * @return Return a new Dialog instance to be displayed by the Fragment.
+     */
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        return new BottomSheetDialog(getActivity(), getTheme());
+    }
+
+    /**
+     * Called immediately after {@link #onCreateView(LayoutInflater, ViewGroup, Bundle)}
+     * has returned, but before any saved state has been restored in to the view.
+     *
+     * @param view               The View returned by {@link #onCreateView(LayoutInflater, ViewGroup, Bundle)}.
+     * @param savedInstanceState If non-null, this fragment is being re-constructed
+     *                           from a previous saved state as given here.
+     */
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        if (savedInstanceState == null) {
+            Fragment fragment = new PreferenceFragment();
+            fragment.setArguments(getArguments());
+            getChildFragmentManager()
+                    .beginTransaction()
+                    .add(R.id.content, fragment)
+                    .commit();
         }
-      }
-    }
-  }
-
-  static class BottomSheetDialog extends com.google.android.material.bottomsheet.BottomSheetDialog {
-    public BottomSheetDialog(@NonNull Context context, @StyleRes int theme) {
-      super(context, theme);
     }
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-      super.onCreate(savedInstanceState);
-      int width = getContext().getResources().getDimensionPixelSize(R.dimen.bottom_sheet_width);
-      // noinspection ConstantConditions
-      getWindow()
-          .setLayout(
-              width > 0 ? width : ViewGroup.LayoutParams.MATCH_PARENT,
-              ViewGroup.LayoutParams.MATCH_PARENT);
+    public static class PreferenceFragment extends PreferenceFragmentCompat {
+
+        @Override
+        public void onCreatePreferences(Bundle bundle, String s) {
+            addPreferencesFromResource(R.xml.preferences_category);
+            Preference category = findPreference(getString(R.string.pref_category));
+            int summary, title;
+            if ((title = getArguments().getInt(EXTRA_TITLE, 0)) != 0) {
+                category.setTitle(title);
+            }
+            if ((summary = getArguments().getInt(EXTRA_SUMMARY, 0)) != 0) {
+                category.setSummary(summary);
+            }
+            int[] preferences = getArguments().getIntArray(EXTRA_XML_PREFERENCES);
+            if (preferences != null) {
+                for (int preference : preferences) {
+                    addPreferencesFromResource(preference);
+                }
+            }
+        }
     }
-  }
+
+    static class BottomSheetDialog extends com.google.android.material.bottomsheet.BottomSheetDialog {
+        public BottomSheetDialog(@NonNull Context context, @StyleRes int theme) {
+            super(context, theme);
+        }
+
+        @Override
+        protected void onCreate(Bundle savedInstanceState) {
+            super.onCreate(savedInstanceState);
+            int width = getContext().getResources().getDimensionPixelSize(R.dimen.bottom_sheet_width);
+            // noinspection ConstantConditions
+            getWindow().setLayout(
+                    width > 0 ? width : ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT);
+        }
+
+    }
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/PopupSettingsFragment.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/PopupSettingsFragment.java
@@ -93,14 +93,18 @@ public class PopupSettingsFragment extends AppCompatDialogFragment {
     public void onCreatePreferences(Bundle bundle, String s) {
       addPreferencesFromResource(R.xml.preferences_category);
       Preference category = findPreference(getString(R.string.pref_category));
+      Bundle args = getArguments();
+      if (args == null) {
+        return;
+      }
       int summary, title;
-      if ((title = getArguments().getInt(EXTRA_TITLE, 0)) != 0) {
+      if ((title = args.getInt(EXTRA_TITLE, 0)) != 0 && category != null) {
         category.setTitle(title);
       }
-      if ((summary = getArguments().getInt(EXTRA_SUMMARY, 0)) != 0) {
+      if ((summary = args.getInt(EXTRA_SUMMARY, 0)) != 0 && category != null) {
         category.setSummary(summary);
       }
-      int[] preferences = getArguments().getIntArray(EXTRA_XML_PREFERENCES);
+      int[] preferences = args.getIntArray(EXTRA_XML_PREFERENCES);
       if (preferences != null) {
         for (int preference : preferences) {
           addPreferencesFromResource(preference);

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/PopupSettingsFragment.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/PopupSettingsFragment.java
@@ -109,7 +109,8 @@ public class PopupSettingsFragment extends AppCompatDialogFragment {
     }
   }
 
-  static class PopupBottomSheetDialog extends com.google.android.material.bottomsheet.BottomSheetDialog {
+  static class PopupBottomSheetDialog
+      extends com.google.android.material.bottomsheet.BottomSheetDialog {
     public PopupBottomSheetDialog(@NonNull Context context, @StyleRes int theme) {
       super(context, theme);
     }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/PopupSettingsFragment.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/PopupSettingsFragment.java
@@ -19,121 +19,111 @@ package io.github.sheepdestroyer.materialisheep;
 import android.app.Dialog;
 import android.content.Context;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.StyleRes;
-import androidx.fragment.app.Fragment;
-import androidx.appcompat.app.AppCompatDialogFragment;
-import androidx.preference.Preference;
-import androidx.preference.PreferenceFragmentCompat;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.StyleRes;
+import androidx.appcompat.app.AppCompatDialogFragment;
+import androidx.fragment.app.Fragment;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceFragmentCompat;
 import com.google.android.material.bottomsheet.BottomSheetDialog;
 
-/**
- * A dialog fragment that displays settings in a popup.
- */
+/** A dialog fragment that displays settings in a popup. */
 public class PopupSettingsFragment extends AppCompatDialogFragment {
-    static final String EXTRA_TITLE = PopupSettingsFragment.class.getName() + ".EXTRA_TITLE";
-    static final String EXTRA_SUMMARY = PopupSettingsFragment.class.getName() + ".EXTRA_SUMMARY";
-    static final String EXTRA_XML_PREFERENCES = PopupSettingsFragment.class.getName() +
-            ".EXTRA_XML_PREFERENCES";
+  static final String EXTRA_TITLE = PopupSettingsFragment.class.getName() + ".EXTRA_TITLE";
+  static final String EXTRA_SUMMARY = PopupSettingsFragment.class.getName() + ".EXTRA_SUMMARY";
+  static final String EXTRA_XML_PREFERENCES =
+      PopupSettingsFragment.class.getName() + ".EXTRA_XML_PREFERENCES";
 
-    /**
-     * Called to have the fragment instantiate its user interface view.
-     *
-     * @param inflater           The LayoutInflater object that can be used to
-     *                           inflate
-     *                           any views in the fragment,
-     * @param container          If non-null, this is the parent view that the
-     *                           fragment's
-     *                           UI should be attached to. The fragment should not
-     *                           add the view itself,
-     *                           but this can be used to generate the LayoutParams
-     *                           of the view.
-     * @param savedInstanceState If non-null, this fragment is being re-constructed
-     *                           from a previous saved state as given here.
-     * @return Return the View for the fragment's UI, or null.
-     */
-    @Nullable
+  /**
+   * Called to have the fragment instantiate its user interface view.
+   *
+   * @param inflater The LayoutInflater object that can be used to inflate any views in the
+   *     fragment,
+   * @param container If non-null, this is the parent view that the fragment's UI should be attached
+   *     to. The fragment should not add the view itself, but this can be used to generate the
+   *     LayoutParams of the view.
+   * @param savedInstanceState If non-null, this fragment is being re-constructed from a previous
+   *     saved state as given here.
+   * @return Return the View for the fragment's UI, or null.
+   */
+  @Nullable
+  @Override
+  public View onCreateView(
+      LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+    return inflater.inflate(R.layout.fragment_popup_settings, container, false);
+  }
+
+  /**
+   * Override to build your own custom Dialog container.
+   *
+   * @param savedInstanceState The last saved instance state of the Fragment, or null if this is a
+   *     freshly created Fragment.
+   * @return Return a new Dialog instance to be displayed by the Fragment.
+   */
+  @NonNull
+  @Override
+  public Dialog onCreateDialog(Bundle savedInstanceState) {
+    return new BottomSheetDialog(getActivity(), getTheme());
+  }
+
+  /**
+   * Called immediately after {@link #onCreateView(LayoutInflater, ViewGroup, Bundle)} has returned,
+   * but before any saved state has been restored in to the view.
+   *
+   * @param view The View returned by {@link #onCreateView(LayoutInflater, ViewGroup, Bundle)}.
+   * @param savedInstanceState If non-null, this fragment is being re-constructed from a previous
+   *     saved state as given here.
+   */
+  @Override
+  public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+    super.onViewCreated(view, savedInstanceState);
+    if (savedInstanceState == null) {
+      Fragment fragment = new PreferenceFragment();
+      fragment.setArguments(getArguments());
+      getChildFragmentManager().beginTransaction().add(R.id.content, fragment).commit();
+    }
+  }
+
+  public static class PreferenceFragment extends PreferenceFragmentCompat {
+
     @Override
-    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container,
-            @Nullable Bundle savedInstanceState) {
-        return inflater.inflate(R.layout.fragment_popup_settings, container, false);
+    public void onCreatePreferences(Bundle bundle, String s) {
+      addPreferencesFromResource(R.xml.preferences_category);
+      Preference category = findPreference(getString(R.string.pref_category));
+      int summary, title;
+      if ((title = getArguments().getInt(EXTRA_TITLE, 0)) != 0) {
+        category.setTitle(title);
+      }
+      if ((summary = getArguments().getInt(EXTRA_SUMMARY, 0)) != 0) {
+        category.setSummary(summary);
+      }
+      int[] preferences = getArguments().getIntArray(EXTRA_XML_PREFERENCES);
+      if (preferences != null) {
+        for (int preference : preferences) {
+          addPreferencesFromResource(preference);
+        }
+      }
+    }
+  }
+
+  static class BottomSheetDialog extends com.google.android.material.bottomsheet.BottomSheetDialog {
+    public BottomSheetDialog(@NonNull Context context, @StyleRes int theme) {
+      super(context, theme);
     }
 
-    /**
-     * Override to build your own custom Dialog container.
-     *
-     * @param savedInstanceState The last saved instance state of the Fragment,
-     *                           or null if this is a freshly created Fragment.
-     * @return Return a new Dialog instance to be displayed by the Fragment.
-     */
-    @NonNull
     @Override
-    public Dialog onCreateDialog(Bundle savedInstanceState) {
-        return new BottomSheetDialog(getActivity(), getTheme());
+    protected void onCreate(Bundle savedInstanceState) {
+      super.onCreate(savedInstanceState);
+      int width = getContext().getResources().getDimensionPixelSize(R.dimen.bottom_sheet_width);
+      // noinspection ConstantConditions
+      getWindow()
+          .setLayout(
+              width > 0 ? width : ViewGroup.LayoutParams.MATCH_PARENT,
+              ViewGroup.LayoutParams.MATCH_PARENT);
     }
-
-    /**
-     * Called immediately after {@link #onCreateView(LayoutInflater, ViewGroup, Bundle)}
-     * has returned, but before any saved state has been restored in to the view.
-     *
-     * @param view               The View returned by {@link #onCreateView(LayoutInflater, ViewGroup, Bundle)}.
-     * @param savedInstanceState If non-null, this fragment is being re-constructed
-     *                           from a previous saved state as given here.
-     */
-    @Override
-    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
-        super.onViewCreated(view, savedInstanceState);
-        if (savedInstanceState == null) {
-            Fragment fragment = new PreferenceFragment();
-            fragment.setArguments(getArguments());
-            getChildFragmentManager()
-                    .beginTransaction()
-                    .add(R.id.content, fragment)
-                    .commit();
-        }
-    }
-
-    public static class PreferenceFragment extends PreferenceFragmentCompat {
-
-        @Override
-        public void onCreatePreferences(Bundle bundle, String s) {
-            addPreferencesFromResource(R.xml.preferences_category);
-            Preference category = findPreference(getString(R.string.pref_category));
-            int summary, title;
-            if ((title = getArguments().getInt(EXTRA_TITLE, 0)) != 0) {
-                category.setTitle(title);
-            }
-            if ((summary = getArguments().getInt(EXTRA_SUMMARY, 0)) != 0) {
-                category.setSummary(summary);
-            }
-            int[] preferences = getArguments().getIntArray(EXTRA_XML_PREFERENCES);
-            if (preferences != null) {
-                for (int preference : preferences) {
-                    addPreferencesFromResource(preference);
-                }
-            }
-        }
-    }
-
-    static class BottomSheetDialog extends com.google.android.material.bottomsheet.BottomSheetDialog {
-        public BottomSheetDialog(@NonNull Context context, @StyleRes int theme) {
-            super(context, theme);
-        }
-
-        @Override
-        protected void onCreate(Bundle savedInstanceState) {
-            super.onCreate(savedInstanceState);
-            int width = getContext().getResources().getDimensionPixelSize(R.dimen.bottom_sheet_width);
-            // noinspection ConstantConditions
-            getWindow().setLayout(
-                    width > 0 ? width : ViewGroup.LayoutParams.MATCH_PARENT,
-                    ViewGroup.LayoutParams.MATCH_PARENT);
-        }
-
-    }
+  }
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/PopupSettingsFragment.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/PopupSettingsFragment.java
@@ -29,7 +29,6 @@ import androidx.appcompat.app.AppCompatDialogFragment;
 import androidx.fragment.app.Fragment;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
-import com.google.android.material.bottomsheet.BottomSheetDialog;
 
 /** A dialog fragment that displays settings in a popup. */
 public class PopupSettingsFragment extends AppCompatDialogFragment {
@@ -67,7 +66,7 @@ public class PopupSettingsFragment extends AppCompatDialogFragment {
   @NonNull
   @Override
   public Dialog onCreateDialog(Bundle savedInstanceState) {
-    return new BottomSheetDialog(getActivity(), getTheme());
+    return new PopupBottomSheetDialog(getActivity(), getTheme());
   }
 
   /**
@@ -110,8 +109,8 @@ public class PopupSettingsFragment extends AppCompatDialogFragment {
     }
   }
 
-  static class BottomSheetDialog extends com.google.android.material.bottomsheet.BottomSheetDialog {
-    public BottomSheetDialog(@NonNull Context context, @StyleRes int theme) {
+  static class PopupBottomSheetDialog extends com.google.android.material.bottomsheet.BottomSheetDialog {
+    public PopupBottomSheetDialog(@NonNull Context context, @StyleRes int theme) {
       super(context, theme);
     }
 


### PR DESCRIPTION
**What:**
Migrated the deprecated `onActivityCreated` lifecycle method to `onViewCreated` in `PopupSettingsFragment.java`.

**Why:**
`onActivityCreated` has been deprecated in modern Android fragment lifecycles. Moving to `onViewCreated` is the recommended and straightforward migration path.

**Impact:**
Removes reliance on deprecated API and resolves a `TODO` comment without affecting the functionality of the bottom sheet dialog fragment.

**Measurement:**
Verified by running `testDebugUnitTest` and `lint` checks, which all passed without introducing any regressions. The project still successfully compiles and passes lint warnings regarding this deprecation.

---
*PR created automatically by Jules for task [3101728630162477678](https://jules.google.com/task/3101728630162477678) started by @sheepdestroyer*

## Summary by Sourcery

Migrate popup settings fragment to use the modern onViewCreated lifecycle callback instead of the deprecated onActivityCreated.

Enhancements:
- Replace use of deprecated onActivityCreated with onViewCreated in PopupSettingsFragment to align with modern Android fragment lifecycle APIs.
- Remove the class-level deprecation suppression now that deprecated fragment APIs are no longer used in this dialog fragment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized deprecated Android lifecycle methods to align with current framework standards, improving compatibility with newer Android versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sheepdestroyer/materialisheep/pull/237?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->