### PR TITLE
🧪 [testing improvement] Add missing error test for getStories in AlgoliaClient

### DIFF
--- a/app/src/test/java/io/github/sheepdestroyer/materialisheep/data/AlgoliaClientTest.java
+++ b/app/src/test/java/io/github/sheepdestroyer/materialisheep/data/AlgoliaClientTest.java
@@ -1,0 +1,70 @@
+package io.github.sheepdestroyer.materialisheep.data;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricTestRunner;
+
+import java.io.IOException;
+
+import io.reactivex.rxjava3.schedulers.Schedulers;
+import retrofit2.Call;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
+
+@RunWith(RobolectricTestRunner.class)
+public class AlgoliaClientTest {
+
+    @Mock
+    RestServiceFactory restServiceFactory;
+
+    @Mock
+    AlgoliaClient.RestService restService;
+
+    @Mock
+    ItemManager hackerNewsClient;
+
+    @Mock
+    Call<AlgoliaClient.AlgoliaHits> mockCall;
+
+    private AlgoliaClient algoliaClient;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        when(restServiceFactory.rxEnabled(true)).thenReturn(restServiceFactory);
+        when(restServiceFactory.create(anyString(), eq(AlgoliaClient.RestService.class))).thenReturn(restService);
+        algoliaClient = new AlgoliaClient(restServiceFactory, hackerNewsClient, Schedulers.trampoline());
+    }
+
+    @Test
+    public void testGetStories_IOException() throws IOException {
+        when(restService.search(anyString(), isNull())).thenReturn(mockCall);
+        when(mockCall.execute()).thenThrow(new IOException("Network error"));
+
+        AlgoliaClient.sSortByTime = false;
+        Item[] result = algoliaClient.getStories("filter", ItemManager.MODE_DEFAULT);
+
+        assertNotNull(result);
+        assertEquals(0, result.length);
+    }
+
+    @Test
+    public void testGetStoriesByDate_IOException() throws IOException {
+        when(restService.searchByDate(anyString(), isNull())).thenReturn(mockCall);
+        when(mockCall.execute()).thenThrow(new IOException("Network error"));
+
+        AlgoliaClient.sSortByTime = true;
+        Item[] result = algoliaClient.getStories("filter", ItemManager.MODE_DEFAULT);
+
+        assertNotNull(result);
+        assertEquals(0, result.length);
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `AlgoliaClient.getStories` method handles IOExceptions thrown by the underlying Retrofit Call, but this error path was not covered by tests. We added a new test class `AlgoliaClientTest` to mock the RestService and Call, specifically throwing an `IOException` to ensure an empty array `Item[0]` is correctly returned without crashing.

📊 **Coverage:** What scenarios are now tested
- The happy path for `sSortByTime = true` throwing an `IOException` during `getStories`.
- The happy path for `sSortByTime = false` throwing an `IOException` during `getStories`.
- Verified that an empty `Item[]` array is returned for both branches when network calls fail.

✨ **Result:** The improvement in test coverage
`AlgoliaClient.getStories` error handling is now fully verified. Regressions in error reporting for search requests via Algolia will now be caught by the test suite, preventing unexpected app crashes when the network is unavailable.

---
*PR created automatically by Jules for task [8017765959348559314](https://jules.google.com/task/8017765959348559314) started by @sheepdestroyer*

## Summary by Sourcery

Tests:
- Introduce AlgoliaClientTest to cover IOException handling for both time-sorted and default getStories search paths.