### PR TITLE
🧹 [code health improvement] Migrate from deprecated TaskDescription API

### DIFF
--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/ThemedActivity.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/ThemedActivity.java
@@ -35,7 +35,6 @@ import android.view.Menu;
 /**
  * An abstract base activity that supports different themes.
  */
-@SuppressWarnings("deprecation") // TODO: Uses deprecated TaskDescription API
 public abstract class ThemedActivity extends AppCompatActivity {
     private final MenuTintDelegate mMenuTintDelegate = new MenuTintDelegate();
     private final Preferences.Observable mThemeObservable = new Preferences.Observable();
@@ -176,10 +175,23 @@ public abstract class ThemedActivity extends AppCompatActivity {
 
     void setTaskTitle(CharSequence title) {
         if (!TextUtils.isEmpty(title)) {
-            setTaskDescription(new ActivityManager.TaskDescription(title.toString(),
-                    BitmapFactory.decodeResource(getResources(), R.drawable.ic_app),
-                    ContextCompat.getColor(this,
-                            AppUtils.getThemedResId(this, androidx.appcompat.R.attr.colorPrimary))));
+            int primaryColor = ContextCompat.getColor(this,
+                    AppUtils.getThemedResId(this, androidx.appcompat.R.attr.colorPrimary));
+            ActivityManager.TaskDescription taskDescription;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                taskDescription = new ActivityManager.TaskDescription.Builder()
+                        .setLabel(title.toString())
+                        .setIcon(R.drawable.ic_app)
+                        .setPrimaryColor(primaryColor)
+                        .build();
+            } else {
+                @SuppressWarnings("deprecation")
+                ActivityManager.TaskDescription legacyTaskDescription = new ActivityManager.TaskDescription(title.toString(),
+                        BitmapFactory.decodeResource(getResources(), R.drawable.ic_app),
+                        primaryColor);
+                taskDescription = legacyTaskDescription;
+            }
+            setTaskDescription(taskDescription);
         }
     }
 }


### PR DESCRIPTION
🎯 **What:** Migrated away from the deprecated `ActivityManager.TaskDescription` constructor in `ThemedActivity.java`. Replaced class-level deprecation suppression with a targeted version check using `ActivityManager.TaskDescription.Builder` for API 33+, retaining the original constructor as a fallback for compatibility.

💡 **Why:** The `TaskDescription` constructor taking a `String, Bitmap, int` was deprecated in Android 13 (Tiramisu, API 33). Migrating to the new `Builder` pattern removes the need for class-wide suppression and future-proofs the codebase against further API deprecations. 

✅ **Verification:**
- Validated via `CheckMinSdk.java` scratchpad that the code cleanly compiles for SDK > 33.
- Confirmed correct fallback implementation for pre-API 33 via `TestDep.java`.
- Ran `./gradlew testDebugUnitTest --no-daemon` to ensure no regressions in tests.
- Checked `./gradlew lintDebug` to verify no new warnings are introduced.

✨ **Result:** Improved maintainability by resolving a deprecation warning cleanly and locally without impacting older SDK support, adhering to modern Android API standards.

---
*PR created automatically by Jules for task [17848509755783683897](https://jules.google.com/task/17848509755783683897) started by @sheepdestroyer*

## Summary by Sourcery

Enhancements:
- Remove class-wide deprecation suppression and localize legacy TaskDescription usage behind a runtime version check.