### PR TITLE
Migrate deprecated Vibrator, Display, and GestureDetector APIs in NavFloatingActionButton

### DIFF
--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/NavFloatingActionButton.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/NavFloatingActionButton.java
@@ -17,11 +17,8 @@
 package io.github.sheepdestroyer.materialisheep.widget;
 
 import android.annotation.SuppressLint;
-import android.annotation.TargetApi;
-import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.os.Build;
 import android.os.VibrationEffect;
 import android.os.Vibrator;
 import android.os.VibratorManager;
@@ -31,254 +28,266 @@ import android.view.GestureDetector;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewTreeObserver;
-import android.view.WindowManager;
 import android.widget.Toast;
-
-import com.google.android.material.floatingactionbutton.FloatingActionButton;
-
-import java.util.Locale;
-
-import androidx.annotation.RequiresApi;
 import androidx.appcompat.app.AlertDialog;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import io.github.sheepdestroyer.materialisheep.AppUtils;
 import io.github.sheepdestroyer.materialisheep.Navigable;
 import io.github.sheepdestroyer.materialisheep.Preferences;
 import io.github.sheepdestroyer.materialisheep.R;
 import io.github.sheepdestroyer.materialisheep.annotation.Synthetic;
+import java.util.Locale;
 
-public class NavFloatingActionButton extends FloatingActionButton implements ViewTreeObserver.OnGlobalLayoutListener {
-    private static final String PREFERENCES_FAB = "_fab";
-    private static final String PREFERENCES_FAB_X = "%1$s_%2$d_%3$d_x";
-    private static final String PREFERENCES_FAB_Y = "%1$s_%2$d_%3$d_y";
-    private static final long VIBRATE_DURATION_MS = 15;
-    private static final int DOUBLE_TAP = -1;
-    private static final int[] KONAMI_CODE = {
-            Navigable.DIRECTION_UP,
-            Navigable.DIRECTION_UP,
-            Navigable.DIRECTION_DOWN,
-            Navigable.DIRECTION_DOWN,
-            Navigable.DIRECTION_LEFT,
-            Navigable.DIRECTION_RIGHT,
-            Navigable.DIRECTION_LEFT,
-            Navigable.DIRECTION_RIGHT,
-            DOUBLE_TAP
-    };
-    @Synthetic
-    final Vibrator mVibrator;
-    private final Preferences.Observable mPreferenceObservable = new Preferences.Observable();
-    @Synthetic
-    Navigable mNavigable;
-    @Synthetic
-    boolean mMoved;
-    private int mNextKonamiCode = 0;
-    private SharedPreferences mPreferences;
-    private String mPreferenceX, mPreferenceY;
-    @Synthetic
-    boolean mVibrationEnabled;
+public class NavFloatingActionButton extends FloatingActionButton
+    implements ViewTreeObserver.OnGlobalLayoutListener {
+  private static final String PREFERENCES_FAB = "_fab";
+  private static final String PREFERENCES_FAB_X = "%1$s_%2$d_%3$d_x";
+  private static final String PREFERENCES_FAB_Y = "%1$s_%2$d_%3$d_y";
+  private static final long VIBRATE_DURATION_MS = 15;
+  private static final int DOUBLE_TAP = -1;
+  private static final int[] KONAMI_CODE = {
+    Navigable.DIRECTION_UP,
+    Navigable.DIRECTION_UP,
+    Navigable.DIRECTION_DOWN,
+    Navigable.DIRECTION_DOWN,
+    Navigable.DIRECTION_LEFT,
+    Navigable.DIRECTION_RIGHT,
+    Navigable.DIRECTION_LEFT,
+    Navigable.DIRECTION_RIGHT,
+    DOUBLE_TAP
+  };
+  @Synthetic final Vibrator mVibrator;
+  private final Preferences.Observable mPreferenceObservable = new Preferences.Observable();
+  @Synthetic Navigable mNavigable;
+  @Synthetic boolean mMoved;
+  private int mNextKonamiCode = 0;
+  private SharedPreferences mPreferences;
+  private String mPreferenceX, mPreferenceY;
+  @Synthetic boolean mVibrationEnabled;
 
-    public static void resetPosition(Context context) {
-        getSharedPreferences(context).edit().clear().apply();
+  public static void resetPosition(Context context) {
+    getSharedPreferences(context).edit().clear().apply();
+  }
+
+  public NavFloatingActionButton(Context context) {
+    this(context, null);
+  }
+
+  public NavFloatingActionButton(Context context, AttributeSet attrs) {
+    this(context, attrs, 0);
+  }
+
+  public NavFloatingActionButton(Context context, AttributeSet attrs, int defStyleAttr) {
+    super(context, attrs, defStyleAttr);
+    bindNavigationPad();
+    mVibrationEnabled = Preferences.navigationVibrationEnabled(context);
+    if (!isInEditMode()) {
+      VibratorManager vibratorManager =
+          (VibratorManager) context.getSystemService(Context.VIBRATOR_MANAGER_SERVICE);
+      mVibrator = vibratorManager.getDefaultVibrator();
+    } else {
+      mVibrator = null;
     }
+  }
 
-    public NavFloatingActionButton(Context context) {
-        this(context, null);
-    }
+  @Override
+  protected void onAttachedToWindow() {
+    super.onAttachedToWindow();
+    getViewTreeObserver().addOnGlobalLayoutListener(this);
+    mPreferenceObservable.subscribe(
+        getContext(),
+        (key, contextChanged) ->
+            mVibrationEnabled = Preferences.navigationVibrationEnabled(getContext()),
+        R.string.pref_navigation_vibrate);
+  }
 
-    public NavFloatingActionButton(Context context, AttributeSet attrs) {
-        this(context, attrs, 0);
-    }
+  @Override
+  protected void onDetachedFromWindow() {
+    super.onDetachedFromWindow();
+    stopObservingViewTree();
+    mPreferenceObservable.unsubscribe(getContext());
+  }
 
-    public NavFloatingActionButton(Context context, AttributeSet attrs, int defStyleAttr) {
-        super(context, attrs, defStyleAttr);
-        bindNavigationPad();
-        mVibrationEnabled = Preferences.navigationVibrationEnabled(context);
-        if (!isInEditMode()) {
-            VibratorManager vibratorManager = (VibratorManager) context.getSystemService(Context.VIBRATOR_MANAGER_SERVICE);
-            mVibrator = vibratorManager.getDefaultVibrator();
-        } else {
-            mVibrator = null;
-        }
-    }
+  @Override
+  public void setOnTouchListener(OnTouchListener l) {
+    throw new UnsupportedOperationException();
+  }
 
-    @Override
-    protected void onAttachedToWindow() {
-        super.onAttachedToWindow();
-        getViewTreeObserver().addOnGlobalLayoutListener(this);
-        mPreferenceObservable.subscribe(getContext(),
-                (key, contextChanged) -> mVibrationEnabled = Preferences.navigationVibrationEnabled(getContext()),
-                R.string.pref_navigation_vibrate);
-    }
+  public void setNavigable(Navigable navigable) {
+    mNavigable = navigable;
+  }
 
-    @Override
-    protected void onDetachedFromWindow() {
-        super.onDetachedFromWindow();
-        stopObservingViewTree();
-        mPreferenceObservable.unsubscribe(getContext());
-    }
+  @Synthetic
+  void bindNavigationPad() {
+    GestureDetector detector =
+        new GestureDetector(
+            getContext(),
+            new GestureDetector.SimpleOnGestureListener() {
+              @Override
+              public boolean onDown(MotionEvent e) {
+                return mNavigable != null;
+              }
 
-    @Override
-    public void setOnTouchListener(OnTouchListener l) {
-        throw new UnsupportedOperationException();
-    }
-
-    public void setNavigable(Navigable navigable) {
-        mNavigable = navigable;
-    }
-
-    @Synthetic
-    void bindNavigationPad() {
-        GestureDetector detector = new GestureDetector(getContext(),
-                new GestureDetector.SimpleOnGestureListener() {
-                    @Override
-                    public boolean onDown(MotionEvent e) {
-                        return mNavigable != null;
-                    }
-
-                    @Override
-                    public boolean onSingleTapConfirmed(MotionEvent e) {
-                        Toast.makeText(getContext(), R.string.hint_nav_short,
-                                Toast.LENGTH_LONG).show();
-                        return true;
-                    }
-
-                    @Override
-                    public boolean onDoubleTap(MotionEvent e) {
-                        trackKonami(DOUBLE_TAP);
-                        return super.onDoubleTap(e);
-                    }
-
-                    @Override
-                    public boolean onFling(MotionEvent motionEvent, MotionEvent motionEvent1,
-                            float velocityX, float velocityY) {
-                        int direction;
-                        if (Math.abs(velocityX) > Math.abs(velocityY)) {
-                            direction = velocityX < 0 ? Navigable.DIRECTION_LEFT : Navigable.DIRECTION_RIGHT;
-                        } else {
-                            direction = velocityY < 0 ? Navigable.DIRECTION_UP : Navigable.DIRECTION_DOWN;
-                        }
-                        mNavigable.onNavigate(direction);
-                        if (mVibrationEnabled) {
-                            mVibrator.vibrate(VibrationEffect.createOneShot(VIBRATE_DURATION_MS, VibrationEffect.DEFAULT_AMPLITUDE));
-                        }
-                        trackKonami(direction);
-                        return false;
-                    }
-
-                    @Override
-                    public void onLongPress(MotionEvent e) {
-                        if (mNavigable == null) {
-                            return;
-                        }
-                        startDrag(e.getX(), e.getY());
-                    }
-                });
-        // noinspection Convert2Lambda
-        super.setOnTouchListener(new OnTouchListener() {
-            @SuppressLint("ClickableViewAccessibility")
-            @Override
-            public boolean onTouch(View view, MotionEvent motionEvent) {
-                return detector.onTouchEvent(motionEvent);
-            }
-        });
-    }
-
-    @Synthetic
-    void startDrag(float startX, float startY) {
-        if (mVibrationEnabled) {
-            mVibrator.vibrate(VibrationEffect.createOneShot(VIBRATE_DURATION_MS * 2, VibrationEffect.DEFAULT_AMPLITUDE));
-        }
-        Toast.makeText(getContext(), R.string.hint_drag, Toast.LENGTH_SHORT).show();
-        // noinspection Convert2Lambda
-        super.setOnTouchListener(new OnTouchListener() {
-            public boolean onTouch(View view, MotionEvent motionEvent) {
-                switch (motionEvent.getAction()) {
-                    case MotionEvent.ACTION_MOVE:
-                        mMoved = true;
-                        view.setX(motionEvent.getRawX() - startX); // TODO compensate shift
-                        view.setY(motionEvent.getRawY() - startY);
-                        break;
-                    case MotionEvent.ACTION_CANCEL:
-                    case MotionEvent.ACTION_UP:
-                        bindNavigationPad();
-                        if (mMoved) {
-                            persistPosition();
-                        }
-                        break;
-                    default:
-                        return false;
-                }
+              @Override
+              public boolean onSingleTapConfirmed(MotionEvent e) {
+                Toast.makeText(getContext(), R.string.hint_nav_short, Toast.LENGTH_LONG).show();
                 return true;
-            }
+              }
+
+              @Override
+              public boolean onDoubleTap(MotionEvent e) {
+                trackKonami(DOUBLE_TAP);
+                return super.onDoubleTap(e);
+              }
+
+              @Override
+              public boolean onFling(
+                  MotionEvent motionEvent,
+                  MotionEvent motionEvent1,
+                  float velocityX,
+                  float velocityY) {
+                int direction;
+                if (Math.abs(velocityX) > Math.abs(velocityY)) {
+                  direction = velocityX < 0 ? Navigable.DIRECTION_LEFT : Navigable.DIRECTION_RIGHT;
+                } else {
+                  direction = velocityY < 0 ? Navigable.DIRECTION_UP : Navigable.DIRECTION_DOWN;
+                }
+                mNavigable.onNavigate(direction);
+                if (mVibrationEnabled) {
+                  mVibrator.vibrate(
+                      VibrationEffect.createOneShot(
+                          VIBRATE_DURATION_MS, VibrationEffect.DEFAULT_AMPLITUDE));
+                }
+                trackKonami(direction);
+                return false;
+              }
+
+              @Override
+              public void onLongPress(MotionEvent e) {
+                if (mNavigable == null) {
+                  return;
+                }
+                startDrag(e.getX(), e.getY());
+              }
+            });
+    // noinspection Convert2Lambda
+    super.setOnTouchListener(
+        new OnTouchListener() {
+          @SuppressLint("ClickableViewAccessibility")
+          @Override
+          public boolean onTouch(View view, MotionEvent motionEvent) {
+            return detector.onTouchEvent(motionEvent);
+          }
         });
-    }
+  }
 
-    @Synthetic
-    boolean trackKonami(int direction) {
-        if (KONAMI_CODE[mNextKonamiCode] != direction) {
-            mNextKonamiCode = direction == KONAMI_CODE[0] ? 1 : 0;
-            return false;
-        } else if (mNextKonamiCode == KONAMI_CODE.length - 1) {
-            mNextKonamiCode = 0;
-            if (mVibrationEnabled) {
-                mVibrator.vibrate(VibrationEffect.createWaveform(new long[] { 0, VIBRATE_DURATION_MS * 2,
-                        100, VIBRATE_DURATION_MS * 2 }, -1));
+  @Synthetic
+  void startDrag(float startX, float startY) {
+    if (mVibrationEnabled) {
+      mVibrator.vibrate(
+          VibrationEffect.createOneShot(
+              VIBRATE_DURATION_MS * 2, VibrationEffect.DEFAULT_AMPLITUDE));
+    }
+    Toast.makeText(getContext(), R.string.hint_drag, Toast.LENGTH_SHORT).show();
+    // noinspection Convert2Lambda
+    super.setOnTouchListener(
+        new OnTouchListener() {
+          public boolean onTouch(View view, MotionEvent motionEvent) {
+            switch (motionEvent.getAction()) {
+              case MotionEvent.ACTION_MOVE:
+                mMoved = true;
+                view.setX(motionEvent.getRawX() - startX); // TODO compensate shift
+                view.setY(motionEvent.getRawY() - startY);
+                break;
+              case MotionEvent.ACTION_CANCEL:
+              case MotionEvent.ACTION_UP:
+                bindNavigationPad();
+                if (mMoved) {
+                  persistPosition();
+                }
+                break;
+              default:
+                return false;
             }
-            new AlertDialog.Builder(getContext())
-                    .setView(R.layout.dialog_konami)
-                    .setPositiveButton(android.R.string.ok,
-                            (dialogInterface, i) -> AppUtils.openPlayStore(getContext()))
-                    .create()
-                    .show();
             return true;
-        } else {
-            mNextKonamiCode++;
-            return true;
-        }
-    }
+          }
+        });
+  }
 
-    @Override
-    public void onGlobalLayout() {
-        restorePosition();
-        stopObservingViewTree();
+  @Synthetic
+  boolean trackKonami(int direction) {
+    if (KONAMI_CODE[mNextKonamiCode] != direction) {
+      mNextKonamiCode = direction == KONAMI_CODE[0] ? 1 : 0;
+      return false;
+    } else if (mNextKonamiCode == KONAMI_CODE.length - 1) {
+      mNextKonamiCode = 0;
+      if (mVibrationEnabled) {
+        mVibrator.vibrate(
+            VibrationEffect.createWaveform(
+                new long[] {0, VIBRATE_DURATION_MS * 2, 100, VIBRATE_DURATION_MS * 2}, -1));
+      }
+      new AlertDialog.Builder(getContext())
+          .setView(R.layout.dialog_konami)
+          .setPositiveButton(
+              android.R.string.ok, (dialogInterface, i) -> AppUtils.openPlayStore(getContext()))
+          .create()
+          .show();
+      return true;
+    } else {
+      mNextKonamiCode++;
+      return true;
     }
+  }
 
-    private void stopObservingViewTree() {
-        getViewTreeObserver().removeOnGlobalLayoutListener(this);
-    }
+  @Override
+  public void onGlobalLayout() {
+    restorePosition();
+    stopObservingViewTree();
+  }
 
-    @SuppressLint("CommitPrefEdits")
-    @Synthetic
-    void persistPosition() {
-        getPreferences()
-                .edit()
-                .putFloat(mPreferenceX, getX())
-                .putFloat(mPreferenceY, getY())
-                .apply();
-    }
+  private void stopObservingViewTree() {
+    getViewTreeObserver().removeOnGlobalLayoutListener(this);
+  }
 
-    private void restorePosition() {
-        setX(getPreferences().getFloat(mPreferenceX, getX()));
-        setY(getPreferences().getFloat(mPreferenceY, getY()));
-    }
+  @SuppressLint("CommitPrefEdits")
+  @Synthetic
+  void persistPosition() {
+    getPreferences().edit().putFloat(mPreferenceX, getX()).putFloat(mPreferenceY, getY()).apply();
+  }
 
-    private DisplayMetrics getDisplayMetrics() {
-        return getContext().getResources().getDisplayMetrics();
-    }
+  private void restorePosition() {
+    setX(getPreferences().getFloat(mPreferenceX, getX()));
+    setY(getPreferences().getFloat(mPreferenceY, getY()));
+  }
 
-    private SharedPreferences getPreferences() {
-        if (mPreferences == null) {
-            mPreferences = getSharedPreferences(getContext());
-            DisplayMetrics metrics = getDisplayMetrics();
-            mPreferenceX = String.format(Locale.US, PREFERENCES_FAB_X,
-                    getContext().getClass().getName(), metrics.widthPixels, metrics.heightPixels);
-            mPreferenceY = String.format(Locale.US, PREFERENCES_FAB_Y,
-                    getContext().getClass().getName(), metrics.widthPixels, metrics.heightPixels);
-        }
-        return mPreferences;
-    }
+  private DisplayMetrics getDisplayMetrics() {
+    return getContext().getResources().getDisplayMetrics();
+  }
 
-    private static SharedPreferences getSharedPreferences(Context context) {
-        return context.getSharedPreferences(context.getPackageName() + PREFERENCES_FAB,
-                Context.MODE_PRIVATE);
+  private SharedPreferences getPreferences() {
+    if (mPreferences == null) {
+      mPreferences = getSharedPreferences(getContext());
+      DisplayMetrics metrics = getDisplayMetrics();
+      mPreferenceX =
+          String.format(
+              Locale.US,
+              PREFERENCES_FAB_X,
+              getContext().getClass().getName(),
+              metrics.widthPixels,
+              metrics.heightPixels);
+      mPreferenceY =
+          String.format(
+              Locale.US,
+              PREFERENCES_FAB_Y,
+              getContext().getClass().getName(),
+              metrics.widthPixels,
+              metrics.heightPixels);
     }
+    return mPreferences;
+  }
+
+  private static SharedPreferences getSharedPreferences(Context context) {
+    return context.getSharedPreferences(
+        context.getPackageName() + PREFERENCES_FAB, Context.MODE_PRIVATE);
+  }
 }

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/NavFloatingActionButton.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/NavFloatingActionButton.java
@@ -192,6 +192,7 @@ public class NavFloatingActionButton extends FloatingActionButton
     // noinspection Convert2Lambda
     super.setOnTouchListener(
         new OnTouchListener() {
+          @Override
           public boolean onTouch(View view, MotionEvent motionEvent) {
             switch (motionEvent.getAction()) {
               case MotionEvent.ACTION_MOVE:

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/NavFloatingActionButton.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/NavFloatingActionButton.java
@@ -22,7 +22,9 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Build;
+import android.os.VibrationEffect;
 import android.os.Vibrator;
+import android.os.VibratorManager;
 import android.util.AttributeSet;
 import android.util.DisplayMetrics;
 import android.view.GestureDetector;
@@ -38,14 +40,12 @@ import java.util.Locale;
 
 import androidx.annotation.RequiresApi;
 import androidx.appcompat.app.AlertDialog;
-import androidx.core.view.GestureDetectorCompat;
 import io.github.sheepdestroyer.materialisheep.AppUtils;
 import io.github.sheepdestroyer.materialisheep.Navigable;
 import io.github.sheepdestroyer.materialisheep.Preferences;
 import io.github.sheepdestroyer.materialisheep.R;
 import io.github.sheepdestroyer.materialisheep.annotation.Synthetic;
 
-@SuppressWarnings("deprecation") // TODO: Uses deprecated Vibrator, Display, GestureDetectorCompat APIs
 public class NavFloatingActionButton extends FloatingActionButton implements ViewTreeObserver.OnGlobalLayoutListener {
     private static final String PREFERENCES_FAB = "_fab";
     private static final String PREFERENCES_FAB_X = "%1$s_%2$d_%3$d_x";
@@ -93,7 +93,8 @@ public class NavFloatingActionButton extends FloatingActionButton implements Vie
         bindNavigationPad();
         mVibrationEnabled = Preferences.navigationVibrationEnabled(context);
         if (!isInEditMode()) {
-            mVibrator = (Vibrator) context.getSystemService(Context.VIBRATOR_SERVICE);
+            VibratorManager vibratorManager = (VibratorManager) context.getSystemService(Context.VIBRATOR_MANAGER_SERVICE);
+            mVibrator = vibratorManager.getDefaultVibrator();
         } else {
             mVibrator = null;
         }
@@ -126,7 +127,7 @@ public class NavFloatingActionButton extends FloatingActionButton implements Vie
 
     @Synthetic
     void bindNavigationPad() {
-        GestureDetectorCompat detectorCompat = new GestureDetectorCompat(getContext(),
+        GestureDetector detector = new GestureDetector(getContext(),
                 new GestureDetector.SimpleOnGestureListener() {
                     @Override
                     public boolean onDown(MotionEvent e) {
@@ -157,7 +158,7 @@ public class NavFloatingActionButton extends FloatingActionButton implements Vie
                         }
                         mNavigable.onNavigate(direction);
                         if (mVibrationEnabled) {
-                            mVibrator.vibrate(VIBRATE_DURATION_MS);
+                            mVibrator.vibrate(VibrationEffect.createOneShot(VIBRATE_DURATION_MS, VibrationEffect.DEFAULT_AMPLITUDE));
                         }
                         trackKonami(direction);
                         return false;
@@ -176,7 +177,7 @@ public class NavFloatingActionButton extends FloatingActionButton implements Vie
             @SuppressLint("ClickableViewAccessibility")
             @Override
             public boolean onTouch(View view, MotionEvent motionEvent) {
-                return detectorCompat.onTouchEvent(motionEvent);
+                return detector.onTouchEvent(motionEvent);
             }
         });
     }
@@ -184,7 +185,7 @@ public class NavFloatingActionButton extends FloatingActionButton implements Vie
     @Synthetic
     void startDrag(float startX, float startY) {
         if (mVibrationEnabled) {
-            mVibrator.vibrate(VIBRATE_DURATION_MS * 2);
+            mVibrator.vibrate(VibrationEffect.createOneShot(VIBRATE_DURATION_MS * 2, VibrationEffect.DEFAULT_AMPLITUDE));
         }
         Toast.makeText(getContext(), R.string.hint_drag, Toast.LENGTH_SHORT).show();
         // noinspection Convert2Lambda
@@ -219,8 +220,8 @@ public class NavFloatingActionButton extends FloatingActionButton implements Vie
         } else if (mNextKonamiCode == KONAMI_CODE.length - 1) {
             mNextKonamiCode = 0;
             if (mVibrationEnabled) {
-                mVibrator.vibrate(new long[] { 0, VIBRATE_DURATION_MS * 2,
-                        100, VIBRATE_DURATION_MS * 2 }, -1);
+                mVibrator.vibrate(VibrationEffect.createWaveform(new long[] { 0, VIBRATE_DURATION_MS * 2,
+                        100, VIBRATE_DURATION_MS * 2 }, -1));
             }
             new AlertDialog.Builder(getContext())
                     .setView(R.layout.dialog_konami)
@@ -261,10 +262,7 @@ public class NavFloatingActionButton extends FloatingActionButton implements Vie
     }
 
     private DisplayMetrics getDisplayMetrics() {
-        DisplayMetrics metrics = new DisplayMetrics();
-        ((WindowManager) getContext().getSystemService(Activity.WINDOW_SERVICE))
-                .getDefaultDisplay().getMetrics(metrics);
-        return metrics;
+        return getContext().getResources().getDisplayMetrics();
     }
 
     private SharedPreferences getPreferences() {

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/NavFloatingActionButton.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/NavFloatingActionButton.java
@@ -17,8 +17,11 @@
 package io.github.sheepdestroyer.materialisheep.widget;
 
 import android.annotation.SuppressLint;
+import android.annotation.TargetApi;
+import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.os.Build;
 import android.os.VibrationEffect;
 import android.os.Vibrator;
 import android.os.VibratorManager;
@@ -28,266 +31,254 @@ import android.view.GestureDetector;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewTreeObserver;
+import android.view.WindowManager;
 import android.widget.Toast;
-import androidx.appcompat.app.AlertDialog;
+
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
+
+import java.util.Locale;
+
+import androidx.annotation.RequiresApi;
+import androidx.appcompat.app.AlertDialog;
 import io.github.sheepdestroyer.materialisheep.AppUtils;
 import io.github.sheepdestroyer.materialisheep.Navigable;
 import io.github.sheepdestroyer.materialisheep.Preferences;
 import io.github.sheepdestroyer.materialisheep.R;
 import io.github.sheepdestroyer.materialisheep.annotation.Synthetic;
-import java.util.Locale;
 
-public class NavFloatingActionButton extends FloatingActionButton
-    implements ViewTreeObserver.OnGlobalLayoutListener {
-  private static final String PREFERENCES_FAB = "_fab";
-  private static final String PREFERENCES_FAB_X = "%1$s_%2$d_%3$d_x";
-  private static final String PREFERENCES_FAB_Y = "%1$s_%2$d_%3$d_y";
-  private static final long VIBRATE_DURATION_MS = 15;
-  private static final int DOUBLE_TAP = -1;
-  private static final int[] KONAMI_CODE = {
-    Navigable.DIRECTION_UP,
-    Navigable.DIRECTION_UP,
-    Navigable.DIRECTION_DOWN,
-    Navigable.DIRECTION_DOWN,
-    Navigable.DIRECTION_LEFT,
-    Navigable.DIRECTION_RIGHT,
-    Navigable.DIRECTION_LEFT,
-    Navigable.DIRECTION_RIGHT,
-    DOUBLE_TAP
-  };
-  @Synthetic final Vibrator mVibrator;
-  private final Preferences.Observable mPreferenceObservable = new Preferences.Observable();
-  @Synthetic Navigable mNavigable;
-  @Synthetic boolean mMoved;
-  private int mNextKonamiCode = 0;
-  private SharedPreferences mPreferences;
-  private String mPreferenceX, mPreferenceY;
-  @Synthetic boolean mVibrationEnabled;
+public class NavFloatingActionButton extends FloatingActionButton implements ViewTreeObserver.OnGlobalLayoutListener {
+    private static final String PREFERENCES_FAB = "_fab";
+    private static final String PREFERENCES_FAB_X = "%1$s_%2$d_%3$d_x";
+    private static final String PREFERENCES_FAB_Y = "%1$s_%2$d_%3$d_y";
+    private static final long VIBRATE_DURATION_MS = 15;
+    private static final int DOUBLE_TAP = -1;
+    private static final int[] KONAMI_CODE = {
+            Navigable.DIRECTION_UP,
+            Navigable.DIRECTION_UP,
+            Navigable.DIRECTION_DOWN,
+            Navigable.DIRECTION_DOWN,
+            Navigable.DIRECTION_LEFT,
+            Navigable.DIRECTION_RIGHT,
+            Navigable.DIRECTION_LEFT,
+            Navigable.DIRECTION_RIGHT,
+            DOUBLE_TAP
+    };
+    @Synthetic
+    final Vibrator mVibrator;
+    private final Preferences.Observable mPreferenceObservable = new Preferences.Observable();
+    @Synthetic
+    Navigable mNavigable;
+    @Synthetic
+    boolean mMoved;
+    private int mNextKonamiCode = 0;
+    private SharedPreferences mPreferences;
+    private String mPreferenceX, mPreferenceY;
+    @Synthetic
+    boolean mVibrationEnabled;
 
-  public static void resetPosition(Context context) {
-    getSharedPreferences(context).edit().clear().apply();
-  }
-
-  public NavFloatingActionButton(Context context) {
-    this(context, null);
-  }
-
-  public NavFloatingActionButton(Context context, AttributeSet attrs) {
-    this(context, attrs, 0);
-  }
-
-  public NavFloatingActionButton(Context context, AttributeSet attrs, int defStyleAttr) {
-    super(context, attrs, defStyleAttr);
-    bindNavigationPad();
-    mVibrationEnabled = Preferences.navigationVibrationEnabled(context);
-    if (!isInEditMode()) {
-      VibratorManager vibratorManager =
-          (VibratorManager) context.getSystemService(Context.VIBRATOR_MANAGER_SERVICE);
-      mVibrator = vibratorManager.getDefaultVibrator();
-    } else {
-      mVibrator = null;
+    public static void resetPosition(Context context) {
+        getSharedPreferences(context).edit().clear().apply();
     }
-  }
 
-  @Override
-  protected void onAttachedToWindow() {
-    super.onAttachedToWindow();
-    getViewTreeObserver().addOnGlobalLayoutListener(this);
-    mPreferenceObservable.subscribe(
-        getContext(),
-        (key, contextChanged) ->
-            mVibrationEnabled = Preferences.navigationVibrationEnabled(getContext()),
-        R.string.pref_navigation_vibrate);
-  }
-
-  @Override
-  protected void onDetachedFromWindow() {
-    super.onDetachedFromWindow();
-    stopObservingViewTree();
-    mPreferenceObservable.unsubscribe(getContext());
-  }
-
-  @Override
-  public void setOnTouchListener(OnTouchListener l) {
-    throw new UnsupportedOperationException();
-  }
-
-  public void setNavigable(Navigable navigable) {
-    mNavigable = navigable;
-  }
-
-  @Synthetic
-  void bindNavigationPad() {
-    GestureDetector detector =
-        new GestureDetector(
-            getContext(),
-            new GestureDetector.SimpleOnGestureListener() {
-              @Override
-              public boolean onDown(MotionEvent e) {
-                return mNavigable != null;
-              }
-
-              @Override
-              public boolean onSingleTapConfirmed(MotionEvent e) {
-                Toast.makeText(getContext(), R.string.hint_nav_short, Toast.LENGTH_LONG).show();
-                return true;
-              }
-
-              @Override
-              public boolean onDoubleTap(MotionEvent e) {
-                trackKonami(DOUBLE_TAP);
-                return super.onDoubleTap(e);
-              }
-
-              @Override
-              public boolean onFling(
-                  MotionEvent motionEvent,
-                  MotionEvent motionEvent1,
-                  float velocityX,
-                  float velocityY) {
-                int direction;
-                if (Math.abs(velocityX) > Math.abs(velocityY)) {
-                  direction = velocityX < 0 ? Navigable.DIRECTION_LEFT : Navigable.DIRECTION_RIGHT;
-                } else {
-                  direction = velocityY < 0 ? Navigable.DIRECTION_UP : Navigable.DIRECTION_DOWN;
-                }
-                mNavigable.onNavigate(direction);
-                if (mVibrationEnabled) {
-                  mVibrator.vibrate(
-                      VibrationEffect.createOneShot(
-                          VIBRATE_DURATION_MS, VibrationEffect.DEFAULT_AMPLITUDE));
-                }
-                trackKonami(direction);
-                return false;
-              }
-
-              @Override
-              public void onLongPress(MotionEvent e) {
-                if (mNavigable == null) {
-                  return;
-                }
-                startDrag(e.getX(), e.getY());
-              }
-            });
-    // noinspection Convert2Lambda
-    super.setOnTouchListener(
-        new OnTouchListener() {
-          @SuppressLint("ClickableViewAccessibility")
-          @Override
-          public boolean onTouch(View view, MotionEvent motionEvent) {
-            return detector.onTouchEvent(motionEvent);
-          }
-        });
-  }
-
-  @Synthetic
-  void startDrag(float startX, float startY) {
-    if (mVibrationEnabled) {
-      mVibrator.vibrate(
-          VibrationEffect.createOneShot(
-              VIBRATE_DURATION_MS * 2, VibrationEffect.DEFAULT_AMPLITUDE));
+    public NavFloatingActionButton(Context context) {
+        this(context, null);
     }
-    Toast.makeText(getContext(), R.string.hint_drag, Toast.LENGTH_SHORT).show();
-    // noinspection Convert2Lambda
-    super.setOnTouchListener(
-        new OnTouchListener() {
-          public boolean onTouch(View view, MotionEvent motionEvent) {
-            switch (motionEvent.getAction()) {
-              case MotionEvent.ACTION_MOVE:
-                mMoved = true;
-                view.setX(motionEvent.getRawX() - startX); // TODO compensate shift
-                view.setY(motionEvent.getRawY() - startY);
-                break;
-              case MotionEvent.ACTION_CANCEL:
-              case MotionEvent.ACTION_UP:
-                bindNavigationPad();
-                if (mMoved) {
-                  persistPosition();
-                }
-                break;
-              default:
-                return false;
+
+    public NavFloatingActionButton(Context context, AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public NavFloatingActionButton(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        bindNavigationPad();
+        mVibrationEnabled = Preferences.navigationVibrationEnabled(context);
+        if (!isInEditMode()) {
+            VibratorManager vibratorManager = (VibratorManager) context.getSystemService(Context.VIBRATOR_MANAGER_SERVICE);
+            mVibrator = vibratorManager.getDefaultVibrator();
+        } else {
+            mVibrator = null;
+        }
+    }
+
+    @Override
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+        getViewTreeObserver().addOnGlobalLayoutListener(this);
+        mPreferenceObservable.subscribe(getContext(),
+                (key, contextChanged) -> mVibrationEnabled = Preferences.navigationVibrationEnabled(getContext()),
+                R.string.pref_navigation_vibrate);
+    }
+
+    @Override
+    protected void onDetachedFromWindow() {
+        super.onDetachedFromWindow();
+        stopObservingViewTree();
+        mPreferenceObservable.unsubscribe(getContext());
+    }
+
+    @Override
+    public void setOnTouchListener(OnTouchListener l) {
+        throw new UnsupportedOperationException();
+    }
+
+    public void setNavigable(Navigable navigable) {
+        mNavigable = navigable;
+    }
+
+    @Synthetic
+    void bindNavigationPad() {
+        GestureDetector detector = new GestureDetector(getContext(),
+                new GestureDetector.SimpleOnGestureListener() {
+                    @Override
+                    public boolean onDown(MotionEvent e) {
+                        return mNavigable != null;
+                    }
+
+                    @Override
+                    public boolean onSingleTapConfirmed(MotionEvent e) {
+                        Toast.makeText(getContext(), R.string.hint_nav_short,
+                                Toast.LENGTH_LONG).show();
+                        return true;
+                    }
+
+                    @Override
+                    public boolean onDoubleTap(MotionEvent e) {
+                        trackKonami(DOUBLE_TAP);
+                        return super.onDoubleTap(e);
+                    }
+
+                    @Override
+                    public boolean onFling(MotionEvent motionEvent, MotionEvent motionEvent1,
+                            float velocityX, float velocityY) {
+                        int direction;
+                        if (Math.abs(velocityX) > Math.abs(velocityY)) {
+                            direction = velocityX < 0 ? Navigable.DIRECTION_LEFT : Navigable.DIRECTION_RIGHT;
+                        } else {
+                            direction = velocityY < 0 ? Navigable.DIRECTION_UP : Navigable.DIRECTION_DOWN;
+                        }
+                        mNavigable.onNavigate(direction);
+                        if (mVibrationEnabled) {
+                            mVibrator.vibrate(VibrationEffect.createOneShot(VIBRATE_DURATION_MS, VibrationEffect.DEFAULT_AMPLITUDE));
+                        }
+                        trackKonami(direction);
+                        return false;
+                    }
+
+                    @Override
+                    public void onLongPress(MotionEvent e) {
+                        if (mNavigable == null) {
+                            return;
+                        }
+                        startDrag(e.getX(), e.getY());
+                    }
+                });
+        // noinspection Convert2Lambda
+        super.setOnTouchListener(new OnTouchListener() {
+            @SuppressLint("ClickableViewAccessibility")
+            @Override
+            public boolean onTouch(View view, MotionEvent motionEvent) {
+                return detector.onTouchEvent(motionEvent);
             }
-            return true;
-          }
         });
-  }
-
-  @Synthetic
-  boolean trackKonami(int direction) {
-    if (KONAMI_CODE[mNextKonamiCode] != direction) {
-      mNextKonamiCode = direction == KONAMI_CODE[0] ? 1 : 0;
-      return false;
-    } else if (mNextKonamiCode == KONAMI_CODE.length - 1) {
-      mNextKonamiCode = 0;
-      if (mVibrationEnabled) {
-        mVibrator.vibrate(
-            VibrationEffect.createWaveform(
-                new long[] {0, VIBRATE_DURATION_MS * 2, 100, VIBRATE_DURATION_MS * 2}, -1));
-      }
-      new AlertDialog.Builder(getContext())
-          .setView(R.layout.dialog_konami)
-          .setPositiveButton(
-              android.R.string.ok, (dialogInterface, i) -> AppUtils.openPlayStore(getContext()))
-          .create()
-          .show();
-      return true;
-    } else {
-      mNextKonamiCode++;
-      return true;
     }
-  }
 
-  @Override
-  public void onGlobalLayout() {
-    restorePosition();
-    stopObservingViewTree();
-  }
-
-  private void stopObservingViewTree() {
-    getViewTreeObserver().removeOnGlobalLayoutListener(this);
-  }
-
-  @SuppressLint("CommitPrefEdits")
-  @Synthetic
-  void persistPosition() {
-    getPreferences().edit().putFloat(mPreferenceX, getX()).putFloat(mPreferenceY, getY()).apply();
-  }
-
-  private void restorePosition() {
-    setX(getPreferences().getFloat(mPreferenceX, getX()));
-    setY(getPreferences().getFloat(mPreferenceY, getY()));
-  }
-
-  private DisplayMetrics getDisplayMetrics() {
-    return getContext().getResources().getDisplayMetrics();
-  }
-
-  private SharedPreferences getPreferences() {
-    if (mPreferences == null) {
-      mPreferences = getSharedPreferences(getContext());
-      DisplayMetrics metrics = getDisplayMetrics();
-      mPreferenceX =
-          String.format(
-              Locale.US,
-              PREFERENCES_FAB_X,
-              getContext().getClass().getName(),
-              metrics.widthPixels,
-              metrics.heightPixels);
-      mPreferenceY =
-          String.format(
-              Locale.US,
-              PREFERENCES_FAB_Y,
-              getContext().getClass().getName(),
-              metrics.widthPixels,
-              metrics.heightPixels);
+    @Synthetic
+    void startDrag(float startX, float startY) {
+        if (mVibrationEnabled) {
+            mVibrator.vibrate(VibrationEffect.createOneShot(VIBRATE_DURATION_MS * 2, VibrationEffect.DEFAULT_AMPLITUDE));
+        }
+        Toast.makeText(getContext(), R.string.hint_drag, Toast.LENGTH_SHORT).show();
+        // noinspection Convert2Lambda
+        super.setOnTouchListener(new OnTouchListener() {
+            public boolean onTouch(View view, MotionEvent motionEvent) {
+                switch (motionEvent.getAction()) {
+                    case MotionEvent.ACTION_MOVE:
+                        mMoved = true;
+                        view.setX(motionEvent.getRawX() - startX); // TODO compensate shift
+                        view.setY(motionEvent.getRawY() - startY);
+                        break;
+                    case MotionEvent.ACTION_CANCEL:
+                    case MotionEvent.ACTION_UP:
+                        bindNavigationPad();
+                        if (mMoved) {
+                            persistPosition();
+                        }
+                        break;
+                    default:
+                        return false;
+                }
+                return true;
+            }
+        });
     }
-    return mPreferences;
-  }
 
-  private static SharedPreferences getSharedPreferences(Context context) {
-    return context.getSharedPreferences(
-        context.getPackageName() + PREFERENCES_FAB, Context.MODE_PRIVATE);
-  }
+    @Synthetic
+    boolean trackKonami(int direction) {
+        if (KONAMI_CODE[mNextKonamiCode] != direction) {
+            mNextKonamiCode = direction == KONAMI_CODE[0] ? 1 : 0;
+            return false;
+        } else if (mNextKonamiCode == KONAMI_CODE.length - 1) {
+            mNextKonamiCode = 0;
+            if (mVibrationEnabled) {
+                mVibrator.vibrate(VibrationEffect.createWaveform(new long[] { 0, VIBRATE_DURATION_MS * 2,
+                        100, VIBRATE_DURATION_MS * 2 }, -1));
+            }
+            new AlertDialog.Builder(getContext())
+                    .setView(R.layout.dialog_konami)
+                    .setPositiveButton(android.R.string.ok,
+                            (dialogInterface, i) -> AppUtils.openPlayStore(getContext()))
+                    .create()
+                    .show();
+            return true;
+        } else {
+            mNextKonamiCode++;
+            return true;
+        }
+    }
+
+    @Override
+    public void onGlobalLayout() {
+        restorePosition();
+        stopObservingViewTree();
+    }
+
+    private void stopObservingViewTree() {
+        getViewTreeObserver().removeOnGlobalLayoutListener(this);
+    }
+
+    @SuppressLint("CommitPrefEdits")
+    @Synthetic
+    void persistPosition() {
+        getPreferences()
+                .edit()
+                .putFloat(mPreferenceX, getX())
+                .putFloat(mPreferenceY, getY())
+                .apply();
+    }
+
+    private void restorePosition() {
+        setX(getPreferences().getFloat(mPreferenceX, getX()));
+        setY(getPreferences().getFloat(mPreferenceY, getY()));
+    }
+
+    private DisplayMetrics getDisplayMetrics() {
+        return getContext().getResources().getDisplayMetrics();
+    }
+
+    private SharedPreferences getPreferences() {
+        if (mPreferences == null) {
+            mPreferences = getSharedPreferences(getContext());
+            DisplayMetrics metrics = getDisplayMetrics();
+            mPreferenceX = String.format(Locale.US, PREFERENCES_FAB_X,
+                    getContext().getClass().getName(), metrics.widthPixels, metrics.heightPixels);
+            mPreferenceY = String.format(Locale.US, PREFERENCES_FAB_Y,
+                    getContext().getClass().getName(), metrics.widthPixels, metrics.heightPixels);
+        }
+        return mPreferences;
+    }
+
+    private static SharedPreferences getSharedPreferences(Context context) {
+        return context.getSharedPreferences(context.getPackageName() + PREFERENCES_FAB,
+                Context.MODE_PRIVATE);
+    }
 }


### PR DESCRIPTION
This PR addresses the use of deprecated APIs in `NavFloatingActionButton`:

1.  **Vibrator API**: Updated to use `VibratorManager` to fetch the default `Vibrator` and replaced deprecated `vibrate(long)` and `vibrate(long[], int)` methods with `VibrationEffect.createOneShot()` and `VibrationEffect.createWaveform()`, adhering to the modern API introduced in Android API 26 and API 31.
2.  **Display API**: Replaced the deprecated `getDefaultDisplay().getMetrics(metrics)` implementation within `getDisplayMetrics()` with a cleaner and more direct `getContext().getResources().getDisplayMetrics()`.
3.  **GestureDetectorCompat**: Migrated from the deprecated `androidx.core.view.GestureDetectorCompat` class to the native `android.view.GestureDetector` which has been natively capable for several API versions.
4.  Removed `@SuppressWarnings("deprecation")` as it's no longer necessary.

These changes modernize the implementation while maintaining identical behavior. All unit tests and linters pass successfully.

---
*PR created automatically by Jules for task [1462124993977151707](https://jules.google.com/task/1462124993977151707) started by @sheepdestroyer*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced floating action button widget with an optimized haptic feedback system for all navigation and drag interactions, improving overall responsiveness and user experience quality. All gesture recognition controls (tap, double-tap, fling, long-press), position persistence, and special feature sequences remain fully functional and operational.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sheepdestroyer/materialisheep/pull/260?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->