### PR TITLE
🧹 [code health improvement] Migrate deprecated TaskDescription to Builder API

### DIFF
--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/ThemedActivity.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/ThemedActivity.java
@@ -177,11 +177,10 @@ public abstract class ThemedActivity extends AppCompatActivity {
     void setTaskTitle(CharSequence title) {
         if (!TextUtils.isEmpty(title)) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                setTaskDescription(new ActivityManager.TaskDescription.Builder()
-                        .setLabel(title.toString())
-                        .setIcon(R.drawable.ic_app)
-                        .setPrimaryColor(ContextCompat.getColor(this, AppUtils.getThemedResId(this, androidx.appcompat.R.attr.colorPrimary)))
-                        .build());
+                setTaskDescription(new ActivityManager.TaskDescription(title.toString(),
+                        R.drawable.ic_app,
+                        ContextCompat.getColor(this,
+                                AppUtils.getThemedResId(this, androidx.appcompat.R.attr.colorPrimary))));
             } else {
                 setTaskDescription(new ActivityManager.TaskDescription(title.toString(),
                         BitmapFactory.decodeResource(getResources(), R.drawable.ic_app),

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/ThemedActivity.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/ThemedActivity.java
@@ -35,7 +35,6 @@ import android.view.Menu;
 /**
  * An abstract base activity that supports different themes.
  */
-@SuppressWarnings("deprecation") // TODO: Uses deprecated TaskDescription API
 public abstract class ThemedActivity extends AppCompatActivity {
     private final MenuTintDelegate mMenuTintDelegate = new MenuTintDelegate();
     private final Preferences.Observable mThemeObservable = new Preferences.Observable();
@@ -174,12 +173,21 @@ public abstract class ThemedActivity extends AppCompatActivity {
         }
     }
 
+    @SuppressWarnings("deprecation")
     void setTaskTitle(CharSequence title) {
         if (!TextUtils.isEmpty(title)) {
-            setTaskDescription(new ActivityManager.TaskDescription(title.toString(),
-                    BitmapFactory.decodeResource(getResources(), R.drawable.ic_app),
-                    ContextCompat.getColor(this,
-                            AppUtils.getThemedResId(this, androidx.appcompat.R.attr.colorPrimary))));
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                setTaskDescription(new ActivityManager.TaskDescription.Builder()
+                        .setLabel(title.toString())
+                        .setIcon(R.drawable.ic_app)
+                        .setPrimaryColor(ContextCompat.getColor(this, AppUtils.getThemedResId(this, androidx.appcompat.R.attr.colorPrimary)))
+                        .build());
+            } else {
+                setTaskDescription(new ActivityManager.TaskDescription(title.toString(),
+                        BitmapFactory.decodeResource(getResources(), R.drawable.ic_app),
+                        ContextCompat.getColor(this,
+                                AppUtils.getThemedResId(this, androidx.appcompat.R.attr.colorPrimary))));
+            }
         }
     }
 }


### PR DESCRIPTION
🎯 **What:** Migrated the deprecated `ActivityManager.TaskDescription` constructor to the modern `ActivityManager.TaskDescription.Builder` API (introduced in API 28) within `ThemedActivity.java`. Added an SDK check to fallback to the legacy constructor for older API levels, and narrowed the scope of the `@SuppressWarnings("deprecation")` annotation.

💡 **Why:** The old `ActivityManager.TaskDescription` constructor is deprecated and uses `BitmapFactory` to decode icons, which is less memory-efficient than passing the drawable resource ID directly to the Builder's `setIcon()` method. This improves codebase maintainability, memory efficiency, and resolves the class-level IDE warning.

✅ **Verification:** Verified by building the app with `./gradlew assembleDebug` and ensuring no regressions by running the test suite with `./gradlew testDebugUnitTest`.

✨ **Result:** Improved code cleanliness by removing a class-level `@SuppressWarnings` and a TODO comment, while safely adopting modern Android APIs without dropping support for older devices.

---
*PR created automatically by Jules for task [11721686047076138695](https://jules.google.com/task/11721686047076138695) started by @sheepdestroyer*

## Summary by Sourcery

Migrate task title handling to use the modern ActivityManager.TaskDescription.Builder API while preserving behavior on pre-P devices.

New Features:
- Add conditional use of ActivityManager.TaskDescription.Builder for setting the activity task title and icon on API 28+.

Enhancements:
- Limit the @SuppressWarnings("deprecation") annotation to the specific method that still needs the legacy TaskDescription constructor and remove the class-level suppression and related TODO.