### PR TITLE
Fix SyncDelegate finish once

### DIFF
--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/data/SyncDelegate.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/data/SyncDelegate.java
@@ -78,6 +78,7 @@ public class SyncDelegate {
   private ProgressListener mListener;
   private Job mJob;
   @VisibleForTesting CacheableWebView mWebView;
+  private boolean mFinished;
 
   /**
    * Constructs a new {@code SyncDelegate}.
@@ -305,7 +306,7 @@ public class SyncDelegate {
 
   private void updateProgress() {
     if (mSyncProgress.getProgress() >= mSyncProgress.getMax()) { // TODO may never done
-      finish(); // TODO finish once only
+      finish();
     } else if (mJob.notificationEnabled) {
       showProgress();
     }
@@ -325,6 +326,10 @@ public class SyncDelegate {
   }
 
   private void finish() {
+    if (mFinished) {
+      return;
+    }
+    mFinished = true;
     if (mListener != null) {
       mListener.onDone(mJob.id);
       mListener = null;


### PR DESCRIPTION
Added mFinished flag to SyncDelegate to ensure it finishes only once as requested.

---
*PR created automatically by Jules for task [15632215702974908038](https://jules.google.com/task/15632215702974908038) started by @sheepdestroyer*

## Summary by Sourcery

Bug Fixes:
- Prevent SyncDelegate from invoking its finish/completion logic multiple times for the same sync job.