### PR TITLE
🧪 [testing improvement] Add missing error test for parseLoginError

### DIFF
--- a/app/src/test/java/io/github/sheepdestroyer/materialisheep/accounts/UserServicesClientTest.java
+++ b/app/src/test/java/io/github/sheepdestroyer/materialisheep/accounts/UserServicesClientTest.java
@@ -1,0 +1,41 @@
+package io.github.sheepdestroyer.materialisheep.accounts;
+
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import okhttp3.Call;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class UserServicesClientTest {
+    private UserServicesClient mUserServicesClient;
+
+    @Before
+    public void setUp() {
+        Call.Factory callFactory = mock(Call.Factory.class);
+        mUserServicesClient = new UserServicesClient(callFactory, Schedulers.trampoline());
+    }
+
+    @Test
+    public void testParseLoginError_ioExceptionReturnsNull() throws Exception {
+        Response response = mock(Response.class);
+        ResponseBody responseBody = mock(ResponseBody.class);
+
+        when(response.body()).thenReturn(responseBody);
+        when(responseBody.string()).thenThrow(new IOException("Mock IO Exception"));
+
+        // Access the private method using reflection since we want to test it specifically
+        java.lang.reflect.Method method = UserServicesClient.class.getDeclaredMethod("parseLoginError", Response.class);
+        method.setAccessible(true);
+
+        String result = (String) method.invoke(mUserServicesClient, response);
+        assertNull(result);
+    }
+}


### PR DESCRIPTION
🎯 **What:** Addressed a testing gap in `UserServicesClient.java` by adding a unit test for the private `parseLoginError` method. This method catches `IOException` when reading a login response body fails.

📊 **Coverage:** Added test coverage for the error condition where reading the OkHttp `ResponseBody.string()` throws an `IOException`. The test verifies that the method catches the exception and correctly returns `null`.

✨ **Result:** Increased test coverage and ensured reliable error handling for the login process in the presence of network or I/O errors. All tests pass with no regressions.

---
*PR created automatically by Jules for task [6115988149747697714](https://jules.google.com/task/6115988149747697714) started by @sheepdestroyer*

## Summary by Sourcery

Tests:
- Introduce a unit test verifying that parseLoginError returns null when ResponseBody.string() throws an IOException.