### PR TITLE
🧹 [code health improvement] Migrate deprecated Custom Tabs and SystemUI APIs in AppUtils

### DIFF
--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/AppUtils.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/AppUtils.java
@@ -57,6 +57,10 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StyleRes;
 import androidx.browser.customtabs.CustomTabsIntent;
+import androidx.browser.customtabs.CustomTabColorSchemeParams;
+import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.core.view.WindowInsetsControllerCompat;
 import androidx.browser.customtabs.CustomTabsSession;
 import androidx.core.content.ContextCompat;
 import androidx.core.util.Pair;
@@ -73,10 +77,7 @@ import io.github.sheepdestroyer.materialisheep.widget.PopupMenu;
 import java.util.ArrayList;
 import java.util.List;
 
-@SuppressWarnings({
-  "WeakerAccess",
-  "deprecation"
-}) // TODO: Uses deprecated SystemUI, Custom Tabs APIs
+@SuppressWarnings("WeakerAccess")
 @PublicApi
 /**
  * A utility class providing common functions for the application. This includes methods for
@@ -858,13 +859,12 @@ public class AppUtils {
     if (Preferences.customTabsEnabled(context)) {
       CustomTabsIntent.Builder builder =
           new CustomTabsIntent.Builder(session)
-              .setToolbarColor(
-                  ContextCompat.getColor(
-                      context,
-                      AppUtils.getThemedResId(context, androidx.appcompat.R.attr.colorPrimary)))
+              .setDefaultColorSchemeParams(
+                  new CustomTabColorSchemeParams.Builder().setToolbarColor(
+                      ContextCompat.getColor(context, AppUtils.getThemedResId(context, androidx.appcompat.R.attr.colorPrimary))).build())
               .setShowTitle(true)
-              .enableUrlBarHiding()
-              .addDefaultShareMenuItem();
+              .setUrlBarHidingEnabled(true)
+              .setShareState(CustomTabsIntent.SHARE_STATE_ON);
       if (item != null) {
         builder.addMenuItem(
             context.getString(R.string.comments),
@@ -928,28 +928,22 @@ public class AppUtils {
 
   static class SystemUiHelper {
     private final Window window;
-    private final int originalUiFlags;
     private boolean enabled = true;
 
     SystemUiHelper(Window window) {
       this.window = window;
-      this.originalUiFlags = window.getDecorView().getSystemUiVisibility();
     }
 
-    @SuppressLint("InlinedApi")
     void setFullscreen(boolean fullscreen) {
       if (!enabled) {
         return;
       }
+      WindowInsetsControllerCompat controller = WindowCompat.getInsetsController(window, window.getDecorView());
       if (fullscreen) {
-        window
-            .getDecorView()
-            .setSystemUiVisibility(
-                originalUiFlags
-                    | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-                    | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
+        controller.hide(WindowInsetsCompat.Type.navigationBars());
+        controller.setSystemBarsBehavior(WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
       } else {
-        window.getDecorView().setSystemUiVisibility(originalUiFlags);
+        controller.show(WindowInsetsCompat.Type.navigationBars());
       }
     }
 


### PR DESCRIPTION
🎯 **What:** Migrated deprecated `CustomTabsIntent.Builder` API calls (like `setToolbarColor`, `enableUrlBarHiding`, and `addDefaultShareMenuItem`) to their modern AndroidX counterparts (`setDefaultColorSchemeParams`, `setUrlBarHidingEnabled`, and `setShareState(CustomTabsIntent.SHARE_STATE_ON)`). Additionally, migrated deprecated `View.setSystemUiVisibility` logic for manipulating system bars to the modern `WindowInsetsControllerCompat`. Removed corresponding `@SuppressWarnings("deprecation")` annotations from the class.

💡 **Why:** Custom Tabs and SystemUI bitwise flags are deprecated. Using modern AndroidX classes like `CustomTabColorSchemeParams` and `WindowInsetsControllerCompat` ensures better compatibility and prevents potential feature-breaking bugs in newer SDKs, while making the code simpler to maintain and read.

✅ **Verification:** Ran `lint`, `check`, and `testDebugUnitTest` specifically on `io.github.sheepdestroyer.materialisheep.AppUtilsTest` and globally using `./gradlew testDebugUnitTest`.

✨ **Result:** Improved code health and maintainability by using modern, supported AndroidX APIs without modifying existing application behavior.

---
*PR created automatically by Jules for task [8619507456656426544](https://jules.google.com/task/8619507456656426544) started by @sheepdestroyer*

## Summary by Sourcery

Migrate deprecated Custom Tabs and system UI handling in AppUtils to modern AndroidX APIs.

Bug Fixes:
- Ensure fullscreen navigation bar handling uses WindowInsetsControllerCompat instead of deprecated system UI flags.

Enhancements:
- Update CustomTabsIntent configuration to use color scheme params, modern URL bar hiding, and share state APIs.
- Remove obsolete deprecation suppression now that Custom Tabs and system UI usage is modernized.