### PR TITLE
🧪 Add test for AppUtils.openPlayStore ActivityNotFoundException

### DIFF
--- a/app/src/test/java/io/github/sheepdestroyer/materialisheep/AppUtilsTest.java
+++ b/app/src/test/java/io/github/sheepdestroyer/materialisheep/AppUtilsTest.java
@@ -95,12 +95,13 @@ public class AppUtilsTest {
   @Test
   public void testOpenPlayStore_ActivityNotFound() {
     Context context = ApplicationProvider.getApplicationContext();
-    Context wrapper = new ContextWrapper(context) {
-      @Override
-      public void startActivity(Intent intent) {
-        throw new ActivityNotFoundException("Activity not found");
-      }
-    };
+    Context wrapper =
+        new ContextWrapper(context) {
+          @Override
+          public void startActivity(Intent intent) {
+            throw new ActivityNotFoundException("Activity not found");
+          }
+        };
 
     AppUtils.openPlayStore(wrapper);
     assertEquals(context.getString(R.string.no_playstore), ShadowToast.getTextOfLatestToast());

--- a/app/src/test/java/io/github/sheepdestroyer/materialisheep/AppUtilsTest.java
+++ b/app/src/test/java/io/github/sheepdestroyer/materialisheep/AppUtilsTest.java
@@ -4,7 +4,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import android.content.ActivityNotFoundException;
 import android.content.Context;
+import android.content.ContextWrapper;
+import android.content.Intent;
 import android.net.ConnectivityManager;
 import android.text.format.DateUtils;
 import androidx.test.core.app.ApplicationProvider;
@@ -13,6 +16,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.Shadows;
 import org.robolectric.shadows.ShadowConnectivityManager;
+import org.robolectric.shadows.ShadowToast;
 
 @RunWith(RobolectricTestRunner.class)
 public class AppUtilsTest {
@@ -86,5 +90,19 @@ public class AppUtilsTest {
 
     // Test edge case (future time)
     assertEquals("0m", AppUtils.getAbbreviatedTimeSpan(now + DateUtils.DAY_IN_MILLIS));
+  }
+
+  @Test
+  public void testOpenPlayStore_ActivityNotFound() {
+    Context context = ApplicationProvider.getApplicationContext();
+    Context wrapper = new ContextWrapper(context) {
+      @Override
+      public void startActivity(Intent intent) {
+        throw new ActivityNotFoundException("Activity not found");
+      }
+    };
+
+    AppUtils.openPlayStore(wrapper);
+    assertEquals(context.getString(R.string.no_playstore), ShadowToast.getTextOfLatestToast());
   }
 }


### PR DESCRIPTION
🎯 **What:** Added a unit test to verify that `AppUtils.openPlayStore` correctly catches `ActivityNotFoundException` and displays a fallback Toast message.
📊 **Coverage:** The previously untested catch block inside `AppUtils.openPlayStore(Context)` is now fully covered using a custom `ContextWrapper` in Robolectric.
✨ **Result:** Test coverage increased, ensuring no regressions in the fallback behavior when the Play Store intent fails to launch.

---
*PR created automatically by Jules for task [3230003456901890271](https://jules.google.com/task/3230003456901890271) started by @sheepdestroyer*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for handling Play Store unavailability scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sheepdestroyer/materialisheep/pull/264?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->