### PR TITLE
🧪 [testing improvement] Add tests for getLaunchScreen in Preferences

### DIFF
--- a/app/src/test/java/io/github/sheepdestroyer/materialisheep/PreferencesTest.java
+++ b/app/src/test/java/io/github/sheepdestroyer/materialisheep/PreferencesTest.java
@@ -70,4 +70,38 @@ public class PreferencesTest {
     Preferences.setSortByRecent(context, false);
     assertFalse(Preferences.isSortByRecent(context));
   }
+
+  @Test
+  public void testGetLaunchScreen() {
+    // Test default value
+    org.junit.Assert.assertEquals(
+        context.getString(R.string.pref_launch_screen_value_top),
+        Preferences.getLaunchScreen(context));
+
+    // Test with a different value
+    sharedPreferences
+        .edit()
+        .putString(
+            context.getString(R.string.pref_launch_screen),
+            context.getString(R.string.pref_launch_screen_value_new))
+        .commit();
+    org.junit.Assert.assertEquals(
+        context.getString(R.string.pref_launch_screen_value_new),
+        Preferences.getLaunchScreen(context));
+  }
+
+  @Test
+  public void testIsLaunchScreenLast() {
+    // Test default value
+    assertFalse(Preferences.isLaunchScreenLast(context));
+
+    // Test with last value
+    sharedPreferences
+        .edit()
+        .putString(
+            context.getString(R.string.pref_launch_screen),
+            context.getString(R.string.pref_launch_screen_value_last))
+        .commit();
+    assertTrue(Preferences.isLaunchScreenLast(context));
+  }
 }


### PR DESCRIPTION
🎯 **What:** Added missing unit tests for `Preferences.getLaunchScreen` and `Preferences.isLaunchScreenLast` methods in `PreferencesTest.java`. These methods handle reading the default launch screen preference from SharedPreferences.
📊 **Coverage:** Covered the default scenarios (happy path) as well as the behavior when specific strings (e.g., "new", "last") are set in SharedPreferences. The tests cover both `getLaunchScreen` and `isLaunchScreenLast`.
✨ **Result:** Test coverage for the `Preferences` class is increased, ensuring reliable behavior of the launch screen preference retrieval.

---
*PR created automatically by Jules for task [9800692898788427999](https://jules.google.com/task/9800692898788427999) started by @sheepdestroyer*

## Summary by Sourcery

Increase test coverage for launch screen preference behavior in the Preferences class.

Tests:
- Add unit tests verifying default and custom values returned by getLaunchScreen.
- Add unit tests verifying default and 'last' behavior of isLaunchScreenLast.