### PR TITLE
🧪 [testing improvement] Add test cases for AppUtils.urlEquals with various schemas and encodings

### DIFF
--- a/app/src/test/java/io/github/sheepdestroyer/materialisheep/AppUtilsTest.java
+++ b/app/src/test/java/io/github/sheepdestroyer/materialisheep/AppUtilsTest.java
@@ -45,6 +45,22 @@ public class AppUtilsTest {
     assertFalse(AppUtils.urlEquals("", "http://example.com"));
     assertFalse(AppUtils.urlEquals("http://example.com", ""));
     assertFalse(AppUtils.urlEquals("", ""));
+
+    // Various schemas
+    assertTrue(AppUtils.urlEquals("https://example.com", "https://example.com/"));
+    assertTrue(AppUtils.urlEquals("ftp://example.com/path", "ftp://example.com/path"));
+    assertFalse(AppUtils.urlEquals("ftp://example.com", "http://example.com"));
+    assertTrue(AppUtils.urlEquals("file:///android_asset/file.html", "file:///android_asset/file.html"));
+
+    // Encodings and query parameters
+    assertTrue(AppUtils.urlEquals("http://example.com/path%20with%20spaces", "http://example.com/path%20with%20spaces"));
+    assertFalse(AppUtils.urlEquals("http://example.com/path with spaces", "http://example.com/path%20with%20spaces"));
+    assertTrue(AppUtils.urlEquals("http://example.com/?q=query", "http://example.com/?q=query"));
+    assertFalse(AppUtils.urlEquals("http://example.com?q=query", "http://example.com/?q=query"));
+
+    // Fragments
+    assertTrue(AppUtils.urlEquals("http://example.com/#fragment", "http://example.com/#fragment"));
+    assertFalse(AppUtils.urlEquals("http://example.com", "http://example.com/#fragment"));
   }
 
   @Test


### PR DESCRIPTION
🎯 **What:** The testing gap in `AppUtilsTest.java` where `urlEquals` was not tested against various real-world URL components (schemas, encodings) has been addressed.

📊 **Coverage:** The following scenarios are now tested:
* Various schemas (`https`, `ftp`, `file://`)
* Encodings (`%20` vs spaces)
* Query parameters (`?q=query`)
* URL fragments (`#fragment`)

✨ **Result:** Test coverage for `AppUtils.urlEquals` is significantly improved, ensuring the method handles complex real-world URLs consistently without regressions.

---
*PR created automatically by Jules for task [8715608337497118353](https://jules.google.com/task/8715608337497118353) started by @sheepdestroyer*

## Summary by Sourcery

Tests:
- Add test cases for urlEquals covering multiple URL schemes, encoded paths, query parameters, and fragments.