### PR TITLE
🧹 [code health improvement] Remove unused imports in ItemSyncJobService

### DIFF
--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/data/ItemSyncJobService.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/data/ItemSyncJobService.java
@@ -16,10 +16,8 @@
 
 package io.github.sheepdestroyer.materialisheep.data;
 
-import android.annotation.TargetApi;
 import android.app.job.JobParameters;
 import android.app.job.JobService;
-import android.os.Build;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 import android.text.TextUtils;


### PR DESCRIPTION
🎯 **What:** Removed unused imports `android.os.Build` and `android.annotation.TargetApi` from `app/src/main/java/io/github/sheepdestroyer/materialisheep/data/ItemSyncJobService.java`.
💡 **Why:** These imports were left over as dead code (likely from a previous annotation removal or API level bump). Removing them reduces clutter and improves readability without changing any behavior.
✅ **Verification:** Ran `./gradlew testDebugUnitTest --no-daemon` and confirmed all unit tests pass, ensuring no unintended side effects. Requested and passed automated code review.
✨ **Result:** A cleaner, more maintainable class file with fewer unused dependencies.

---
*PR created automatically by Jules for task [1069990738210352198](https://jules.google.com/task/1069990738210352198) started by @sheepdestroyer*

## Summary by Sourcery

Enhancements:
- Remove unused android.os.Build and android.annotation.TargetApi imports from ItemSyncJobService to reduce clutter and improve code readability.