### PR TITLE
🧹 [code health improvement] Defer sync on low battery

### DIFF
--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/data/SyncDelegate.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/data/SyncDelegate.java
@@ -138,6 +138,7 @@ public class SyncDelegate {
                   Preferences.Offline.isWifiOnly(context)
                       ? JobInfo.NETWORK_TYPE_UNMETERED
                       : JobInfo.NETWORK_TYPE_ANY)
+              .setRequiresBatteryNotLow(true)
               .setExtras(job.toPersistableBundle());
       if (Preferences.Offline.currentConnectionEnabled(context)) {
         builder.setOverrideDeadline(0);
@@ -196,7 +197,6 @@ public class SyncDelegate {
       sync(cachedItem);
     } else {
       updateProgress();
-      // TODO defer on low battery as well?
       mHnRestService
           .networkItem(itemId)
           .enqueue(


### PR DESCRIPTION
🎯 **What:** Addressed a `TODO` comment in `SyncDelegate.java` that noted syncing should be deferred on low battery. Added `setRequiresBatteryNotLow(true)` to the `JobInfo.Builder` when scheduling sync jobs and removed the pending TODO.
💡 **Why:** Relying on Android's built-in `JobScheduler` to evaluate battery condition improves maintainability over custom runtime state checking. It seamlessly leverages system-level battery metrics natively.
✅ **Verification:** Re-ran `./gradlew testDebugUnitTest` and confirmed there are no regressions.
✨ **Result:** Cleaned up code health by replacing a `TODO` comment with concrete, simple JobScheduler logic.

---
*PR created automatically by Jules for task [1231055463829893253](https://jules.google.com/task/1231055463829893253) started by @sheepdestroyer*