### PR TITLE
🧪 [testing improvement] Add error test for getFromCache in SyncDelegate

### DIFF
--- a/app/src/test/java/io/github/sheepdestroyer/materialisheep/data/SyncDelegateTest.java
+++ b/app/src/test/java/io/github/sheepdestroyer/materialisheep/data/SyncDelegateTest.java
@@ -1,0 +1,64 @@
+package io.github.sheepdestroyer.materialisheep.data;
+
+import android.content.Context;
+import androidx.test.core.app.ApplicationProvider;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricTestRunner;
+
+import java.io.IOException;
+import java.util.concurrent.Executor;
+
+import retrofit2.Call;
+
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@RunWith(RobolectricTestRunner.class)
+public class SyncDelegateTest {
+
+    @Mock
+    RestServiceFactory factory;
+
+    @Mock
+    ReadabilityClient readabilityClient;
+
+    @Mock
+    HackerNewsClient.RestService restService;
+
+    @Mock
+    Call<HackerNewsItem> mockCall;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        when(factory.create(
+                eq(HackerNewsClient.BASE_API_URL),
+                eq(HackerNewsClient.RestService.class),
+                any(Executor.class)
+        )).thenReturn(restService);
+    }
+
+    @Test
+    public void testGetFromCache_ioException_returnsNull() throws Exception {
+        Context context = ApplicationProvider.getApplicationContext();
+        SyncDelegate syncDelegate = new SyncDelegate(context, factory, readabilityClient);
+
+        String itemId = "123";
+        when(restService.cachedItem(itemId)).thenReturn(mockCall);
+        when(mockCall.execute()).thenThrow(new IOException("Test exception"));
+
+        // Use reflection to access the private method
+        java.lang.reflect.Method method = SyncDelegate.class.getDeclaredMethod("getFromCache", String.class);
+        method.setAccessible(true);
+        HackerNewsItem result = (HackerNewsItem) method.invoke(syncDelegate, itemId);
+
+        assertNull(result);
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added a unit test for the private `getFromCache` method in `SyncDelegate.java` to verify it correctly returns `null` when an `IOException` is thrown by the underlying `HnRestService`.

📊 **Coverage:** The new `SyncDelegateTest` class covers the previously untested error path (the `catch (IOException e)` block) in `getFromCache`.

✨ **Result:** Improved test coverage for `SyncDelegate`, ensuring that network failures during cache retrieval are safely handled and do not crash the synchronization process.

---
*PR created automatically by Jules for task [2423564874903565653](https://jules.google.com/task/2423564874903565653) started by @sheepdestroyer*

## Summary by Sourcery

Tests:
- Introduce SyncDelegateTest to verify getFromCache returns null when the underlying RestService throws an IOException.