### PR TITLE
Refactor: replace deprecated system strings with action verbs in ComposeActivity dialog

### DIFF
--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/ComposeActivity.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/ComposeActivity.java
@@ -42,7 +42,6 @@ import io.github.sheepdestroyer.materialisheep.annotation.Synthetic;
 /**
  * Activity for composing a new comment or reply.
  */
-@SuppressWarnings("deprecation") // TODO: Uses deprecated android.R.string.yes/no
 public class ComposeActivity extends ThemedActivity {
     public static final String EXTRA_PARENT_ID = ComposeActivity.class.getName() + ".EXTRA_PARENT_ID";
     public static final String EXTRA_PARENT_TEXT = ComposeActivity.class.getName() + ".EXTRA_PARENT_TEXT";
@@ -73,10 +72,10 @@ public class ComposeActivity extends ThemedActivity {
             mAlertDialogBuilder
                     .init(ComposeActivity.this)
                     .setMessage(R.string.confirm_save_draft)
-                    .setNegativeButton(android.R.string.no, (dialog, which) -> {
+                    .setNegativeButton(R.string.discard_draft, (dialog, which) -> {
                         getOnBackPressedDispatcher().onBackPressed();
                     })
-                    .setPositiveButton(android.R.string.yes, (dialog, which) -> {
+                    .setPositiveButton(R.string.save_draft, (dialog, which) -> {
                         Preferences.saveDraft(ComposeActivity.this, mParentId,
                                 mEditText.getText().toString());
                         getOnBackPressedDispatcher().onBackPressed();


### PR DESCRIPTION
## What
Replaced deprecated `android.R.string.yes` and `android.R.string.no` with explicit, context-aware action labels (`R.string.save_draft` and `R.string.discard_draft`) in the "Save draft?" AlertDialog within `ComposeActivity.java`.

## Why
Using generic "Yes/No" strings for dialog actions is discouraged by Material Design guidelines and the `android.R.string.yes/no` resources are officially deprecated. Explicit action verbs ("Save draft", "Discard draft") improve accessibility, clarity, and ensure adherence to Android modern standard practices.

## Impact
- **ComposeActivity**: The "Save draft?" dialog now presents clearer choices to the user.
- **Codebase**: Resolves usage of deprecated resources and cleans up obsolete `@SuppressWarnings("deprecation")` annotations.

## Measurement
All unit tests and linting (`testDebugUnitTest`, `lint`) continue to pass successfully.

---
*PR created automatically by Jules for task [1936852130844203032](https://jules.google.com/task/1936852130844203032) started by @sheepdestroyer*

## Summary by Sourcery

Enhancements:
- Use context-specific "Save draft" and "Discard draft" labels in the compose discard confirmation dialog instead of generic yes/no system strings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the draft-save confirmation dialog that appears when leaving the composer by updating to app-specific localized string resources. This improvement ensures better consistency across the application interface and provides comprehensive localization support for users in different languages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sheepdestroyer/materialisheep/pull/238?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->