### PR TITLE
🧪 [testing improvement] Add error test for AdBlocker asset loading

### DIFF
--- a/app/src/test/java/io/github/sheepdestroyer/materialisheep/AdBlockerTest.java
+++ b/app/src/test/java/io/github/sheepdestroyer/materialisheep/AdBlockerTest.java
@@ -1,0 +1,56 @@
+package io.github.sheepdestroyer.materialisheep;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import android.content.Context;
+import android.content.ContextWrapper;
+import android.content.res.AssetManager;
+import androidx.test.core.app.ApplicationProvider;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.Set;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class AdBlockerTest {
+
+    @Test
+    public void init_whenAssetManagerThrowsIOException_listRemainsEmpty() throws Exception {
+        Context context = ApplicationProvider.getApplicationContext();
+
+        Field field = AdBlocker.class.getDeclaredField("AD_HOSTS");
+        field.setAccessible(true);
+        Set<String> adHosts = (Set<String>) field.get(null);
+
+        // Wait for the background task from Application to finish
+        int retries = 50;
+        while (adHosts.isEmpty() && retries > 0) {
+            Thread.sleep(100);
+            retries--;
+        }
+
+        // Clear it now that it's done
+        adHosts.clear();
+
+        AssetManager mockAssetManager = mock(AssetManager.class);
+        when(mockAssetManager.open(anyString())).thenThrow(new IOException("Mock exception"));
+
+        Context wrapper = new ContextWrapper(context) {
+            @Override
+            public AssetManager getAssets() {
+                return mockAssetManager;
+            }
+        };
+
+        AdBlocker.init(wrapper, Schedulers.trampoline());
+
+        assertTrue("AD_HOSTS should be empty when IOException occurs", adHosts.isEmpty());
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap for handling missing or corrupt AdBlocker asset files was addressed.
📊 **Coverage:** Tested the scenario where `AssetManager` throws an `IOException` while trying to open the ad hosts file, validating that the internal `AD_HOSTS` list remains empty.
✨ **Result:** Test coverage for `AdBlocker` initialization improved, ensuring it degrades gracefully without crashing the application when resources are unavailable.

---
*PR created automatically by Jules for task [6603884069328513992](https://jules.google.com/task/6603884069328513992) started by @sheepdestroyer*

## Summary by Sourcery

Tests:
- Introduce AdBlockerTest to cover the case where AssetManager throws an IOException and ensure the AD_HOSTS set remains empty.