### PR TITLE
Migrate deprecated Preference APIs in ThemePreference and SpinnerPreference

### DIFF
--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/preference/SpinnerPreference.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/preference/SpinnerPreference.java
@@ -19,8 +19,6 @@ package io.github.sheepdestroyer.materialisheep.preference;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.database.DataSetObserver;
-import androidx.preference.Preference;
-import androidx.preference.PreferenceViewHolder;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.view.View;
@@ -28,158 +26,157 @@ import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.Spinner;
 import android.widget.SpinnerAdapter;
-
+import androidx.preference.Preference;
+import androidx.preference.PreferenceViewHolder;
 import io.github.sheepdestroyer.materialisheep.R;
 import io.github.sheepdestroyer.materialisheep.annotation.Synthetic;
 
 /**
- * {@link Preference} with spinner as custom widget.
- * Entries, entry values and entry layouts should be provided via arrays.
- * Preference value will be persisted as string.
+ * {@link Preference} with spinner as custom widget. Entries, entry values and entry layouts should
+ * be provided via arrays. Preference value will be persisted as string.
  */
 public abstract class SpinnerPreference extends Preference {
-    @Synthetic
-    String[] mEntries = new String[0];
-    @Synthetic
-    String[] mEntryValues = new String[0];
-    @Synthetic
-    int mSelection = 0;
+  @Synthetic String[] mEntries = new String[0];
+  @Synthetic String[] mEntryValues = new String[0];
+  @Synthetic int mSelection = 0;
 
-    @SuppressWarnings("unused")
-    public SpinnerPreference(Context context, AttributeSet attrs) {
-        this(context, attrs, 0);
+  @SuppressWarnings("unused")
+  public SpinnerPreference(Context context, AttributeSet attrs) {
+    this(context, attrs, 0);
+  }
+
+  public SpinnerPreference(Context context, AttributeSet attrs, int defStyleAttr) {
+    super(context, attrs, defStyleAttr);
+    setWidgetLayoutResource(R.layout.preference_spinner);
+    init(context, attrs);
+  }
+
+  private void init(Context context, AttributeSet attrs) {
+    TypedArray ta = context.obtainStyledAttributes(attrs, R.styleable.SpinnerPreference);
+    int entriesResId = ta.getResourceId(R.styleable.SpinnerPreference_entries, 0);
+    if (entriesResId != 0) {
+      mEntries = context.getResources().getStringArray(entriesResId);
     }
-
-    public SpinnerPreference(Context context, AttributeSet attrs, int defStyleAttr) {
-        super(context, attrs, defStyleAttr);
-        setWidgetLayoutResource(R.layout.preference_spinner);
-        init(context, attrs);
+    int valuesResId = ta.getResourceId(R.styleable.SpinnerPreference_entryValues, 0);
+    if (valuesResId != 0) {
+      mEntryValues = context.getResources().getStringArray(valuesResId);
     }
+    ta.recycle();
+  }
 
-    private void init(Context context, AttributeSet attrs) {
-        TypedArray ta = context.obtainStyledAttributes(attrs, R.styleable.SpinnerPreference);
-        int entriesResId = ta.getResourceId(R.styleable.SpinnerPreference_entries, 0);
-        if (entriesResId != 0) {
-            mEntries = context.getResources().getStringArray(entriesResId);
-        }
-        int valuesResId = ta.getResourceId(R.styleable.SpinnerPreference_entryValues, 0);
-        if (valuesResId != 0) {
-            mEntryValues = context.getResources().getStringArray(valuesResId);
-        }
-        ta.recycle();
+  @Override
+  protected Object onGetDefaultValue(TypedArray a, int index) {
+    return a.getString(index);
+  }
+
+  @Override
+  protected void onSetInitialValue(Object defaultValue) {
+    super.onSetInitialValue(defaultValue);
+    String value = getPersistedString((String) defaultValue);
+    for (int i = 0; i < mEntryValues.length; i++) {
+      if (TextUtils.equals(mEntryValues[i], value)) {
+        mSelection = i;
+        break;
+      }
     }
+  }
 
-    @Override
-    protected Object onGetDefaultValue(TypedArray a, int index) {
-        return a.getString(index);
-    }
-
-    @Override
-    protected void onSetInitialValue(Object defaultValue) {
-        super.onSetInitialValue(defaultValue);
-        String value = getPersistedString((String) defaultValue);
-        for (int i = 0; i < mEntryValues.length; i++) {
-            if (TextUtils.equals(mEntryValues[i], value)) {
-                mSelection = i;
-                break;
+  @Override
+  public void onBindViewHolder(PreferenceViewHolder holder) {
+    super.onBindViewHolder(holder);
+    final Spinner spinner = (Spinner) holder.findViewById(R.id.spinner);
+    holder.itemView.setOnClickListener(v -> spinner.performClick());
+    spinner.setAdapter(
+        new SpinnerAdapter() {
+          @Override
+          public View getDropDownView(int position, View convertView, ViewGroup parent) {
+            if (convertView == null) {
+              convertView = createDropDownView(position, parent);
             }
-        }
-    }
+            bindDropDownView(position, convertView);
+            return convertView;
+          }
 
-    @Override
-    public void onBindViewHolder(PreferenceViewHolder holder) {
-        super.onBindViewHolder(holder);
-        final Spinner spinner = (Spinner) holder.findViewById(R.id.spinner);
-        holder.itemView.setOnClickListener(v -> spinner.performClick());
-        spinner.setAdapter(new SpinnerAdapter() {
-            @Override
-            public View getDropDownView(int position, View convertView, ViewGroup parent) {
-                if (convertView == null) {
-                    convertView = createDropDownView(position, parent);
-                }
-                bindDropDownView(position, convertView);
-                return convertView;
-            }
+          @Override
+          public void registerDataSetObserver(DataSetObserver observer) {
+            // no op
+          }
 
-            @Override
-            public void registerDataSetObserver(DataSetObserver observer) {
-                // no op
-            }
+          @Override
+          public void unregisterDataSetObserver(DataSetObserver observer) {
+            // no op
+          }
 
-            @Override
-            public void unregisterDataSetObserver(DataSetObserver observer) {
-                // no op
-            }
+          @Override
+          public int getCount() {
+            return mEntries.length;
+          }
 
-            @Override
-            public int getCount() {
-                return mEntries.length;
-            }
+          @Override
+          public Object getItem(int position) {
+            return null; // not applicable
+          }
 
-            @Override
-            public Object getItem(int position) {
-                return null; // not applicable
-            }
+          @Override
+          public long getItemId(int position) {
+            return position;
+          }
 
-            @Override
-            public long getItemId(int position) {
-                return position;
-            }
+          @Override
+          public boolean hasStableIds() {
+            return true;
+          }
 
-            @Override
-            public boolean hasStableIds() {
-                return true;
-            }
+          @Override
+          public View getView(int position, View convertView, ViewGroup parent) {
+            return getDropDownView(position, convertView, parent);
+          }
 
-            @Override
-            public View getView(int position, View convertView, ViewGroup parent) {
-                return getDropDownView(position, convertView, parent);
-            }
+          @Override
+          public int getItemViewType(int position) {
+            return 0;
+          }
 
-            @Override
-            public int getItemViewType(int position) {
-                return 0;
-            }
+          @Override
+          public int getViewTypeCount() {
+            return 1;
+          }
 
-            @Override
-            public int getViewTypeCount() {
-                return 1;
-            }
-
-            @Override
-            public boolean isEmpty() {
-                return false;
-            }
+          @Override
+          public boolean isEmpty() {
+            return false;
+          }
         });
-        spinner.setSelection(mSelection);
-        spinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
-            @Override
-            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
-                mSelection = position;
-                persistString(mEntryValues[position]);
-            }
+    spinner.setSelection(mSelection);
+    spinner.setOnItemSelectedListener(
+        new AdapterView.OnItemSelectedListener() {
+          @Override
+          public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+            mSelection = position;
+            persistString(mEntryValues[position]);
+          }
 
-            @Override
-            public void onNothingSelected(AdapterView<?> parent) {
-                // no op
-            }
+          @Override
+          public void onNothingSelected(AdapterView<?> parent) {
+            // no op
+          }
         });
-    }
+  }
 
-    /**
-     * Create dropdown view for item at given position
-     *
-     * @param position item position
-     * @param parent   parent view
-     * @return created view
-     */
-    protected abstract View createDropDownView(int position, ViewGroup parent);
+  /**
+   * Create dropdown view for item at given position
+   *
+   * @param position item position
+   * @param parent parent view
+   * @return created view
+   */
+  protected abstract View createDropDownView(int position, ViewGroup parent);
 
-    /**
-     * Customize dropdown view for given spinner item
-     *
-     * @param position item position
-     * @param view     item view
-     */
-    protected abstract void bindDropDownView(int position, View view);
+  /**
+   * Customize dropdown view for given spinner item
+   *
+   * @param position item position
+   * @param view item view
+   */
+  protected abstract void bindDropDownView(int position, View view);
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/preference/SpinnerPreference.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/preference/SpinnerPreference.java
@@ -41,11 +41,11 @@ public abstract class SpinnerPreference extends Preference {
   @Synthetic int mSelection = 0;
 
   @SuppressWarnings("unused")
-  public SpinnerPreference(Context context, AttributeSet attrs) {
+  protected SpinnerPreference(Context context, AttributeSet attrs) {
     this(context, attrs, 0);
   }
 
-  public SpinnerPreference(Context context, AttributeSet attrs, int defStyleAttr) {
+  protected SpinnerPreference(Context context, AttributeSet attrs, int defStyleAttr) {
     super(context, attrs, defStyleAttr);
     setWidgetLayoutResource(R.layout.preference_spinner);
     init(context, attrs);

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/preference/SpinnerPreference.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/preference/SpinnerPreference.java
@@ -19,8 +19,6 @@ package io.github.sheepdestroyer.materialisheep.preference;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.database.DataSetObserver;
-import androidx.preference.Preference;
-import androidx.preference.PreferenceViewHolder;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.view.View;
@@ -28,158 +26,157 @@ import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.Spinner;
 import android.widget.SpinnerAdapter;
-
+import androidx.preference.Preference;
+import androidx.preference.PreferenceViewHolder;
 import io.github.sheepdestroyer.materialisheep.R;
 import io.github.sheepdestroyer.materialisheep.annotation.Synthetic;
 
 /**
- * {@link Preference} with spinner as custom widget.
- * Entries, entry values and entry layouts should be provided via arrays.
- * Preference value will be persisted as string.
+ * {@link Preference} with spinner as custom widget. Entries, entry values and entry layouts should
+ * be provided via arrays. Preference value will be persisted as string.
  */
 public abstract class SpinnerPreference extends Preference {
-    @Synthetic
-    String[] mEntries = new String[0];
-    @Synthetic
-    String[] mEntryValues = new String[0];
-    @Synthetic
-    int mSelection = 0;
+  @Synthetic String[] mEntries = new String[0];
+  @Synthetic String[] mEntryValues = new String[0];
+  @Synthetic int mSelection = 0;
 
-    @SuppressWarnings("unused")
-    public SpinnerPreference(Context context, AttributeSet attrs) {
-        this(context, attrs, 0);
+  @SuppressWarnings("unused")
+  public SpinnerPreference(Context context, AttributeSet attrs) {
+    this(context, attrs, 0);
+  }
+
+  public SpinnerPreference(Context context, AttributeSet attrs, int defStyleAttr) {
+    super(context, attrs, defStyleAttr);
+    setWidgetLayoutResource(R.layout.preference_spinner);
+    init(context, attrs);
+  }
+
+  private void init(Context context, AttributeSet attrs) {
+    TypedArray ta = context.obtainStyledAttributes(attrs, R.styleable.SpinnerPreference);
+    int entriesResId = ta.getResourceId(R.styleable.SpinnerPreference_entries, 0);
+    if (entriesResId != 0) {
+      mEntries = context.getResources().getStringArray(entriesResId);
     }
-
-    public SpinnerPreference(Context context, AttributeSet attrs, int defStyleAttr) {
-        super(context, attrs, defStyleAttr);
-        setWidgetLayoutResource(R.layout.preference_spinner);
-        init(context, attrs);
+    int valuesResId = ta.getResourceId(R.styleable.SpinnerPreference_entryValues, 0);
+    if (valuesResId != 0) {
+      mEntryValues = context.getResources().getStringArray(valuesResId);
     }
+    ta.recycle();
+  }
 
-    private void init(Context context, AttributeSet attrs) {
-        TypedArray ta = context.obtainStyledAttributes(attrs, R.styleable.SpinnerPreference);
-        int entriesResId = ta.getResourceId(R.styleable.SpinnerPreference_entries, 0);
-        if (entriesResId != 0) {
-            mEntries = context.getResources().getStringArray(entriesResId);
-        }
-        int valuesResId = ta.getResourceId(R.styleable.SpinnerPreference_entryValues, 0);
-        if (valuesResId != 0) {
-            mEntryValues = context.getResources().getStringArray(valuesResId);
-        }
-        ta.recycle();
+  @Override
+  protected Object onGetDefaultValue(TypedArray a, int index) {
+    return a.getString(index);
+  }
+
+  @Override
+  protected void onSetInitialValue(Object defaultValue) {
+    super.onSetInitialValue(defaultValue);
+    String value = getPersistedString((String) defaultValue);
+    for (int i = 0; i < mEntryValues.length; i++) {
+      if (TextUtils.equals(mEntryValues[i], value)) {
+        mSelection = i;
+        break;
+      }
     }
+  }
 
-    @Override
-    protected Object onGetDefaultValue(TypedArray a, int index) {
-        return a.getString(index);
-    }
-
-    @Override
-    protected void onSetInitialValue(Object defaultValue) {
-        super.onSetInitialValue(defaultValue);
-        String value = getPersistedString((String) defaultValue);
-        for (int i = 0; i < mEntryValues.length; i++) {
-            if (TextUtils.equals(mEntryValues[i], value)) {
-                mSelection = i;
-                break;
+  @Override
+  public void onBindViewHolder(PreferenceViewHolder holder) {
+    super.onBindViewHolder(holder);
+    final Spinner spinner = (Spinner) holder.findViewById(R.id.spinner);
+    holder.itemView.setOnClickListener(v -> spinner.performClick());
+    spinner.setAdapter(
+        new SpinnerAdapter() {
+          @Override
+          public View getDropDownView(int position, View convertView, ViewGroup parent) {
+            if (convertView == null) {
+              convertView = createDropDownView(position, parent);
             }
-        }
-    }
+            bindDropDownView(position, convertView);
+            return convertView;
+          }
 
-    @Override
-    public void onBindViewHolder(PreferenceViewHolder holder) {
-        super.onBindViewHolder(holder);
-        final Spinner spinner = (Spinner) holder.findViewById(R.id.spinner);
-        holder.itemView.setOnClickListener(v -> spinner.performClick());
-        spinner.setAdapter(new SpinnerAdapter() {
-            @Override
-            public View getDropDownView(int position, View convertView, ViewGroup parent) {
-                if (convertView == null) {
-                    convertView = createDropDownView(position, parent);
-                }
-                bindDropDownView(position, convertView);
-                return convertView;
-            }
+          @Override
+          public void registerDataSetObserver(DataSetObserver observer) {
+            // no op
+          }
 
-            @Override
-            public void registerDataSetObserver(DataSetObserver observer) {
-                // no op
-            }
+          @Override
+          public void unregisterDataSetObserver(DataSetObserver observer) {
+            // no op
+          }
 
-            @Override
-            public void unregisterDataSetObserver(DataSetObserver observer) {
-                // no op
-            }
+          @Override
+          public int getCount() {
+            return mEntries.length;
+          }
 
-            @Override
-            public int getCount() {
-                return mEntries.length;
-            }
+          @Override
+          public Object getItem(int position) {
+            return null; // not applicable
+          }
 
-            @Override
-            public Object getItem(int position) {
-                return null; // not applicable
-            }
+          @Override
+          public long getItemId(int position) {
+            return position;
+          }
 
-            @Override
-            public long getItemId(int position) {
-                return position;
-            }
+          @Override
+          public boolean hasStableIds() {
+            return true;
+          }
 
-            @Override
-            public boolean hasStableIds() {
-                return true;
-            }
+          @Override
+          public View getView(int position, View convertView, ViewGroup parent) {
+            return getDropDownView(position, convertView, parent);
+          }
 
-            @Override
-            public View getView(int position, View convertView, ViewGroup parent) {
-                return getDropDownView(position, convertView, parent);
-            }
+          @Override
+          public int getItemViewType(int position) {
+            return 0;
+          }
 
-            @Override
-            public int getItemViewType(int position) {
-                return 0;
-            }
+          @Override
+          public int getViewTypeCount() {
+            return 1;
+          }
 
-            @Override
-            public int getViewTypeCount() {
-                return 1;
-            }
-
-            @Override
-            public boolean isEmpty() {
-                return false;
-            }
+          @Override
+          public boolean isEmpty() {
+            return false;
+          }
         });
-        spinner.setSelection(mSelection);
-        spinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
-            @Override
-            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
-                mSelection = position;
-                persistString(mEntryValues[position]);
-            }
+    spinner.setSelection(mSelection);
+    spinner.setOnItemSelectedListener(
+        new AdapterView.OnItemSelectedListener() {
+          @Override
+          public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+            mSelection = position;
+            persistString(mEntryValues[position]);
+          }
 
-            @Override
-            public void onNothingSelected(AdapterView<?> parent) {
-                // no op
-            }
+          @Override
+          public void onNothingSelected(AdapterView<?> parent) {
+            // no op
+          }
         });
-    }
+  }
 
-    /**
-     * Create dropdown view for item at given position
-     * 
-     * @param position item position
-     * @param parent   parent view
-     * @return created view
-     */
-    protected abstract View createDropDownView(int position, ViewGroup parent);
+  /**
+   * Create dropdown view for item at given position
+   *
+   * @param position item position
+   * @param parent parent view
+   * @return created view
+   */
+  protected abstract View createDropDownView(int position, ViewGroup parent);
 
-    /**
-     * Customize dropdown view for given spinner item
-     * 
-     * @param position item position
-     * @param view     item view
-     */
-    protected abstract void bindDropDownView(int position, View view);
+  /**
+   * Customize dropdown view for given spinner item
+   *
+   * @param position item position
+   * @param view item view
+   */
+  protected abstract void bindDropDownView(int position, View view);
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/preference/SpinnerPreference.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/preference/SpinnerPreference.java
@@ -19,6 +19,8 @@ package io.github.sheepdestroyer.materialisheep.preference;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.database.DataSetObserver;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceViewHolder;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.view.View;
@@ -26,157 +28,158 @@ import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.Spinner;
 import android.widget.SpinnerAdapter;
-import androidx.preference.Preference;
-import androidx.preference.PreferenceViewHolder;
+
 import io.github.sheepdestroyer.materialisheep.R;
 import io.github.sheepdestroyer.materialisheep.annotation.Synthetic;
 
 /**
- * {@link Preference} with spinner as custom widget. Entries, entry values and entry layouts should
- * be provided via arrays. Preference value will be persisted as string.
+ * {@link Preference} with spinner as custom widget.
+ * Entries, entry values and entry layouts should be provided via arrays.
+ * Preference value will be persisted as string.
  */
 public abstract class SpinnerPreference extends Preference {
-  @Synthetic String[] mEntries = new String[0];
-  @Synthetic String[] mEntryValues = new String[0];
-  @Synthetic int mSelection = 0;
+    @Synthetic
+    String[] mEntries = new String[0];
+    @Synthetic
+    String[] mEntryValues = new String[0];
+    @Synthetic
+    int mSelection = 0;
 
-  @SuppressWarnings("unused")
-  public SpinnerPreference(Context context, AttributeSet attrs) {
-    this(context, attrs, 0);
-  }
-
-  public SpinnerPreference(Context context, AttributeSet attrs, int defStyleAttr) {
-    super(context, attrs, defStyleAttr);
-    setWidgetLayoutResource(R.layout.preference_spinner);
-    init(context, attrs);
-  }
-
-  private void init(Context context, AttributeSet attrs) {
-    TypedArray ta = context.obtainStyledAttributes(attrs, R.styleable.SpinnerPreference);
-    int entriesResId = ta.getResourceId(R.styleable.SpinnerPreference_entries, 0);
-    if (entriesResId != 0) {
-      mEntries = context.getResources().getStringArray(entriesResId);
+    @SuppressWarnings("unused")
+    public SpinnerPreference(Context context, AttributeSet attrs) {
+        this(context, attrs, 0);
     }
-    int valuesResId = ta.getResourceId(R.styleable.SpinnerPreference_entryValues, 0);
-    if (valuesResId != 0) {
-      mEntryValues = context.getResources().getStringArray(valuesResId);
+
+    public SpinnerPreference(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        setWidgetLayoutResource(R.layout.preference_spinner);
+        init(context, attrs);
     }
-    ta.recycle();
-  }
 
-  @Override
-  protected Object onGetDefaultValue(TypedArray a, int index) {
-    return a.getString(index);
-  }
-
-  @Override
-  protected void onSetInitialValue(Object defaultValue) {
-    super.onSetInitialValue(defaultValue);
-    String value = getPersistedString((String) defaultValue);
-    for (int i = 0; i < mEntryValues.length; i++) {
-      if (TextUtils.equals(mEntryValues[i], value)) {
-        mSelection = i;
-        break;
-      }
+    private void init(Context context, AttributeSet attrs) {
+        TypedArray ta = context.obtainStyledAttributes(attrs, R.styleable.SpinnerPreference);
+        int entriesResId = ta.getResourceId(R.styleable.SpinnerPreference_entries, 0);
+        if (entriesResId != 0) {
+            mEntries = context.getResources().getStringArray(entriesResId);
+        }
+        int valuesResId = ta.getResourceId(R.styleable.SpinnerPreference_entryValues, 0);
+        if (valuesResId != 0) {
+            mEntryValues = context.getResources().getStringArray(valuesResId);
+        }
+        ta.recycle();
     }
-  }
 
-  @Override
-  public void onBindViewHolder(PreferenceViewHolder holder) {
-    super.onBindViewHolder(holder);
-    final Spinner spinner = (Spinner) holder.findViewById(R.id.spinner);
-    holder.itemView.setOnClickListener(v -> spinner.performClick());
-    spinner.setAdapter(
-        new SpinnerAdapter() {
-          @Override
-          public View getDropDownView(int position, View convertView, ViewGroup parent) {
-            if (convertView == null) {
-              convertView = createDropDownView(position, parent);
+    @Override
+    protected Object onGetDefaultValue(TypedArray a, int index) {
+        return a.getString(index);
+    }
+
+    @Override
+    protected void onSetInitialValue(Object defaultValue) {
+        super.onSetInitialValue(defaultValue);
+        String value = getPersistedString((String) defaultValue);
+        for (int i = 0; i < mEntryValues.length; i++) {
+            if (TextUtils.equals(mEntryValues[i], value)) {
+                mSelection = i;
+                break;
             }
-            bindDropDownView(position, convertView);
-            return convertView;
-          }
+        }
+    }
 
-          @Override
-          public void registerDataSetObserver(DataSetObserver observer) {
-            // no op
-          }
+    @Override
+    public void onBindViewHolder(PreferenceViewHolder holder) {
+        super.onBindViewHolder(holder);
+        final Spinner spinner = (Spinner) holder.findViewById(R.id.spinner);
+        holder.itemView.setOnClickListener(v -> spinner.performClick());
+        spinner.setAdapter(new SpinnerAdapter() {
+            @Override
+            public View getDropDownView(int position, View convertView, ViewGroup parent) {
+                if (convertView == null) {
+                    convertView = createDropDownView(position, parent);
+                }
+                bindDropDownView(position, convertView);
+                return convertView;
+            }
 
-          @Override
-          public void unregisterDataSetObserver(DataSetObserver observer) {
-            // no op
-          }
+            @Override
+            public void registerDataSetObserver(DataSetObserver observer) {
+                // no op
+            }
 
-          @Override
-          public int getCount() {
-            return mEntries.length;
-          }
+            @Override
+            public void unregisterDataSetObserver(DataSetObserver observer) {
+                // no op
+            }
 
-          @Override
-          public Object getItem(int position) {
-            return null; // not applicable
-          }
+            @Override
+            public int getCount() {
+                return mEntries.length;
+            }
 
-          @Override
-          public long getItemId(int position) {
-            return position;
-          }
+            @Override
+            public Object getItem(int position) {
+                return null; // not applicable
+            }
 
-          @Override
-          public boolean hasStableIds() {
-            return true;
-          }
+            @Override
+            public long getItemId(int position) {
+                return position;
+            }
 
-          @Override
-          public View getView(int position, View convertView, ViewGroup parent) {
-            return getDropDownView(position, convertView, parent);
-          }
+            @Override
+            public boolean hasStableIds() {
+                return true;
+            }
 
-          @Override
-          public int getItemViewType(int position) {
-            return 0;
-          }
+            @Override
+            public View getView(int position, View convertView, ViewGroup parent) {
+                return getDropDownView(position, convertView, parent);
+            }
 
-          @Override
-          public int getViewTypeCount() {
-            return 1;
-          }
+            @Override
+            public int getItemViewType(int position) {
+                return 0;
+            }
 
-          @Override
-          public boolean isEmpty() {
-            return false;
-          }
+            @Override
+            public int getViewTypeCount() {
+                return 1;
+            }
+
+            @Override
+            public boolean isEmpty() {
+                return false;
+            }
         });
-    spinner.setSelection(mSelection);
-    spinner.setOnItemSelectedListener(
-        new AdapterView.OnItemSelectedListener() {
-          @Override
-          public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
-            mSelection = position;
-            persistString(mEntryValues[position]);
-          }
+        spinner.setSelection(mSelection);
+        spinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+                mSelection = position;
+                persistString(mEntryValues[position]);
+            }
 
-          @Override
-          public void onNothingSelected(AdapterView<?> parent) {
-            // no op
-          }
+            @Override
+            public void onNothingSelected(AdapterView<?> parent) {
+                // no op
+            }
         });
-  }
+    }
 
-  /**
-   * Create dropdown view for item at given position
-   *
-   * @param position item position
-   * @param parent parent view
-   * @return created view
-   */
-  protected abstract View createDropDownView(int position, ViewGroup parent);
+    /**
+     * Create dropdown view for item at given position
+     *
+     * @param position item position
+     * @param parent   parent view
+     * @return created view
+     */
+    protected abstract View createDropDownView(int position, ViewGroup parent);
 
-  /**
-   * Customize dropdown view for given spinner item
-   *
-   * @param position item position
-   * @param view item view
-   */
-  protected abstract void bindDropDownView(int position, View view);
+    /**
+     * Customize dropdown view for given spinner item
+     *
+     * @param position item position
+     * @param view     item view
+     */
+    protected abstract void bindDropDownView(int position, View view);
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/preference/SpinnerPreference.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/preference/SpinnerPreference.java
@@ -37,7 +37,6 @@ import io.github.sheepdestroyer.materialisheep.annotation.Synthetic;
  * Entries, entry values and entry layouts should be provided via arrays.
  * Preference value will be persisted as string.
  */
-@SuppressWarnings("deprecation") // TODO: Uses deprecated Preference APIs
 public abstract class SpinnerPreference extends Preference {
     @Synthetic
     String[] mEntries = new String[0];
@@ -76,9 +75,9 @@ public abstract class SpinnerPreference extends Preference {
     }
 
     @Override
-    protected void onSetInitialValue(boolean restorePersistedValue, Object defaultValue) {
-        super.onSetInitialValue(restorePersistedValue, defaultValue);
-        String value = restorePersistedValue ? getPersistedString(null) : (String) defaultValue;
+    protected void onSetInitialValue(Object defaultValue) {
+        super.onSetInitialValue(defaultValue);
+        String value = getPersistedString((String) defaultValue);
         for (int i = 0; i < mEntryValues.length; i++) {
             if (TextUtils.equals(mEntryValues[i], value)) {
                 mSelection = i;

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/preference/ThemePreference.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/preference/ThemePreference.java
@@ -18,160 +18,160 @@ package io.github.sheepdestroyer.materialisheep.preference;
 
 import android.content.Context;
 import android.content.res.TypedArray;
-import android.text.TextUtils;
-import android.util.AttributeSet;
-import android.view.View;
 import androidx.annotation.StringRes;
 import androidx.annotation.StyleRes;
 import androidx.collection.ArrayMap;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceViewHolder;
+import android.text.TextUtils;
+import android.util.AttributeSet;
+import android.view.View;
+
 import io.github.sheepdestroyer.materialisheep.Preferences;
 import io.github.sheepdestroyer.materialisheep.R;
 import io.github.sheepdestroyer.materialisheep.annotation.Synthetic;
 
 public class ThemePreference extends Preference {
 
-  private static final String LIGHT = "light";
-  private static final String DARK = "dark";
-  private static final String BLACK = "black";
-  private static final String SEPIA = "sepia";
-  private static final String GREEN = "green";
-  private static final String SOLARIZED = "solarized";
-  private static final String SOLARIZED_DARK = "solarized_dark";
-  private static final ArrayMap<Integer, String> BUTTONS = new ArrayMap<>();
-  private static final ArrayMap<String, ThemeSpec> VALUES = new ArrayMap<>();
+    private static final String LIGHT = "light";
+    private static final String DARK = "dark";
+    private static final String BLACK = "black";
+    private static final String SEPIA = "sepia";
+    private static final String GREEN = "green";
+    private static final String SOLARIZED = "solarized";
+    private static final String SOLARIZED_DARK = "solarized_dark";
+    private static final ArrayMap<Integer, String> BUTTONS = new ArrayMap<>();
+    private static final ArrayMap<String, ThemeSpec> VALUES = new ArrayMap<>();
+    static {
+        BUTTONS.put(R.id.theme_light, LIGHT);
+        BUTTONS.put(R.id.theme_dark, DARK);
+        BUTTONS.put(R.id.theme_black, BLACK);
+        BUTTONS.put(R.id.theme_sepia, SEPIA);
+        BUTTONS.put(R.id.theme_green, GREEN);
+        BUTTONS.put(R.id.theme_solarized, SOLARIZED);
+        BUTTONS.put(R.id.theme_solarized_dark, SOLARIZED_DARK);
 
-  static {
-    BUTTONS.put(R.id.theme_light, LIGHT);
-    BUTTONS.put(R.id.theme_dark, DARK);
-    BUTTONS.put(R.id.theme_black, BLACK);
-    BUTTONS.put(R.id.theme_sepia, SEPIA);
-    BUTTONS.put(R.id.theme_green, GREEN);
-    BUTTONS.put(R.id.theme_solarized, SOLARIZED);
-    BUTTONS.put(R.id.theme_solarized_dark, SOLARIZED_DARK);
-
-    VALUES.put(LIGHT, new DayNightSpec(R.string.theme_light));
-    VALUES.put(DARK, new DarkSpec(R.string.theme_dark));
-    VALUES.put(BLACK, new DarkSpec(R.string.theme_black, R.style.Black));
-    VALUES.put(SEPIA, new DayNightSpec(R.string.theme_sepia, R.style.Sepia));
-    VALUES.put(GREEN, new DayNightSpec(R.string.theme_green, R.style.Green));
-    VALUES.put(SOLARIZED, new DayNightSpec(R.string.theme_solarized, R.style.Solarized));
-    VALUES.put(SOLARIZED_DARK, new DarkSpec(R.string.theme_solarized_dark, R.style.Solarized_Dark));
-  }
-
-  private String mSelectedTheme;
-
-  public static ThemeSpec getTheme(String value, boolean isTranslucent) {
-    ThemeSpec themeSpec = VALUES.get(VALUES.containsKey(value) ? value : LIGHT);
-    return isTranslucent ? themeSpec.getTranslucent() : themeSpec;
-  }
-
-  @SuppressWarnings("unused")
-  public ThemePreference(Context context, AttributeSet attrs) {
-    this(context, attrs, 0);
-  }
-
-  public ThemePreference(Context context, AttributeSet attrs, int defStyleAttr) {
-    super(context, attrs, defStyleAttr);
-    setLayoutResource(R.layout.preference_theme);
-  }
-
-  @Override
-  protected Object onGetDefaultValue(TypedArray a, int index) {
-    return LIGHT;
-  }
-
-  @Override
-  protected void onSetInitialValue(Object defaultValue) {
-    super.onSetInitialValue(defaultValue);
-    mSelectedTheme = getPersistedString((String) defaultValue);
-    if (TextUtils.isEmpty(mSelectedTheme)) {
-      mSelectedTheme = LIGHT;
+        VALUES.put(LIGHT, new DayNightSpec(R.string.theme_light));
+        VALUES.put(DARK, new DarkSpec(R.string.theme_dark));
+        VALUES.put(BLACK, new DarkSpec(R.string.theme_black, R.style.Black));
+        VALUES.put(SEPIA, new DayNightSpec(R.string.theme_sepia, R.style.Sepia));
+        VALUES.put(GREEN, new DayNightSpec(R.string.theme_green, R.style.Green));
+        VALUES.put(SOLARIZED, new DayNightSpec(R.string.theme_solarized, R.style.Solarized));
+        VALUES.put(SOLARIZED_DARK, new DarkSpec(R.string.theme_solarized_dark,
+                R.style.Solarized_Dark));
     }
-    setSummary(VALUES.get(mSelectedTheme).summary);
-  }
 
-  @Override
-  public void onBindViewHolder(PreferenceViewHolder holder) {
-    super.onBindViewHolder(holder);
-    holder.itemView.setClickable(false);
-    for (int i = 0; i < BUTTONS.size(); i++) {
-      final int buttonId = BUTTONS.keyAt(i);
-      final String value = BUTTONS.valueAt(i);
-      View button = holder.findViewById(buttonId);
-      button.setClickable(true);
-      button.setOnClickListener(
-          v -> {
-            mSelectedTheme = value;
-            if (shouldDisableDependents()) {
-              Preferences.Theme.disableAutoDayNight(getContext());
+    private String mSelectedTheme;
+
+    public static ThemeSpec getTheme(String value, boolean isTranslucent) {
+        ThemeSpec themeSpec = VALUES.get(VALUES.containsKey(value) ? value : LIGHT);
+        return isTranslucent ? themeSpec.getTranslucent() : themeSpec;
+    }
+
+    @SuppressWarnings("unused")
+    public ThemePreference(Context context, AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public ThemePreference(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        setLayoutResource(R.layout.preference_theme);
+    }
+
+    @Override
+    protected Object onGetDefaultValue(TypedArray a, int index) {
+        return LIGHT;
+    }
+
+    @Override
+    protected void onSetInitialValue(Object defaultValue) {
+        super.onSetInitialValue(defaultValue);
+        mSelectedTheme = getPersistedString((String) defaultValue);
+        if (TextUtils.isEmpty(mSelectedTheme)) {
+            mSelectedTheme = LIGHT;
+        }
+        setSummary(VALUES.get(mSelectedTheme).summary);
+    }
+
+    @Override
+    public void onBindViewHolder(PreferenceViewHolder holder) {
+        super.onBindViewHolder(holder);
+        holder.itemView.setClickable(false);
+        for (int i = 0; i < BUTTONS.size(); i++) {
+            final int buttonId = BUTTONS.keyAt(i);
+            final String value = BUTTONS.valueAt(i);
+            View button = holder.findViewById(buttonId);
+            button.setClickable(true);
+            button.setOnClickListener(v -> {
+                mSelectedTheme = value;
+                if (shouldDisableDependents()) {
+                    Preferences.Theme.disableAutoDayNight(getContext());
+                }
+                setSummary(VALUES.get(value).summary);
+                persistString(value);
+            });
+        }
+    }
+
+    @Override
+    public boolean shouldDisableDependents() {
+        // assume only auto day-night is dependent
+        return !(VALUES.get(mSelectedTheme) instanceof DayNightSpec);
+    }
+
+    public static class ThemeSpec {
+        final @StringRes int summary;
+        public final @StyleRes int theme;
+        public final @StyleRes int themeOverrides;
+        ThemeSpec translucent;
+
+        @Synthetic
+        ThemeSpec(@StringRes int summary, @StyleRes int theme, @StyleRes int themeOverrides) {
+            this.summary = summary;
+            this.theme = theme;
+            this.themeOverrides = themeOverrides;
+        }
+
+        ThemeSpec getTranslucent() {
+            return this;
+        }
+    }
+
+    static class DarkSpec extends ThemeSpec {
+
+        DarkSpec(@StringRes int summary) {
+            this(summary, -1);
+        }
+
+        DarkSpec(@StringRes int summary, @StyleRes int themeOverrides) {
+            super(summary, R.style.AppTheme_Dark, themeOverrides);
+        }
+
+        @Override
+        ThemeSpec getTranslucent() {
+            if (translucent == null) {
+                translucent = new ThemeSpec(summary, R.style.AppTheme_Dark_Translucent, themeOverrides);
             }
-            setSummary(VALUES.get(value).summary);
-            persistString(value);
-          });
-    }
-  }
-
-  @Override
-  public boolean shouldDisableDependents() {
-    // assume only auto day-night is dependent
-    return !(VALUES.get(mSelectedTheme) instanceof DayNightSpec);
-  }
-
-  public static class ThemeSpec {
-    final @StringRes int summary;
-    public final @StyleRes int theme;
-    public final @StyleRes int themeOverrides;
-    ThemeSpec translucent;
-
-    @Synthetic
-    ThemeSpec(@StringRes int summary, @StyleRes int theme, @StyleRes int themeOverrides) {
-      this.summary = summary;
-      this.theme = theme;
-      this.themeOverrides = themeOverrides;
+            return translucent;
+        }
     }
 
-    ThemeSpec getTranslucent() {
-      return this;
+    public static class DayNightSpec extends ThemeSpec {
+
+        DayNightSpec(@StringRes int summary) {
+            this(summary, -1);
+        }
+
+        DayNightSpec(@StringRes int summary, @StyleRes int themeOverrides) {
+            super(summary, R.style.AppTheme_DayNight, themeOverrides);
+        }
+
+        @Override
+        ThemeSpec getTranslucent() {
+            if (translucent == null) {
+                translucent = new ThemeSpec(summary, R.style.AppTheme_Translucent, themeOverrides);
+            }
+            return translucent;
+        }
     }
-  }
-
-  static class DarkSpec extends ThemeSpec {
-
-    DarkSpec(@StringRes int summary) {
-      this(summary, -1);
-    }
-
-    DarkSpec(@StringRes int summary, @StyleRes int themeOverrides) {
-      super(summary, R.style.AppTheme_Dark, themeOverrides);
-    }
-
-    @Override
-    ThemeSpec getTranslucent() {
-      if (translucent == null) {
-        translucent = new ThemeSpec(summary, R.style.AppTheme_Dark_Translucent, themeOverrides);
-      }
-      return translucent;
-    }
-  }
-
-  public static class DayNightSpec extends ThemeSpec {
-
-    DayNightSpec(@StringRes int summary) {
-      this(summary, -1);
-    }
-
-    DayNightSpec(@StringRes int summary, @StyleRes int themeOverrides) {
-      super(summary, R.style.AppTheme_DayNight, themeOverrides);
-    }
-
-    @Override
-    ThemeSpec getTranslucent() {
-      if (translucent == null) {
-        translucent = new ThemeSpec(summary, R.style.AppTheme_Translucent, themeOverrides);
-      }
-      return translucent;
-    }
-  }
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/preference/ThemePreference.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/preference/ThemePreference.java
@@ -31,7 +31,6 @@ import io.github.sheepdestroyer.materialisheep.Preferences;
 import io.github.sheepdestroyer.materialisheep.R;
 import io.github.sheepdestroyer.materialisheep.annotation.Synthetic;
 
-@SuppressWarnings("deprecation") // TODO: Uses deprecated Preference APIs
 public class ThemePreference extends Preference {
 
     private static final String LIGHT = "light";
@@ -85,9 +84,9 @@ public class ThemePreference extends Preference {
     }
 
     @Override
-    protected void onSetInitialValue(boolean restorePersistedValue, Object defaultValue) {
-        super.onSetInitialValue(restorePersistedValue, defaultValue);
-        mSelectedTheme = restorePersistedValue ? getPersistedString(null) : (String) defaultValue;
+    protected void onSetInitialValue(Object defaultValue) {
+        super.onSetInitialValue(defaultValue);
+        mSelectedTheme = getPersistedString((String) defaultValue);
         if (TextUtils.isEmpty(mSelectedTheme)) {
             mSelectedTheme = LIGHT;
         }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/preference/ThemePreference.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/preference/ThemePreference.java
@@ -18,160 +18,160 @@ package io.github.sheepdestroyer.materialisheep.preference;
 
 import android.content.Context;
 import android.content.res.TypedArray;
+import android.text.TextUtils;
+import android.util.AttributeSet;
+import android.view.View;
 import androidx.annotation.StringRes;
 import androidx.annotation.StyleRes;
 import androidx.collection.ArrayMap;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceViewHolder;
-import android.text.TextUtils;
-import android.util.AttributeSet;
-import android.view.View;
-
 import io.github.sheepdestroyer.materialisheep.Preferences;
 import io.github.sheepdestroyer.materialisheep.R;
 import io.github.sheepdestroyer.materialisheep.annotation.Synthetic;
 
 public class ThemePreference extends Preference {
 
-    private static final String LIGHT = "light";
-    private static final String DARK = "dark";
-    private static final String BLACK = "black";
-    private static final String SEPIA = "sepia";
-    private static final String GREEN = "green";
-    private static final String SOLARIZED = "solarized";
-    private static final String SOLARIZED_DARK = "solarized_dark";
-    private static final ArrayMap<Integer, String> BUTTONS = new ArrayMap<>();
-    private static final ArrayMap<String, ThemeSpec> VALUES = new ArrayMap<>();
-    static {
-        BUTTONS.put(R.id.theme_light, LIGHT);
-        BUTTONS.put(R.id.theme_dark, DARK);
-        BUTTONS.put(R.id.theme_black, BLACK);
-        BUTTONS.put(R.id.theme_sepia, SEPIA);
-        BUTTONS.put(R.id.theme_green, GREEN);
-        BUTTONS.put(R.id.theme_solarized, SOLARIZED);
-        BUTTONS.put(R.id.theme_solarized_dark, SOLARIZED_DARK);
+  private static final String LIGHT = "light";
+  private static final String DARK = "dark";
+  private static final String BLACK = "black";
+  private static final String SEPIA = "sepia";
+  private static final String GREEN = "green";
+  private static final String SOLARIZED = "solarized";
+  private static final String SOLARIZED_DARK = "solarized_dark";
+  private static final ArrayMap<Integer, String> BUTTONS = new ArrayMap<>();
+  private static final ArrayMap<String, ThemeSpec> VALUES = new ArrayMap<>();
 
-        VALUES.put(LIGHT, new DayNightSpec(R.string.theme_light));
-        VALUES.put(DARK, new DarkSpec(R.string.theme_dark));
-        VALUES.put(BLACK, new DarkSpec(R.string.theme_black, R.style.Black));
-        VALUES.put(SEPIA, new DayNightSpec(R.string.theme_sepia, R.style.Sepia));
-        VALUES.put(GREEN, new DayNightSpec(R.string.theme_green, R.style.Green));
-        VALUES.put(SOLARIZED, new DayNightSpec(R.string.theme_solarized, R.style.Solarized));
-        VALUES.put(SOLARIZED_DARK, new DarkSpec(R.string.theme_solarized_dark,
-                R.style.Solarized_Dark));
+  static {
+    BUTTONS.put(R.id.theme_light, LIGHT);
+    BUTTONS.put(R.id.theme_dark, DARK);
+    BUTTONS.put(R.id.theme_black, BLACK);
+    BUTTONS.put(R.id.theme_sepia, SEPIA);
+    BUTTONS.put(R.id.theme_green, GREEN);
+    BUTTONS.put(R.id.theme_solarized, SOLARIZED);
+    BUTTONS.put(R.id.theme_solarized_dark, SOLARIZED_DARK);
+
+    VALUES.put(LIGHT, new DayNightSpec(R.string.theme_light));
+    VALUES.put(DARK, new DarkSpec(R.string.theme_dark));
+    VALUES.put(BLACK, new DarkSpec(R.string.theme_black, R.style.Black));
+    VALUES.put(SEPIA, new DayNightSpec(R.string.theme_sepia, R.style.Sepia));
+    VALUES.put(GREEN, new DayNightSpec(R.string.theme_green, R.style.Green));
+    VALUES.put(SOLARIZED, new DayNightSpec(R.string.theme_solarized, R.style.Solarized));
+    VALUES.put(SOLARIZED_DARK, new DarkSpec(R.string.theme_solarized_dark, R.style.Solarized_Dark));
+  }
+
+  private String mSelectedTheme;
+
+  public static ThemeSpec getTheme(String value, boolean isTranslucent) {
+    ThemeSpec themeSpec = VALUES.get(VALUES.containsKey(value) ? value : LIGHT);
+    return isTranslucent ? themeSpec.getTranslucent() : themeSpec;
+  }
+
+  @SuppressWarnings("unused")
+  public ThemePreference(Context context, AttributeSet attrs) {
+    this(context, attrs, 0);
+  }
+
+  public ThemePreference(Context context, AttributeSet attrs, int defStyleAttr) {
+    super(context, attrs, defStyleAttr);
+    setLayoutResource(R.layout.preference_theme);
+  }
+
+  @Override
+  protected Object onGetDefaultValue(TypedArray a, int index) {
+    return LIGHT;
+  }
+
+  @Override
+  protected void onSetInitialValue(Object defaultValue) {
+    super.onSetInitialValue(defaultValue);
+    mSelectedTheme = getPersistedString((String) defaultValue);
+    if (TextUtils.isEmpty(mSelectedTheme)) {
+      mSelectedTheme = LIGHT;
     }
+    setSummary(VALUES.get(mSelectedTheme).summary);
+  }
 
-    private String mSelectedTheme;
-
-    public static ThemeSpec getTheme(String value, boolean isTranslucent) {
-        ThemeSpec themeSpec = VALUES.get(VALUES.containsKey(value) ? value : LIGHT);
-        return isTranslucent ? themeSpec.getTranslucent() : themeSpec;
-    }
-
-    @SuppressWarnings("unused")
-    public ThemePreference(Context context, AttributeSet attrs) {
-        this(context, attrs, 0);
-    }
-
-    public ThemePreference(Context context, AttributeSet attrs, int defStyleAttr) {
-        super(context, attrs, defStyleAttr);
-        setLayoutResource(R.layout.preference_theme);
-    }
-
-    @Override
-    protected Object onGetDefaultValue(TypedArray a, int index) {
-        return LIGHT;
-    }
-
-    @Override
-    protected void onSetInitialValue(Object defaultValue) {
-        super.onSetInitialValue(defaultValue);
-        mSelectedTheme = getPersistedString((String) defaultValue);
-        if (TextUtils.isEmpty(mSelectedTheme)) {
-            mSelectedTheme = LIGHT;
-        }
-        setSummary(VALUES.get(mSelectedTheme).summary);
-    }
-
-    @Override
-    public void onBindViewHolder(PreferenceViewHolder holder) {
-        super.onBindViewHolder(holder);
-        holder.itemView.setClickable(false);
-        for (int i = 0; i < BUTTONS.size(); i++) {
-            final int buttonId = BUTTONS.keyAt(i);
-            final String value = BUTTONS.valueAt(i);
-            View button = holder.findViewById(buttonId);
-            button.setClickable(true);
-            button.setOnClickListener(v -> {
-                mSelectedTheme = value;
-                if (shouldDisableDependents()) {
-                    Preferences.Theme.disableAutoDayNight(getContext());
-                }
-                setSummary(VALUES.get(value).summary);
-                persistString(value);
-            });
-        }
-    }
-
-    @Override
-    public boolean shouldDisableDependents() {
-        // assume only auto day-night is dependent
-        return !(VALUES.get(mSelectedTheme) instanceof DayNightSpec);
-    }
-
-    public static class ThemeSpec {
-        final @StringRes int summary;
-        public final @StyleRes int theme;
-        public final @StyleRes int themeOverrides;
-        ThemeSpec translucent;
-
-        @Synthetic
-        ThemeSpec(@StringRes int summary, @StyleRes int theme, @StyleRes int themeOverrides) {
-            this.summary = summary;
-            this.theme = theme;
-            this.themeOverrides = themeOverrides;
-        }
-
-        ThemeSpec getTranslucent() {
-            return this;
-        }
-    }
-
-    static class DarkSpec extends ThemeSpec {
-
-        DarkSpec(@StringRes int summary) {
-            this(summary, -1);
-        }
-
-        DarkSpec(@StringRes int summary, @StyleRes int themeOverrides) {
-            super(summary, R.style.AppTheme_Dark, themeOverrides);
-        }
-
-        @Override
-        ThemeSpec getTranslucent() {
-            if (translucent == null) {
-                translucent = new ThemeSpec(summary, R.style.AppTheme_Dark_Translucent, themeOverrides);
+  @Override
+  public void onBindViewHolder(PreferenceViewHolder holder) {
+    super.onBindViewHolder(holder);
+    holder.itemView.setClickable(false);
+    for (int i = 0; i < BUTTONS.size(); i++) {
+      final int buttonId = BUTTONS.keyAt(i);
+      final String value = BUTTONS.valueAt(i);
+      View button = holder.findViewById(buttonId);
+      button.setClickable(true);
+      button.setOnClickListener(
+          v -> {
+            mSelectedTheme = value;
+            if (shouldDisableDependents()) {
+              Preferences.Theme.disableAutoDayNight(getContext());
             }
-            return translucent;
-        }
+            setSummary(VALUES.get(value).summary);
+            persistString(value);
+          });
+    }
+  }
+
+  @Override
+  public boolean shouldDisableDependents() {
+    // assume only auto day-night is dependent
+    return !(VALUES.get(mSelectedTheme) instanceof DayNightSpec);
+  }
+
+  public static class ThemeSpec {
+    final @StringRes int summary;
+    public final @StyleRes int theme;
+    public final @StyleRes int themeOverrides;
+    ThemeSpec translucent;
+
+    @Synthetic
+    ThemeSpec(@StringRes int summary, @StyleRes int theme, @StyleRes int themeOverrides) {
+      this.summary = summary;
+      this.theme = theme;
+      this.themeOverrides = themeOverrides;
     }
 
-    public static class DayNightSpec extends ThemeSpec {
-
-        DayNightSpec(@StringRes int summary) {
-            this(summary, -1);
-        }
-
-        DayNightSpec(@StringRes int summary, @StyleRes int themeOverrides) {
-            super(summary, R.style.AppTheme_DayNight, themeOverrides);
-        }
-
-        @Override
-        ThemeSpec getTranslucent() {
-            if (translucent == null) {
-                translucent = new ThemeSpec(summary, R.style.AppTheme_Translucent, themeOverrides);
-            }
-            return translucent;
-        }
+    ThemeSpec getTranslucent() {
+      return this;
     }
+  }
+
+  static class DarkSpec extends ThemeSpec {
+
+    DarkSpec(@StringRes int summary) {
+      this(summary, -1);
+    }
+
+    DarkSpec(@StringRes int summary, @StyleRes int themeOverrides) {
+      super(summary, R.style.AppTheme_Dark, themeOverrides);
+    }
+
+    @Override
+    ThemeSpec getTranslucent() {
+      if (translucent == null) {
+        translucent = new ThemeSpec(summary, R.style.AppTheme_Dark_Translucent, themeOverrides);
+      }
+      return translucent;
+    }
+  }
+
+  public static class DayNightSpec extends ThemeSpec {
+
+    DayNightSpec(@StringRes int summary) {
+      this(summary, -1);
+    }
+
+    DayNightSpec(@StringRes int summary, @StyleRes int themeOverrides) {
+      super(summary, R.style.AppTheme_DayNight, themeOverrides);
+    }
+
+    @Override
+    ThemeSpec getTranslucent() {
+      if (translucent == null) {
+        translucent = new ThemeSpec(summary, R.style.AppTheme_Translucent, themeOverrides);
+      }
+      return translucent;
+    }
+  }
 }


### PR DESCRIPTION
**What**: Replaced deprecated `onSetInitialValue(boolean, Object)` lifecycle methods inside `ThemePreference.java` and `SpinnerPreference.java` with their modern `onSetInitialValue(Object)` AndroidX equivalents.

**Why**: To eliminate deprecated `Preference` framework API warnings. Both classes were suppressing these warnings with `@SuppressWarnings("deprecation")`. Migrating to the current AndroidX signatures cleans up the codebase and ensures compatibility with current library versions.

**Impact**: 
- `ThemePreference` and `SpinnerPreference` no longer suppress deprecation warnings.
- State initialization via `getPersistedString()` behaves identically by utilizing the new signature's `defaultValue` fallback.

**Measurement**:
- Unit tests (`./gradlew testDebugUnitTest --no-daemon`) passed locally. No regressions in state management behavior.

---
*PR created automatically by Jules for task [12585009456408893579](https://jules.google.com/task/12585009456408893579) started by @sheepdestroyer*