### PR TITLE
🔒 [security fix] Fix path traversal vulnerability in FileDownloader

### DIFF
--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/data/FileDownloader.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/data/FileDownloader.java
@@ -12,6 +12,7 @@ import javax.inject.Inject;
 
 import io.github.sheepdestroyer.materialisheep.annotation.Synthetic;
 import okhttp3.Call;
+import okio.ByteString;
 import okhttp3.Callback;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -48,7 +49,8 @@ public class FileDownloader {
      */
     @WorkerThread
     public void downloadFile(String url, String mimeType, FileDownloaderCallback callback) {
-        File outputFile = new File(mCacheDir, new File(url).getName());
+        String filename = ByteString.encodeUtf8(url).sha256().hex();
+        File outputFile = new File(mCacheDir, filename);
         if (outputFile.exists()) {
             mMainHandler.post(() -> callback.onSuccess(outputFile.getPath()));
             return;


### PR DESCRIPTION
🎯 **What:** Fixed a path traversal vulnerability in `FileDownloader` where `new File(url).getName()` was used directly to create cache files.
⚠️ **Risk:** An attacker could craft a malicious URL (or a server could respond with one) containing directory traversal sequences (like `../`), potentially overwriting sensitive files elsewhere on the device.
🛡️ **Solution:** Replaced `new File(url).getName()` with a secure SHA-256 hash of the full URL using `okio.ByteString.encodeUtf8(url).sha256().hex()`. This guarantees a safe, unique, and purely alphanumeric filename, neutralizing any path traversal payloads.

---
*PR created automatically by Jules for task [12743478638601623084](https://jules.google.com/task/12743478638601623084) started by @sheepdestroyer*

## Summary by Sourcery

Bug Fixes:
- Prevent path traversal in FileDownloader cache file creation by replacing URL-derived filenames with a SHA-256 hash of the URL.