### PR TITLE
Migrate deprecated onNestedScroll API

### DIFF
--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/FabAwareScrollBehavior.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/FabAwareScrollBehavior.java
@@ -16,94 +16,114 @@
 package io.github.sheepdestroyer.materialisheep;
 
 import android.content.Context;
-import androidx.annotation.NonNull;
-import com.google.android.material.appbar.AppBarLayout;
-import androidx.coordinatorlayout.widget.CoordinatorLayout;
-import com.google.android.material.floatingactionbutton.FloatingActionButton;
-import androidx.core.view.ViewCompat;
 import android.util.AttributeSet;
 import android.view.View;
-
+import androidx.annotation.NonNull;
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
+import androidx.core.view.ViewCompat;
+import com.google.android.material.appbar.AppBarLayout;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import java.util.List;
 
 /**
- * A {@link CoordinatorLayout.Behavior} that hides a
- * {@link FloatingActionButton} when the user
+ * A {@link CoordinatorLayout.Behavior} that hides a {@link FloatingActionButton} when the user
  * scrolls down and shows it when the user scrolls up.
  */
 public class FabAwareScrollBehavior extends AppBarLayout.ScrollingViewBehavior {
-    static final Object HIDDEN = new Object();
+  static final Object HIDDEN = new Object();
 
-    public FabAwareScrollBehavior(Context context, AttributeSet attrs) {
-        super(context, attrs);
-    }
+  public FabAwareScrollBehavior(Context context, AttributeSet attrs) {
+    super(context, attrs);
+  }
 
-    /**
-     * Determines whether the behavior depends on another view.
-     *
-     * @param parent     The CoordinatorLayout parent.
-     * @param child      The child view.
-     * @param dependency The dependency view.
-     * @return True if the behavior depends on the dependency, false otherwise.
-     */
-    @Override
-    public boolean layoutDependsOn(CoordinatorLayout parent, View child, View dependency) {
-        return super.layoutDependsOn(parent, child, dependency) ||
-                dependency instanceof FloatingActionButton;
-    }
+  /**
+   * Determines whether the behavior depends on another view.
+   *
+   * @param parent The CoordinatorLayout parent.
+   * @param child The child view.
+   * @param dependency The dependency view.
+   * @return True if the behavior depends on the dependency, false otherwise.
+   */
+  @Override
+  public boolean layoutDependsOn(CoordinatorLayout parent, View child, View dependency) {
+    return super.layoutDependsOn(parent, child, dependency)
+        || dependency instanceof FloatingActionButton;
+  }
 
-    /**
-     * Called when a nested scroll is about to start.
-     *
-     * @param coordinatorLayout The CoordinatorLayout parent.
-     * @param child             The child view.
-     * @param directTargetChild The direct target of the scroll.
-     * @param target            The target of the scroll.
-     * @param axes              The scroll axes.
-     * @param type              The type of the scroll.
-     * @return True if the behavior accepts the nested scroll, false otherwise.
-     */
-    @Override
-    public boolean onStartNestedScroll(@NonNull CoordinatorLayout coordinatorLayout, @NonNull View child,
-            @NonNull View directTargetChild, @NonNull View target, int axes, int type) {
-        // Ensure we react to vertical scrolling
-        return axes == ViewCompat.SCROLL_AXIS_VERTICAL
-                || super.onStartNestedScroll(coordinatorLayout, child, directTargetChild, target, axes, type);
-    }
+  /**
+   * Called when a nested scroll is about to start.
+   *
+   * @param coordinatorLayout The CoordinatorLayout parent.
+   * @param child The child view.
+   * @param directTargetChild The direct target of the scroll.
+   * @param target The target of the scroll.
+   * @param axes The scroll axes.
+   * @param type The type of the scroll.
+   * @return True if the behavior accepts the nested scroll, false otherwise.
+   */
+  @Override
+  public boolean onStartNestedScroll(
+      @NonNull CoordinatorLayout coordinatorLayout,
+      @NonNull View child,
+      @NonNull View directTargetChild,
+      @NonNull View target,
+      int axes,
+      int type) {
+    // Ensure we react to vertical scrolling
+    return axes == ViewCompat.SCROLL_AXIS_VERTICAL
+        || super.onStartNestedScroll(
+            coordinatorLayout, child, directTargetChild, target, axes, type);
+  }
 
-    /**
-     * Called when a nested scroll is in progress.
-     *
-     * @param coordinatorLayout The CoordinatorLayout parent.
-     * @param child             The child view.
-     * @param target            The target of the scroll.
-     * @param dxConsumed        The horizontal distance consumed by the target.
-     * @param dyConsumed        The vertical distance consumed by the target.
-     * @param dxUnconsumed      The horizontal distance not consumed by the target.
-     * @param dyUnconsumed      The vertical distance not consumed by the target.
-     * @param type              The type of the scroll.
-     */
-    @Override
-    public void onNestedScroll(@NonNull CoordinatorLayout coordinatorLayout, @NonNull View child, @NonNull View target,
-            int dxConsumed, int dyConsumed, int dxUnconsumed, int dyUnconsumed, int type, @NonNull int[] consumed) {
-        super.onNestedScroll(coordinatorLayout, child, target, dxConsumed, dyConsumed, dxUnconsumed, dyUnconsumed,
-                type, consumed);
-        if (dyConsumed > 0) {
-            // User scrolled down -> hide the FAB
-            List<View> dependencies = coordinatorLayout.getDependencies(child);
-            for (View view : dependencies) {
-                if (view instanceof FloatingActionButton) {
-                    ((FloatingActionButton) view).hide();
-                }
-            }
-        } else if (dyConsumed < 0) {
-            // User scrolled up -> show the FAB
-            List<View> dependencies = coordinatorLayout.getDependencies(child);
-            for (View view : dependencies) {
-                if (view instanceof FloatingActionButton && !HIDDEN.equals(view.getTag())) {
-                    ((FloatingActionButton) view).show();
-                }
-            }
+  /**
+   * Called when a nested scroll is in progress.
+   *
+   * @param coordinatorLayout The CoordinatorLayout parent.
+   * @param child The child view.
+   * @param target The target of the scroll.
+   * @param dxConsumed The horizontal distance consumed by the target.
+   * @param dyConsumed The vertical distance consumed by the target.
+   * @param dxUnconsumed The horizontal distance not consumed by the target.
+   * @param dyUnconsumed The vertical distance not consumed by the target.
+   * @param type The type of the scroll.
+   */
+  @Override
+  public void onNestedScroll(
+      @NonNull CoordinatorLayout coordinatorLayout,
+      @NonNull View child,
+      @NonNull View target,
+      int dxConsumed,
+      int dyConsumed,
+      int dxUnconsumed,
+      int dyUnconsumed,
+      int type,
+      @NonNull int[] consumed) {
+    super.onNestedScroll(
+        coordinatorLayout,
+        child,
+        target,
+        dxConsumed,
+        dyConsumed,
+        dxUnconsumed,
+        dyUnconsumed,
+        type,
+        consumed);
+    if (dyConsumed > 0) {
+      // User scrolled down -> hide the FAB
+      List<View> dependencies = coordinatorLayout.getDependencies(child);
+      for (View view : dependencies) {
+        if (view instanceof FloatingActionButton) {
+          ((FloatingActionButton) view).hide();
         }
+      }
+    } else if (dyConsumed < 0) {
+      // User scrolled up -> show the FAB
+      List<View> dependencies = coordinatorLayout.getDependencies(child);
+      for (View view : dependencies) {
+        if (view instanceof FloatingActionButton && !HIDDEN.equals(view.getTag())) {
+          ((FloatingActionButton) view).show();
+        }
+      }
     }
+  }
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/FabAwareScrollBehavior.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/FabAwareScrollBehavior.java
@@ -31,7 +31,6 @@ import java.util.List;
  * {@link FloatingActionButton} when the user
  * scrolls down and shows it when the user scrolls up.
  */
-@SuppressWarnings("deprecation") // TODO: Uses deprecated onNestedScroll API
 public class FabAwareScrollBehavior extends AppBarLayout.ScrollingViewBehavior {
     static final Object HIDDEN = new Object();
 
@@ -86,9 +85,9 @@ public class FabAwareScrollBehavior extends AppBarLayout.ScrollingViewBehavior {
      */
     @Override
     public void onNestedScroll(@NonNull CoordinatorLayout coordinatorLayout, @NonNull View child, @NonNull View target,
-            int dxConsumed, int dyConsumed, int dxUnconsumed, int dyUnconsumed, int type) {
+            int dxConsumed, int dyConsumed, int dxUnconsumed, int dyUnconsumed, int type, @NonNull int[] consumed) {
         super.onNestedScroll(coordinatorLayout, child, target, dxConsumed, dyConsumed, dxUnconsumed, dyUnconsumed,
-                type);
+                type, consumed);
         if (dyConsumed > 0) {
             // User scrolled down -> hide the FAB
             List<View> dependencies = coordinatorLayout.getDependencies(child);

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/FabAwareScrollBehavior.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/FabAwareScrollBehavior.java
@@ -16,114 +16,94 @@
 package io.github.sheepdestroyer.materialisheep;
 
 import android.content.Context;
+import androidx.annotation.NonNull;
+import com.google.android.material.appbar.AppBarLayout;
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
+import androidx.core.view.ViewCompat;
 import android.util.AttributeSet;
 import android.view.View;
-import androidx.annotation.NonNull;
-import androidx.coordinatorlayout.widget.CoordinatorLayout;
-import androidx.core.view.ViewCompat;
-import com.google.android.material.appbar.AppBarLayout;
-import com.google.android.material.floatingactionbutton.FloatingActionButton;
+
 import java.util.List;
 
 /**
- * A {@link CoordinatorLayout.Behavior} that hides a {@link FloatingActionButton} when the user
+ * A {@link CoordinatorLayout.Behavior} that hides a
+ * {@link FloatingActionButton} when the user
  * scrolls down and shows it when the user scrolls up.
  */
 public class FabAwareScrollBehavior extends AppBarLayout.ScrollingViewBehavior {
-  static final Object HIDDEN = new Object();
+    static final Object HIDDEN = new Object();
 
-  public FabAwareScrollBehavior(Context context, AttributeSet attrs) {
-    super(context, attrs);
-  }
-
-  /**
-   * Determines whether the behavior depends on another view.
-   *
-   * @param parent The CoordinatorLayout parent.
-   * @param child The child view.
-   * @param dependency The dependency view.
-   * @return True if the behavior depends on the dependency, false otherwise.
-   */
-  @Override
-  public boolean layoutDependsOn(CoordinatorLayout parent, View child, View dependency) {
-    return super.layoutDependsOn(parent, child, dependency)
-        || dependency instanceof FloatingActionButton;
-  }
-
-  /**
-   * Called when a nested scroll is about to start.
-   *
-   * @param coordinatorLayout The CoordinatorLayout parent.
-   * @param child The child view.
-   * @param directTargetChild The direct target of the scroll.
-   * @param target The target of the scroll.
-   * @param axes The scroll axes.
-   * @param type The type of the scroll.
-   * @return True if the behavior accepts the nested scroll, false otherwise.
-   */
-  @Override
-  public boolean onStartNestedScroll(
-      @NonNull CoordinatorLayout coordinatorLayout,
-      @NonNull View child,
-      @NonNull View directTargetChild,
-      @NonNull View target,
-      int axes,
-      int type) {
-    // Ensure we react to vertical scrolling
-    return axes == ViewCompat.SCROLL_AXIS_VERTICAL
-        || super.onStartNestedScroll(
-            coordinatorLayout, child, directTargetChild, target, axes, type);
-  }
-
-  /**
-   * Called when a nested scroll is in progress.
-   *
-   * @param coordinatorLayout The CoordinatorLayout parent.
-   * @param child The child view.
-   * @param target The target of the scroll.
-   * @param dxConsumed The horizontal distance consumed by the target.
-   * @param dyConsumed The vertical distance consumed by the target.
-   * @param dxUnconsumed The horizontal distance not consumed by the target.
-   * @param dyUnconsumed The vertical distance not consumed by the target.
-   * @param type The type of the scroll.
-   */
-  @Override
-  public void onNestedScroll(
-      @NonNull CoordinatorLayout coordinatorLayout,
-      @NonNull View child,
-      @NonNull View target,
-      int dxConsumed,
-      int dyConsumed,
-      int dxUnconsumed,
-      int dyUnconsumed,
-      int type,
-      @NonNull int[] consumed) {
-    super.onNestedScroll(
-        coordinatorLayout,
-        child,
-        target,
-        dxConsumed,
-        dyConsumed,
-        dxUnconsumed,
-        dyUnconsumed,
-        type,
-        consumed);
-    if (dyConsumed > 0) {
-      // User scrolled down -> hide the FAB
-      List<View> dependencies = coordinatorLayout.getDependencies(child);
-      for (View view : dependencies) {
-        if (view instanceof FloatingActionButton) {
-          ((FloatingActionButton) view).hide();
-        }
-      }
-    } else if (dyConsumed < 0) {
-      // User scrolled up -> show the FAB
-      List<View> dependencies = coordinatorLayout.getDependencies(child);
-      for (View view : dependencies) {
-        if (view instanceof FloatingActionButton && !HIDDEN.equals(view.getTag())) {
-          ((FloatingActionButton) view).show();
-        }
-      }
+    public FabAwareScrollBehavior(Context context, AttributeSet attrs) {
+        super(context, attrs);
     }
-  }
+
+    /**
+     * Determines whether the behavior depends on another view.
+     *
+     * @param parent     The CoordinatorLayout parent.
+     * @param child      The child view.
+     * @param dependency The dependency view.
+     * @return True if the behavior depends on the dependency, false otherwise.
+     */
+    @Override
+    public boolean layoutDependsOn(CoordinatorLayout parent, View child, View dependency) {
+        return super.layoutDependsOn(parent, child, dependency) ||
+                dependency instanceof FloatingActionButton;
+    }
+
+    /**
+     * Called when a nested scroll is about to start.
+     *
+     * @param coordinatorLayout The CoordinatorLayout parent.
+     * @param child             The child view.
+     * @param directTargetChild The direct target of the scroll.
+     * @param target            The target of the scroll.
+     * @param axes              The scroll axes.
+     * @param type              The type of the scroll.
+     * @return True if the behavior accepts the nested scroll, false otherwise.
+     */
+    @Override
+    public boolean onStartNestedScroll(@NonNull CoordinatorLayout coordinatorLayout, @NonNull View child,
+            @NonNull View directTargetChild, @NonNull View target, int axes, int type) {
+        // Ensure we react to vertical scrolling
+        return axes == ViewCompat.SCROLL_AXIS_VERTICAL
+                || super.onStartNestedScroll(coordinatorLayout, child, directTargetChild, target, axes, type);
+    }
+
+    /**
+     * Called when a nested scroll is in progress.
+     *
+     * @param coordinatorLayout The CoordinatorLayout parent.
+     * @param child             The child view.
+     * @param target            The target of the scroll.
+     * @param dxConsumed        The horizontal distance consumed by the target.
+     * @param dyConsumed        The vertical distance consumed by the target.
+     * @param dxUnconsumed      The horizontal distance not consumed by the target.
+     * @param dyUnconsumed      The vertical distance not consumed by the target.
+     * @param type              The type of the scroll.
+     */
+    @Override
+    public void onNestedScroll(@NonNull CoordinatorLayout coordinatorLayout, @NonNull View child, @NonNull View target,
+            int dxConsumed, int dyConsumed, int dxUnconsumed, int dyUnconsumed, int type, @NonNull int[] consumed) {
+        super.onNestedScroll(coordinatorLayout, child, target, dxConsumed, dyConsumed, dxUnconsumed, dyUnconsumed,
+                type, consumed);
+        if (dyConsumed > 0) {
+            // User scrolled down -> hide the FAB
+            List<View> dependencies = coordinatorLayout.getDependencies(child);
+            for (View view : dependencies) {
+                if (view instanceof FloatingActionButton) {
+                    ((FloatingActionButton) view).hide();
+                }
+            }
+        } else if (dyConsumed < 0) {
+            // User scrolled up -> show the FAB
+            List<View> dependencies = coordinatorLayout.getDependencies(child);
+            for (View view : dependencies) {
+                if (view instanceof FloatingActionButton && !HIDDEN.equals(view.getTag())) {
+                    ((FloatingActionButton) view).show();
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
## What
Migrated `FabAwareScrollBehavior` away from the deprecated `onNestedScroll` API.

## Why
The older `onNestedScroll` overload is deprecated in AndroidX's `CoordinatorLayout.Behavior`. Using deprecated APIs causes compiler warnings and can lead to unexpected behavior or incompatibilities with newer Android Jetpack libraries.

## Impact
- `FabAwareScrollBehavior.java`

## Measurement
Confirmed successful project compilation and unit test passes without warnings for this class.

---
*PR created automatically by Jules for task [15897922501780180994](https://jules.google.com/task/15897922501780180994) started by @sheepdestroyer*

## Summary by Sourcery

Enhancements:
- Update FabAwareScrollBehavior to use the newer onNestedScroll overload that includes the consumed array parameter and drop the deprecation suppression on the behavior class.