### PR TITLE
🧪 [testing improvement] Add error tests for parseSwipeAction

### DIFF
--- a/app/src/test/java/io/github/sheepdestroyer/materialisheep/PreferencesTest.java
+++ b/app/src/test/java/io/github/sheepdestroyer/materialisheep/PreferencesTest.java
@@ -1,5 +1,6 @@
 package io.github.sheepdestroyer.materialisheep;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -69,5 +70,19 @@ public class PreferencesTest {
     // Set to false
     Preferences.setSortByRecent(context, false);
     assertFalse(Preferences.isSortByRecent(context));
+  }
+
+  @Test
+  public void testParseSwipeActionErrorHandling() throws Exception {
+    java.lang.reflect.Method method = Preferences.class.getDeclaredMethod("parseSwipeAction", String.class);
+    method.setAccessible(true);
+
+    // Test invalid string (IllegalArgumentException)
+    Object resultInvalid = method.invoke(null, "InvalidSwipeAction");
+    assertEquals(Preferences.SwipeAction.None, resultInvalid);
+
+    // Test null (NullPointerException)
+    Object resultNull = method.invoke(null, (String) null);
+    assertEquals(Preferences.SwipeAction.None, resultNull);
   }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of unit tests covering the error handling (catch block) of the private `parseSwipeAction` method in `Preferences.java`.
📊 **Coverage:** The scenarios now tested include passing an invalid string (`"InvalidSwipeAction"`) which triggers an `IllegalArgumentException`, and passing a `null` value which triggers a `NullPointerException`. The test verifies that both cases are successfully caught and return `SwipeAction.None`.
✨ **Result:** Test coverage is improved by fully exercising all paths and edge cases within the `parseSwipeAction` method.

---
*PR created automatically by Jules for task [7034721967148787216](https://jules.google.com/task/7034721967148787216) started by @sheepdestroyer*

## Summary by Sourcery

Tests:
- Add tests verifying parseSwipeAction returns SwipeAction.None for invalid strings and null input.