### PR TITLE
🧪 [testing improvement] Add error handling tests for getFloatFromString

### DIFF
--- a/app/src/test/java/io/github/sheepdestroyer/materialisheep/PreferencesTest.java
+++ b/app/src/test/java/io/github/sheepdestroyer/materialisheep/PreferencesTest.java
@@ -1,5 +1,6 @@
 package io.github.sheepdestroyer.materialisheep;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -69,5 +70,25 @@ public class PreferencesTest {
     // Set to false
     Preferences.setSortByRecent(context, false);
     assertFalse(Preferences.isSortByRecent(context));
+  }
+
+  @Test
+  public void testGetFloatFromStringErrorHandling() {
+    // Test default value (NullPointerException case inside getFloatFromString)
+    assertEquals(1.0f, Preferences.getLineHeight(context), 0.001f);
+
+    // Test valid float string
+    sharedPreferences
+        .edit()
+        .putString(context.getString(R.string.pref_line_height), "2.5")
+        .commit();
+    assertEquals(2.5f, Preferences.getLineHeight(context), 0.001f);
+
+    // Test invalid non-float string (NumberFormatException case inside getFloatFromString)
+    sharedPreferences
+        .edit()
+        .putString(context.getString(R.string.pref_line_height), "not_a_float")
+        .commit();
+    assertEquals(1.0f, Preferences.getLineHeight(context), 0.001f);
   }
 }


### PR DESCRIPTION
What: Addressed testing gap for preference float parsing errors via getLineHeight.
Coverage: Valid float parsing, NumberFormatException for invalid strings, NullPointerException for missing values.
Result: Improved test coverage and reliability for preference parsing.

---
*PR created automatically by Jules for task [7673326693252845902](https://jules.google.com/task/7673326693252845902) started by @sheepdestroyer*

## Summary by Sourcery

Tests:
- Add tests validating default line height, successful float parsing, and fallback behavior on invalid or missing preference values.