### PR TITLE
🧹 [code health improvement] Ensure sync finishes only once in SyncDelegate

### DIFF
--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/data/SyncDelegate.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/data/SyncDelegate.java
@@ -78,6 +78,7 @@ public class SyncDelegate {
   private ProgressListener mListener;
   private Job mJob;
   @VisibleForTesting CacheableWebView mWebView;
+  private boolean mFinished;
 
   /**
    * Constructs a new {@code SyncDelegate}.
@@ -173,6 +174,7 @@ public class SyncDelegate {
       message.what = Integer.valueOf(mJob.id);
       mHandler.sendMessageDelayed(message, TIMEOUT_MILLIS);
       mSyncProgress = new SyncProgress(mJob);
+      mFinished = false;
       sync(mJob.id);
     } else {
       syncDeferredItems();
@@ -305,7 +307,10 @@ public class SyncDelegate {
 
   private void updateProgress() {
     if (mSyncProgress.getProgress() >= mSyncProgress.getMax()) { // TODO may never done
-      finish(); // TODO finish once only
+      if (!mFinished) {
+        mFinished = true;
+        finish();
+      }
     } else if (mJob.notificationEnabled) {
       showProgress();
     }


### PR DESCRIPTION
🎯 **What:** Introduced a `mFinished` boolean flag in `SyncDelegate` to track if the synchronization process has already been finalized.
💡 **Why:** A TODO comment highlighted that `finish()` could potentially be called multiple times. Adding this simple boolean flag ensures that the finish logic is strictly executed only once, improving code health and avoiding unnecessary duplicate UI notifications or logical errors.
✅ **Verification:** Verified by compiling the app and successfully running the full test suite (`./gradlew testDebugUnitTest`). Code review was also successfully performed and passed.
✨ **Result:** The `SyncDelegate` now guarantees that `finish()` is processed precisely once per job execution, correctly preserving existing control flow while ensuring long-term code maintainability.

---
*PR created automatically by Jules for task [12749105164773682012](https://jules.google.com/task/12749105164773682012) started by @sheepdestroyer*

## Summary by Sourcery

Ensure SyncDelegate finalizes synchronization only once per job execution to prevent duplicate finish handling.

Bug Fixes:
- Prevent multiple invocations of SyncDelegate.finish() when sync progress reaches completion.

Enhancements:
- Introduce an mFinished flag in SyncDelegate to track completion state and improve synchronization control flow clarity.