### PR TITLE
Fix UI overlap with Android system bars

### DIFF
--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -18,6 +18,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@id/content_frame"
     android:orientation="vertical"
+    android:fitsSystemWindows="true"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 

--- a/app/src/main/res/layout/activity_compose.xml
+++ b/app/src/main/res/layout/activity_compose.xml
@@ -19,6 +19,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
+    android:fitsSystemWindows="true"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 

--- a/app/src/main/res/layout/activity_feedback.xml
+++ b/app/src/main/res/layout/activity_feedback.xml
@@ -19,6 +19,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical"
+    android:fitsSystemWindows="true"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 

--- a/app/src/main/res/layout/activity_item.xml
+++ b/app/src/main/res/layout/activity_item.xml
@@ -20,6 +20,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@id/content_frame"
+    android:fitsSystemWindows="true"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 

--- a/app/src/main/res/layout/activity_list.xml
+++ b/app/src/main/res/layout/activity_list.xml
@@ -19,6 +19,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@id/content_frame"
+    android:fitsSystemWindows="true"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -19,7 +19,8 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <LinearLayout

--- a/app/src/main/res/layout/activity_offline_web.xml
+++ b/app/src/main/res/layout/activity_offline_web.xml
@@ -19,6 +19,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@id/content_frame"
+    android:fitsSystemWindows="true"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 

--- a/app/src/main/res/layout/activity_preferences.xml
+++ b/app/src/main/res/layout/activity_preferences.xml
@@ -19,6 +19,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@id/content_frame"
     android:orientation="vertical"
+    android:fitsSystemWindows="true"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 

--- a/app/src/main/res/layout/activity_release.xml
+++ b/app/src/main/res/layout/activity_release.xml
@@ -18,6 +18,7 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical"
+    android:fitsSystemWindows="true"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -20,8 +20,9 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
+    android:fitsSystemWindows="true"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="match_parent">
 
     <include layout="@layout/toolbar" />
 

--- a/app/src/main/res/layout/activity_submit.xml
+++ b/app/src/main/res/layout/activity_submit.xml
@@ -18,6 +18,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical"
+    android:fitsSystemWindows="true"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 

--- a/app/src/main/res/layout/activity_thread_preview.xml
+++ b/app/src/main/res/layout/activity_thread_preview.xml
@@ -18,6 +18,7 @@
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical"
+    android:fitsSystemWindows="true"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 

--- a/app/src/main/res/layout/activity_user.xml
+++ b/app/src/main/res/layout/activity_user.xml
@@ -19,6 +19,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@id/content_frame"
+    android:fitsSystemWindows="true"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 


### PR DESCRIPTION
The top buttons in various activities were inaccessible because they were being drawn behind the Android system UI (status bar). This was addressed by adding `android:fitsSystemWindows="true"` to the root layout elements of all activities. This attribute ensures the system applies appropriate padding to keep the UI within the "safe area" of the screen. 

Changes were applied to:
- `activity_item.xml`
- `activity_list.xml`
- `activity_submit.xml`
- `activity_compose.xml`
- `activity_user.xml`
- `activity_offline_web.xml`
- `activity_feedback.xml`
- `activity_about.xml`
- `activity_settings.xml`
- `activity_preferences.xml`
- `activity_login.xml`
- `activity_release.xml`
- `activity_thread_preview.xml`

Additionally, `layout_height` was updated to `match_parent` in `activity_login.xml` and `activity_settings.xml` as required for `fitsSystemWindows` to work correctly on root layouts.

Fixes #266

---
*PR created automatically by Jules for task [7712476981761572959](https://jules.google.com/task/7712476981761572959) started by @sheepdestroyer*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved layout handling across all app screens to better work with system interface elements like status bars, navigation bars, and screen notches. Changes ensure consistent spacing and proper positioning of content throughout the app, providing a more polished and visually cohesive experience across all devices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sheepdestroyer/materialisheep/pull/267?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->