### PR TITLE
🧪 [testing improvement] Add error test for HackerNewsClient.getItem

### DIFF
--- a/app/src/test/java/io/github/sheepdestroyer/materialisheep/data/HackerNewsClientTest.java
+++ b/app/src/test/java/io/github/sheepdestroyer/materialisheep/data/HackerNewsClientTest.java
@@ -1,0 +1,56 @@
+package io.github.sheepdestroyer.materialisheep.data;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricTestRunner;
+
+import java.io.IOException;
+
+import retrofit2.Call;
+import retrofit2.Response;
+
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@RunWith(RobolectricTestRunner.class)
+public class HackerNewsClientTest {
+
+    @Mock
+    RestServiceFactory restServiceFactory;
+
+    @Mock
+    SessionManager sessionManager;
+
+    @Mock
+    FavoriteManager favoriteManager;
+
+    @Mock
+    HackerNewsClient.RestService restService;
+
+    @Mock
+    Call<HackerNewsItem> mockCall;
+
+    private HackerNewsClient client;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        when(restServiceFactory.rxEnabled(true)).thenReturn(restServiceFactory);
+        when(restServiceFactory.create(HackerNewsClient.BASE_API_URL, HackerNewsClient.RestService.class)).thenReturn(restService);
+        client = new HackerNewsClient(restServiceFactory, sessionManager, favoriteManager);
+    }
+
+    @Test
+    public void testGetItem_IOExceptionReturnsNull() throws IOException {
+        when(restService.item(anyString())).thenReturn(mockCall);
+        when(mockCall.execute()).thenThrow(new IOException("Test exception"));
+
+        Item item = client.getItem("1", ItemManager.MODE_DEFAULT);
+
+        assertNull("getItem should return null when execute throws IOException", item);
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added a missing unit test for the `getItem` method in `HackerNewsClient` to verify that it correctly handles an `IOException` thrown during a network call.

📊 **Coverage:** Tests the `catch (IOException e)` block in `getItem(String itemId, @CacheMode int cacheMode)` and verifies that the method returns `null` as expected in this error scenario.

✨ **Result:** Improved test coverage for `HackerNewsClient`, ensuring that network failures during item retrieval do not cause crashes and gracefully return a null result. The test passes successfully and has been verified with `./gradlew testDebugUnitTest`.

---
*PR created automatically by Jules for task [15422575082162500883](https://jules.google.com/task/15422575082162500883) started by @sheepdestroyer*

## Summary by Sourcery

Tests:
- Add Robolectric-based unit test for HackerNewsClient.getItem to verify null is returned when the network call throws an IOException.