### PR TITLE
🧹 [code health improvement] Fix empty catch block for SecurityException in AppUtils

### DIFF
--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/AppUtils.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/AppUtils.java
@@ -41,6 +41,7 @@ import android.text.TextUtils;
 import android.text.format.DateUtils;
 import android.text.style.ClickableSpan;
 import android.text.style.URLSpan;
+import android.util.Log;
 import android.view.ContextThemeWrapper;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
@@ -510,6 +511,7 @@ public class AppUtils {
               true);
     } catch (SecurityException e) {
       // Permission GET_ACCOUNTS not granted, ignore
+      Log.w("AppUtils", "GET_ACCOUNTS permission not granted", e);
     }
   }
 


### PR DESCRIPTION
🎯 **What:** Added a `Log.w` statement to an empty `SecurityException` catch block in `AppUtils.java` and included the required `android.util.Log` import.

💡 **Why:** Silently catching and ignoring exceptions (even expected ones like missing permissions) is an anti-pattern. Adding a simple log statement significantly improves debuggability without altering application behavior. It allows developers to see when the `GET_ACCOUNTS` permission is denied instead of the app failing silently.

✅ **Verification:** 
- Modified the catch block using standard Java/Android APIs (`android.util.Log`).
- Verified the code changes locally.
- Ran the full test suite (`./gradlew testDebugUnitTest`), which passed successfully.

✨ **Result:** Improved maintainability and debuggability of the `AppUtils` class without modifying its core behavior.

---
*PR created automatically by Jules for task [3649527946091069841](https://jules.google.com/task/3649527946091069841) started by @sheepdestroyer*

## Summary by Sourcery

Log SecurityException occurrences when GET_ACCOUNTS permission is missing in AppUtils to improve debuggability.

Enhancements:
- Add a warning log message to the SecurityException catch block in AppUtils when GET_ACCOUNTS permission is not granted.
- Import android.util.Log in AppUtils to support the new logging behavior.