### PR TITLE
🧪 [testing improvement] Add test for Preferences.getDefaultStoryView

### DIFF
--- a/app/src/test/java/io/github/sheepdestroyer/materialisheep/PreferencesTest.java
+++ b/app/src/test/java/io/github/sheepdestroyer/materialisheep/PreferencesTest.java
@@ -61,6 +61,39 @@ public class PreferencesTest {
   }
 
   @Test
+  public void testGetDefaultStoryView() {
+    // Default is Article
+    org.junit.Assert.assertEquals(Preferences.StoryViewMode.Article, Preferences.getDefaultStoryView(context));
+
+    // Test Comment mode
+    sharedPreferences
+        .edit()
+        .putString(
+            context.getString(R.string.pref_story_display),
+            context.getString(R.string.pref_story_display_value_comments))
+        .commit();
+    org.junit.Assert.assertEquals(Preferences.StoryViewMode.Comment, Preferences.getDefaultStoryView(context));
+
+    // Test Readability mode
+    sharedPreferences
+        .edit()
+        .putString(
+            context.getString(R.string.pref_story_display),
+            context.getString(R.string.pref_story_display_value_readability))
+        .commit();
+    org.junit.Assert.assertEquals(Preferences.StoryViewMode.Readability, Preferences.getDefaultStoryView(context));
+
+    // Test Article mode (explicitly set)
+    sharedPreferences
+        .edit()
+        .putString(
+            context.getString(R.string.pref_story_display),
+            context.getString(R.string.pref_story_display_value_article))
+        .commit();
+    org.junit.Assert.assertEquals(Preferences.StoryViewMode.Article, Preferences.getDefaultStoryView(context));
+  }
+
+  @Test
   public void testSetSortByRecent() {
     // Set to true
     Preferences.setSortByRecent(context, true);


### PR DESCRIPTION
🎯 **What:** The testing gap addressed for `Preferences.getDefaultStoryView`. \n📊 **Coverage:** Tested default path, Comment mode, Readability mode, and explicit Article mode scenarios. \n✨ **Result:** Enhanced test coverage and ensure reliability of the default story view preference retrieval.

---
*PR created automatically by Jules for task [9731886827911882114](https://jules.google.com/task/9731886827911882114) started by @sheepdestroyer*

## Summary by Sourcery

Tests:
- Add unit test verifying Preferences.getDefaultStoryView returns the correct mode for default, comments, readability, and explicit article settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage verifying the default story view preference.
  * Added checks for Article, Comment, and Readability view selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->