### PR TITLE
🧹 [code health improvement] Ensure sync finishes only once

### DIFF
--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/data/SyncDelegate.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/data/SyncDelegate.java
@@ -77,6 +77,7 @@ public class SyncDelegate {
   private final Context mContext;
   private ProgressListener mListener;
   private Job mJob;
+  private boolean mFinished;
   @VisibleForTesting CacheableWebView mWebView;
 
   /**
@@ -167,6 +168,7 @@ public class SyncDelegate {
 
   void performSync(@NonNull Job job) {
     // assume that connection wouldn't change until we finish syncing
+    mFinished = false;
     mJob = job;
     if (!TextUtils.isEmpty(mJob.id)) {
       Message message = Message.obtain(mHandler, this::stopSync);
@@ -304,8 +306,12 @@ public class SyncDelegate {
   }
 
   private void updateProgress() {
+    if (mFinished) {
+      return;
+    }
     if (mSyncProgress.getProgress() >= mSyncProgress.getMax()) { // TODO may never done
-      finish(); // TODO finish once only
+      mFinished = true;
+      finish();
     } else if (mJob.notificationEnabled) {
       showProgress();
     }


### PR DESCRIPTION
🎯 **What:** Introduced a private boolean flag `mFinished` in `SyncDelegate.java` to track if the sync process has been marked as finished, preventing duplicate `finish()` invocations.
💡 **Why:** Addressed a `TODO` comment indicating that the sync finish logic should only occur once. Previously, if `updateProgress()` was invoked multiple times rapidly at the end of a sync, `finish()` might be executed repeatedly, leading to potential inconsistent state or redundant teardown operations. Using a boolean flag ensures the teardown block executes safely exactly once per `performSync()` cycle.
✅ **Verification:** Verified locally by running the full unit test suite (`./gradlew testDebugUnitTest --no-daemon`) to ensure no regressions were introduced.
✨ **Result:** Improved state predictability and code health by implementing an explicit guard against duplicate finalization routines.

---
*PR created automatically by Jules for task [1652089712169383853](https://jules.google.com/task/1652089712169383853) started by @sheepdestroyer*

## Summary by Sourcery

Guard sync completion to ensure finalization runs only once per sync cycle.

Bug Fixes:
- Prevent multiple invocations of sync finalization when progress updates reach completion repeatedly.

Enhancements:
- Introduce an internal finished flag in the sync delegate to improve state tracking and code health around sync completion.