### PR TITLE
🧹 [code health improvement] Fix local vote update logic in StoryRecyclerViewAdapter

### DIFF
--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/StoryRecyclerViewAdapter.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/StoryRecyclerViewAdapter.java
@@ -615,8 +615,9 @@ public class StoryRecyclerViewAdapter extends
 
         @Override
         public void onDone(boolean successful) {
-            // TODO update locally only, as API does not update instantly
-            mItem.incrementScore();
+            if (successful) {
+                mItem.incrementScore();
+            }
             mItem.clearPendingVoted();
             StoryRecyclerViewAdapter adapter = mAdapter.get();
             if (adapter != null && adapter.isAttached()) {


### PR DESCRIPTION
🎯 **What:** Modified `VoteCallback.onDone` in `StoryRecyclerViewAdapter` to only increment the item's local score if the voting API request was successful, while ensuring the pending UI state is always cleared. The obsolete `TODO` comment was removed.

💡 **Why:** This improves correctness by preventing the local score from falsely incrementing when a network request fails. It also cleans up dead comments (the TODO was already partially fulfilled). Ensuring `clearPendingVoted()` runs unconditionally prevents the UI from getting permanently stuck in a "pending" state on network failures.

✅ **Verification:** Verified by reviewing the logic and running `./gradlew testDebugUnitTest` and `./gradlew lintDebug` to ensure no regressions were introduced.

✨ **Result:** A safer, more robust implementation of local state management for voting, with improved maintainability through comment cleanup.

---
*PR created automatically by Jules for task [18234137165779615640](https://jules.google.com/task/18234137165779615640) started by @sheepdestroyer*

## Summary by Sourcery

Gate local vote score updates on successful API responses while always clearing pending vote state in the story list adapter.

Bug Fixes:
- Prevent local story vote scores from increasing when the voting API call fails.
- Ensure pending vote UI state is cleared regardless of API call success.

Enhancements:
- Remove obsolete TODO comment related to local vote score updates.