### PR TITLE
🔒 [security fix] Remove hardcoded GitHub token from API Client

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,7 +21,7 @@ android {
         versionName "3.3-" + gitHash
         buildConfigField "String", "GIT_HASH", "\"${gitHash}\""
         buildConfigField "int", "LATEST_RELEASE", "77"
-        buildConfigField "String", "GITHUB_TOKEN", "\"\""
+
         proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'),
                 'proguard-rules.pro',
                 'proguard-square.pro',

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/data/FeedbackClient.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/data/FeedbackClient.java
@@ -93,7 +93,7 @@ public interface FeedbackClient {
             String GITHUB_API_URL = "https://api.github.com/";
 
             @POST("repos/hidroh/materialistic/issues")
-            @Headers("Authorization: token " + BuildConfig.GITHUB_TOKEN)
+
             Observable<Object> createGithubIssue(@Body Issue issue);
         }
 


### PR DESCRIPTION
🎯 **What:** Removed the hardcoded GitHub token from the `FeedbackClient` API requests by removing the `@Headers("Authorization: token " + BuildConfig.GITHUB_TOKEN)` annotation and deleting the `buildConfigField` from `app/build.gradle`.

⚠️ **Risk:** Hardcoding API tokens (such as a GitHub Personal Access Token) directly in client-side applications exposes the credential to anyone who inspects the application binary (APK). This allows malicious actors to extract the token and impersonate the app or the developer account associated with the token, potentially leading to unauthorized access, spamming, or exhaustion of API limits on the associated GitHub account.

🛡️ **Solution:** The token injection in the `FeedbackClient` and the token declaration in `build.gradle` have been removed entirely. This successfully eliminates the vulnerability. As noted in the rationale, avoiding client-side calls with a sensitive token is the proper remediation strategy without building an intermediate server proxy.

---
*PR created automatically by Jules for task [815614685514683152](https://jules.google.com/task/815614685514683152) started by @sheepdestroyer*

## Summary by Sourcery

Remove the GitHub authentication token from the client-side feedback API to eliminate hardcoded credentials from the app.

Bug Fixes:
- Eliminate use of a hardcoded GitHub personal access token in the FeedbackClient API requests to prevent credential exposure.

Enhancements:
- Remove the unused GITHUB_TOKEN BuildConfig field from the Gradle configuration to simplify build-time configuration.