### PR TITLE
🧪 [testing improvement] Add missing test for HackerNewsClient.getStories

### DIFF
--- a/app/src/test/java/io/github/sheepdestroyer/materialisheep/data/HackerNewsClientTest.java
+++ b/app/src/test/java/io/github/sheepdestroyer/materialisheep/data/HackerNewsClientTest.java
@@ -1,0 +1,52 @@
+package io.github.sheepdestroyer.materialisheep.data;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import static org.mockito.Mockito.*;
+import static org.junit.Assert.*;
+
+import retrofit2.Call;
+import retrofit2.Response;
+import java.io.IOException;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class HackerNewsClientTest {
+
+    @Mock
+    private RestServiceFactory restServiceFactory;
+    @Mock
+    private HackerNewsClient.RestService restService;
+    @Mock
+    private SessionManager sessionManager;
+    @Mock
+    private FavoriteManager favoriteManager;
+    @Mock
+    private Call<int[]> mockCall;
+
+    private HackerNewsClient client;
+
+    @Before
+    public void setUp() {
+        when(restServiceFactory.rxEnabled(true)).thenReturn(restServiceFactory);
+        when(restServiceFactory.create(HackerNewsClient.BASE_API_URL, HackerNewsClient.RestService.class)).thenReturn(restService);
+
+        client = new HackerNewsClient(restServiceFactory, sessionManager, favoriteManager);
+        // We do not have direct access to set mIoScheduler and mMainThreadScheduler,
+        // but the synchronous method getStories(filter, cacheMode) does not use them anyway.
+    }
+
+    @Test
+    public void getStories_ioException_returnsEmptyArray() throws IOException {
+        when(restService.topStories()).thenReturn(mockCall);
+        when(mockCall.execute()).thenThrow(new IOException("Network error"));
+
+        Item[] items = client.getStories(ItemManager.TOP_FETCH_MODE, ItemManager.MODE_DEFAULT);
+
+        assertNotNull(items);
+        assertEquals(0, items.length);
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added a missing unit test to `HackerNewsClientTest` for the synchronous `getStories` method. This addresses the testing gap by asserting the correct fallback behavior when the network call fails.

📊 **Coverage:** The new test covers the error condition (specifically an `IOException` thrown during `execute()`) of the synchronous `getStories` method in `HackerNewsClient`, ensuring it handles network failures safely by returning an empty `Item[]` array rather than crashing or returning null.

✨ **Result:** Test coverage for `HackerNewsClient` has improved by covering its core `getStories` error path, reducing the risk of regressions and unhandled exceptions propagating from network errors.

---
*PR created automatically by Jules for task [8737506748239189268](https://jules.google.com/task/8737506748239189268) started by @sheepdestroyer*

## Summary by Sourcery

Tests:
- Add a new HackerNewsClientTest verifying getStories returns an empty Item array when the underlying network call throws an IOException.