### PR TITLE
🧹 [code health improvement] Remove unused import in LazyLoadFragment

### DIFF
--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/LazyLoadFragment.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/LazyLoadFragment.java
@@ -16,7 +16,6 @@
 
 package io.github.sheepdestroyer.materialisheep;
 
-import android.content.Context;
 import android.os.Bundle;
 import androidx.lifecycle.ViewModelProvider;
 


### PR DESCRIPTION
🎯 **What:** Removed unused `import android.content.Context;` from `LazyLoadFragment.java` on line 19.
💡 **Why:** To improve maintainability and keep the codebase clean and warning-free without affecting behavior.
✅ **Verification:** Verified by compiling the app and successfully running the full unit test suite (`./gradlew testDebugUnitTest`).
✨ **Result:** A cleaner file with no unused imports and unchanged functionality.

---
*PR created automatically by Jules for task [10749339922610045953](https://jules.google.com/task/10749339922610045953) started by @sheepdestroyer*

## Summary by Sourcery

Enhancements:
- Clean up LazyLoadFragment by removing an unused Android Context import.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused internal code without affecting app functionality or user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->