### PR TITLE
🧹 [code health improvement] Fix empty catch block in Preferences.java

### DIFF
--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/Preferences.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/Preferences.java
@@ -22,6 +22,7 @@ import android.content.SharedPreferences;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.text.TextUtils;
+import android.util.Log;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -483,7 +484,7 @@ public class Preferences {
             try {
                 info = context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
             } catch (PackageManager.NameNotFoundException e) {
-                // no op
+                Log.w("Preferences", "Failed to get package info", e);
             }
             // considered seen if first time install or last seen release is up to date
             if (info != null && info.firstInstallTime == info.lastUpdateTime) {


### PR DESCRIPTION
🎯 **What:** Added a log statement to an empty `catch` block for `PackageManager.NameNotFoundException` in `Preferences.isReleaseNotesSeen()`.
💡 **Why:** Silently swallowing exceptions is a bad practice. Adding a log statement ensures that if this exception occurs, it is recorded for debugging purposes without altering the application's flow.
✅ **Verification:** Ran the full test suite (`./gradlew testDebugUnitTest`) to ensure no regressions were introduced.
✨ **Result:** Improved code health and maintainability by logging the exception rather than silently ignoring it.

---
*PR created automatically by Jules for task [13141328294005938343](https://jules.google.com/task/13141328294005938343) started by @sheepdestroyer*

## Summary by Sourcery

Enhancements:
- Add warning log for PackageManager.NameNotFoundException in release notes preference handling to improve debuggability.