### PR TITLE
Migrate from deprecated Fragment.instantiate API

### DIFF
--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/PreferencesActivity.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/PreferencesActivity.java
@@ -26,7 +26,6 @@ import android.view.MenuItem;
 /**
  * An activity that displays a preference screen.
  */
-@SuppressWarnings("deprecation") // TODO: Uses deprecated Fragment.instantiate API
 public class PreferencesActivity extends ThemedActivity {
     public static final String EXTRA_TITLE = PreferencesActivity.class.getName() + ".EXTRA_TITLE";
     public static final String EXTRA_PREFERENCES = PreferencesActivity.class.getName() + ".EXTRA_PREFERENCES";
@@ -53,10 +52,12 @@ public class PreferencesActivity extends ThemedActivity {
         if (savedInstanceState == null) {
             Bundle args = new Bundle();
             args.putInt(EXTRA_PREFERENCES, getIntent().getIntExtra(EXTRA_PREFERENCES, 0));
+            SettingsFragment fragment = new SettingsFragment();
+            fragment.setArguments(args);
             getSupportFragmentManager()
                     .beginTransaction()
                     .add(R.id.content_frame,
-                            Fragment.instantiate(this, SettingsFragment.class.getName(), args),
+                            fragment,
                             SettingsFragment.class.getName())
                     .commit();
         }


### PR DESCRIPTION
**What:**
Migrated away from the deprecated `Fragment.instantiate` API in `PreferencesActivity.java` and removed the corresponding `@SuppressWarnings("deprecation")` and TODO comment.

**Why:**
The `Fragment.instantiate(Context, String, Bundle)` API is deprecated in modern Android development. The standard and recommended approach is to instantiate the fragment directly using its constructor and pass arguments using `setArguments()`.

**Impact:**
Improves code health and aligns with modern Android API recommendations without altering existing behavior.

**Measurement:**
Verified correctness via standard unit test suite execution which passed successfully.

---
*PR created automatically by Jules for task [1375799391020288317](https://jules.google.com/task/1375799391020288317) started by @sheepdestroyer*

## Summary by Sourcery

Enhancements:
- Remove the deprecation suppression and TODO comment now that PreferencesActivity uses non-deprecated fragment instantiation.