### PR TITLE
🧪 Test missing for AppUtils.getAbbreviatedTimeSpan

### DIFF
--- a/app/src/test/java/io/github/sheepdestroyer/materialisheep/AppUtilsTest.java
+++ b/app/src/test/java/io/github/sheepdestroyer/materialisheep/AppUtilsTest.java
@@ -1,74 +1,68 @@
 package io.github.sheepdestroyer.materialisheep;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import android.content.Context;
-import android.text.format.DateUtils;
 import androidx.test.core.app.ApplicationProvider;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import android.text.format.DateUtils;
+
 @RunWith(RobolectricTestRunner.class)
 public class AppUtilsTest {
-  @Test
-  public void testHasConnection() {
-    Context context = ApplicationProvider.getApplicationContext();
-    android.net.ConnectivityManager connectivityManager =
-        (android.net.ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
-    org.robolectric.shadows.ShadowConnectivityManager shadowConnectivityManager =
-        org.robolectric.Shadows.shadowOf(connectivityManager);
+        @Test
+        public void testHasConnection() {
+                Context context = ApplicationProvider.getApplicationContext();
+                android.net.ConnectivityManager connectivityManager = (android.net.ConnectivityManager) context
+                                .getSystemService(Context.CONNECTIVITY_SERVICE);
+                org.robolectric.shadows.ShadowConnectivityManager shadowConnectivityManager = org.robolectric.Shadows
+                                .shadowOf(connectivityManager);
 
-    // Test with no connection
-    shadowConnectivityManager.setActiveNetworkInfo(null);
-    assertFalse(AppUtils.hasConnection(context));
+                // Test with no connection
+                shadowConnectivityManager.setActiveNetworkInfo(null);
+                assertFalse(AppUtils.hasConnection(context));
 
-    // Test with connection
-    shadowConnectivityManager.setActiveNetworkInfo(
-        org.robolectric.shadows.ShadowNetworkInfo.newInstance(
-            android.net.NetworkInfo.DetailedState.CONNECTED,
-            android.net.ConnectivityManager.TYPE_WIFI,
-            0,
-            true,
-            true));
-    assertTrue(AppUtils.hasConnection(context));
+                // Test with connection
+                shadowConnectivityManager.setActiveNetworkInfo(
+                                org.robolectric.shadows.ShadowNetworkInfo.newInstance(
+                                                android.net.NetworkInfo.DetailedState.CONNECTED,
+                                                android.net.ConnectivityManager.TYPE_WIFI, 0, true, true));
+                assertTrue(AppUtils.hasConnection(context));
 
-    // Test with disconnected network
-    shadowConnectivityManager.setActiveNetworkInfo(
-        org.robolectric.shadows.ShadowNetworkInfo.newInstance(
-            android.net.NetworkInfo.DetailedState.DISCONNECTED,
-            android.net.ConnectivityManager.TYPE_WIFI,
-            0,
-            true,
-            false));
-    assertFalse(AppUtils.hasConnection(context));
-  }
+                // Test with disconnected network
+                shadowConnectivityManager.setActiveNetworkInfo(
+                                org.robolectric.shadows.ShadowNetworkInfo.newInstance(
+                                                android.net.NetworkInfo.DetailedState.DISCONNECTED,
+                                                android.net.ConnectivityManager.TYPE_WIFI, 0, true, false));
+                assertFalse(AppUtils.hasConnection(context));
+        }
 
-  @Test
-  public void testGetAbbreviatedTimeSpan() {
-    long now = System.currentTimeMillis();
+        @Test
+        public void testGetAbbreviatedTimeSpan() {
+                long now = System.currentTimeMillis();
 
-    // Test Years
-    assertEquals("2y", AppUtils.getAbbreviatedTimeSpan(now - (2 * DateUtils.YEAR_IN_MILLIS)));
+                // Test Years
+                assertEquals("2y", AppUtils.getAbbreviatedTimeSpan(now - (2 * DateUtils.YEAR_IN_MILLIS)));
 
-    // Test Weeks
-    assertEquals("3w", AppUtils.getAbbreviatedTimeSpan(now - (3 * DateUtils.WEEK_IN_MILLIS)));
+                // Test Weeks
+                assertEquals("3w", AppUtils.getAbbreviatedTimeSpan(now - (3 * DateUtils.WEEK_IN_MILLIS)));
 
-    // Test Days
-    assertEquals("4d", AppUtils.getAbbreviatedTimeSpan(now - (4 * DateUtils.DAY_IN_MILLIS)));
+                // Test Days
+                assertEquals("4d", AppUtils.getAbbreviatedTimeSpan(now - (4 * DateUtils.DAY_IN_MILLIS)));
 
-    // Test Hours
-    assertEquals("5h", AppUtils.getAbbreviatedTimeSpan(now - (5 * DateUtils.HOUR_IN_MILLIS)));
+                // Test Hours
+                assertEquals("5h", AppUtils.getAbbreviatedTimeSpan(now - (5 * DateUtils.HOUR_IN_MILLIS)));
 
-    // Test Minutes
-    assertEquals("10m", AppUtils.getAbbreviatedTimeSpan(now - (10 * DateUtils.MINUTE_IN_MILLIS)));
+                // Test Minutes
+                assertEquals("10m", AppUtils.getAbbreviatedTimeSpan(now - (10 * DateUtils.MINUTE_IN_MILLIS)));
 
-    // Test edge case (just now / 0 difference)
-    assertEquals("0m", AppUtils.getAbbreviatedTimeSpan(now));
+                // Test edge case (just now / 0 difference)
+                assertEquals("0m", AppUtils.getAbbreviatedTimeSpan(now));
 
-    // Test edge case (future time)
-    assertEquals("0m", AppUtils.getAbbreviatedTimeSpan(now + DateUtils.DAY_IN_MILLIS));
-  }
+                // Test edge case (future time)
+                assertEquals("0m", AppUtils.getAbbreviatedTimeSpan(now + DateUtils.DAY_IN_MILLIS));
+        }
 }

--- a/app/src/test/java/io/github/sheepdestroyer/materialisheep/AppUtilsTest.java
+++ b/app/src/test/java/io/github/sheepdestroyer/materialisheep/AppUtilsTest.java
@@ -1,68 +1,74 @@
 package io.github.sheepdestroyer.materialisheep;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import android.content.Context;
+import android.text.format.DateUtils;
 import androidx.test.core.app.ApplicationProvider;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
-import android.text.format.DateUtils;
-
 @RunWith(RobolectricTestRunner.class)
 public class AppUtilsTest {
-        @Test
-        public void testHasConnection() {
-                Context context = ApplicationProvider.getApplicationContext();
-                android.net.ConnectivityManager connectivityManager = (android.net.ConnectivityManager) context
-                                .getSystemService(Context.CONNECTIVITY_SERVICE);
-                org.robolectric.shadows.ShadowConnectivityManager shadowConnectivityManager = org.robolectric.Shadows
-                                .shadowOf(connectivityManager);
+  @Test
+  public void testHasConnection() {
+    Context context = ApplicationProvider.getApplicationContext();
+    android.net.ConnectivityManager connectivityManager =
+        (android.net.ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+    org.robolectric.shadows.ShadowConnectivityManager shadowConnectivityManager =
+        org.robolectric.Shadows.shadowOf(connectivityManager);
 
-                // Test with no connection
-                shadowConnectivityManager.setActiveNetworkInfo(null);
-                assertFalse(AppUtils.hasConnection(context));
+    // Test with no connection
+    shadowConnectivityManager.setActiveNetworkInfo(null);
+    assertFalse(AppUtils.hasConnection(context));
 
-                // Test with connection
-                shadowConnectivityManager.setActiveNetworkInfo(
-                                org.robolectric.shadows.ShadowNetworkInfo.newInstance(
-                                                android.net.NetworkInfo.DetailedState.CONNECTED,
-                                                android.net.ConnectivityManager.TYPE_WIFI, 0, true, true));
-                assertTrue(AppUtils.hasConnection(context));
+    // Test with connection
+    shadowConnectivityManager.setActiveNetworkInfo(
+        org.robolectric.shadows.ShadowNetworkInfo.newInstance(
+            android.net.NetworkInfo.DetailedState.CONNECTED,
+            android.net.ConnectivityManager.TYPE_WIFI,
+            0,
+            true,
+            true));
+    assertTrue(AppUtils.hasConnection(context));
 
-                // Test with disconnected network
-                shadowConnectivityManager.setActiveNetworkInfo(
-                                org.robolectric.shadows.ShadowNetworkInfo.newInstance(
-                                                android.net.NetworkInfo.DetailedState.DISCONNECTED,
-                                                android.net.ConnectivityManager.TYPE_WIFI, 0, true, false));
-                assertFalse(AppUtils.hasConnection(context));
-        }
+    // Test with disconnected network
+    shadowConnectivityManager.setActiveNetworkInfo(
+        org.robolectric.shadows.ShadowNetworkInfo.newInstance(
+            android.net.NetworkInfo.DetailedState.DISCONNECTED,
+            android.net.ConnectivityManager.TYPE_WIFI,
+            0,
+            true,
+            false));
+    assertFalse(AppUtils.hasConnection(context));
+  }
 
-        @Test
-        public void testGetAbbreviatedTimeSpan() {
-                long now = System.currentTimeMillis();
+  @Test
+  public void testGetAbbreviatedTimeSpan() {
+    long now = System.currentTimeMillis();
 
-                // Test Years
-                assertEquals("2y", AppUtils.getAbbreviatedTimeSpan(now - (2 * DateUtils.YEAR_IN_MILLIS)));
+    // Test Years
+    assertEquals("2y", AppUtils.getAbbreviatedTimeSpan(now - (2 * DateUtils.YEAR_IN_MILLIS)));
 
-                // Test Weeks
-                assertEquals("3w", AppUtils.getAbbreviatedTimeSpan(now - (3 * DateUtils.WEEK_IN_MILLIS)));
+    // Test Weeks
+    assertEquals("3w", AppUtils.getAbbreviatedTimeSpan(now - (3 * DateUtils.WEEK_IN_MILLIS)));
 
-                // Test Days
-                assertEquals("4d", AppUtils.getAbbreviatedTimeSpan(now - (4 * DateUtils.DAY_IN_MILLIS)));
+    // Test Days
+    assertEquals("4d", AppUtils.getAbbreviatedTimeSpan(now - (4 * DateUtils.DAY_IN_MILLIS)));
 
-                // Test Hours
-                assertEquals("5h", AppUtils.getAbbreviatedTimeSpan(now - (5 * DateUtils.HOUR_IN_MILLIS)));
+    // Test Hours
+    assertEquals("5h", AppUtils.getAbbreviatedTimeSpan(now - (5 * DateUtils.HOUR_IN_MILLIS)));
 
-                // Test Minutes
-                assertEquals("10m", AppUtils.getAbbreviatedTimeSpan(now - (10 * DateUtils.MINUTE_IN_MILLIS)));
+    // Test Minutes
+    assertEquals("10m", AppUtils.getAbbreviatedTimeSpan(now - (10 * DateUtils.MINUTE_IN_MILLIS)));
 
-                // Test edge case (just now / 0 difference)
-                assertEquals("0m", AppUtils.getAbbreviatedTimeSpan(now));
+    // Test edge case (just now / 0 difference)
+    assertEquals("0m", AppUtils.getAbbreviatedTimeSpan(now));
 
-                // Test edge case (future time)
-                assertEquals("0m", AppUtils.getAbbreviatedTimeSpan(now + DateUtils.DAY_IN_MILLIS));
-        }
+    // Test edge case (future time)
+    assertEquals("0m", AppUtils.getAbbreviatedTimeSpan(now + DateUtils.DAY_IN_MILLIS));
+  }
 }

--- a/app/src/test/java/io/github/sheepdestroyer/materialisheep/AppUtilsTest.java
+++ b/app/src/test/java/io/github/sheepdestroyer/materialisheep/AppUtilsTest.java
@@ -8,6 +8,8 @@ import org.robolectric.RobolectricTestRunner;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import android.text.format.DateUtils;
 
 @RunWith(RobolectricTestRunner.class)
 public class AppUtilsTest {
@@ -36,5 +38,31 @@ public class AppUtilsTest {
                                                 android.net.NetworkInfo.DetailedState.DISCONNECTED,
                                                 android.net.ConnectivityManager.TYPE_WIFI, 0, true, false));
                 assertFalse(AppUtils.hasConnection(context));
+        }
+
+        @Test
+        public void testGetAbbreviatedTimeSpan() {
+                long now = System.currentTimeMillis();
+
+                // Test Years
+                assertEquals("2y", AppUtils.getAbbreviatedTimeSpan(now - (2 * DateUtils.YEAR_IN_MILLIS)));
+
+                // Test Weeks
+                assertEquals("3w", AppUtils.getAbbreviatedTimeSpan(now - (3 * DateUtils.WEEK_IN_MILLIS)));
+
+                // Test Days
+                assertEquals("4d", AppUtils.getAbbreviatedTimeSpan(now - (4 * DateUtils.DAY_IN_MILLIS)));
+
+                // Test Hours
+                assertEquals("5h", AppUtils.getAbbreviatedTimeSpan(now - (5 * DateUtils.HOUR_IN_MILLIS)));
+
+                // Test Minutes
+                assertEquals("10m", AppUtils.getAbbreviatedTimeSpan(now - (10 * DateUtils.MINUTE_IN_MILLIS)));
+
+                // Test edge case (just now / 0 difference)
+                assertEquals("0m", AppUtils.getAbbreviatedTimeSpan(now));
+
+                // Test edge case (future time)
+                assertEquals("0m", AppUtils.getAbbreviatedTimeSpan(now + DateUtils.DAY_IN_MILLIS));
         }
 }


### PR DESCRIPTION
🎯 **What:** Added unit tests to `AppUtilsTest.java` to test the pure function `AppUtils.getAbbreviatedTimeSpan()`.
📊 **Coverage:** Covered formatting scenarios for years ("y"), weeks ("w"), days ("d"), hours ("h"), and minutes ("m"). It also covers the edge cases for 0 difference (just now) and future times (handled as 0 due to Math.max in the source code).
✨ **Result:** Improved overall test coverage for the AppUtils class, resulting in robust tests that do not rely on static time or mocking and instead use dynamic current system time offsets dynamically.

---
*PR created automatically by Jules for task [5706448063160771479](https://jules.google.com/task/5706448063160771479) started by @sheepdestroyer*

## Summary by Sourcery

Tests:
- Add Robolectric unit test for AppUtils.getAbbreviatedTimeSpan covering years, weeks, days, hours, minutes, zero-difference, and future timestamps.