### PR TITLE
🧪 [testing improvement] Add error test for loading Readability.js

### DIFF
--- a/app/src/test/java/io/github/sheepdestroyer/materialisheep/data/ReadabilityClientTest.java
+++ b/app/src/test/java/io/github/sheepdestroyer/materialisheep/data/ReadabilityClientTest.java
@@ -1,0 +1,42 @@
+package io.github.sheepdestroyer.materialisheep.data;
+
+import android.content.Context;
+import android.content.res.AssetManager;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.io.IOException;
+
+import io.reactivex.rxjava3.core.Scheduler;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(RobolectricTestRunner.class)
+public class ReadabilityClientTest {
+
+    @Test
+    public void testInit_assetException() throws IOException {
+        Context context = mock(Context.class);
+        AssetManager assetManager = mock(AssetManager.class);
+        LocalCache cache = mock(LocalCache.class);
+
+        when(context.getAssets()).thenReturn(assetManager);
+        when(assetManager.open(eq("Readability.js"))).thenThrow(new IOException("Test exception"));
+
+        Scheduler ioScheduler = Schedulers.trampoline();
+        Scheduler mainThreadScheduler = Schedulers.trampoline();
+
+        // This should handle the IOException internally and not crash
+        ReadabilityClient.Impl client = new ReadabilityClient.Impl(context, cache, ioScheduler, mainThreadScheduler);
+
+        assertNotNull(client);
+        verify(assetManager).open(eq("Readability.js"));
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap where `ReadabilityClient.Impl` loads "Readability.js" from assets and catches an `IOException` was not being exercised. Added a unit test covering this exception block.
📊 **Coverage:** A new `ReadabilityClientTest` class was added to test the scenario where `AssetManager.open("Readability.js")` throws an `IOException`, ensuring the exception is caught during instantiation and doesn't crash the application.
✨ **Result:** The `try-catch` block inside the constructor of `ReadabilityClient.Impl` is now fully covered by unit tests, increasing overall code testability and reliability.

---
*PR created automatically by Jules for task [15565390388146065631](https://jules.google.com/task/15565390388146065631) started by @sheepdestroyer*

## Summary by Sourcery

Tests:
- Introduce ReadabilityClientTest to cover the scenario where AssetManager.open("Readability.js") throws an IOException, ensuring the client still initializes successfully.