### PR TITLE
🔒 Fix Local File Inclusion in CacheableWebView

### DIFF
--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/CacheableWebView.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/CacheableWebView.java
@@ -21,12 +21,17 @@ import android.content.Context;
 import android.net.Uri;
 import android.text.TextUtils;
 import android.util.AttributeSet;
+import android.webkit.MimeTypeMap;
 import android.webkit.WebChromeClient;
+import android.webkit.WebResourceRequest;
+import android.webkit.WebResourceResponse;
 import android.webkit.WebSettings;
 import android.webkit.WebViewClient;
 import androidx.annotation.CallSuper;
 import io.github.sheepdestroyer.materialisheep.AppUtils;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.util.Map;
 
 public class CacheableWebView extends MaterialWebView {
@@ -89,7 +94,7 @@ public class CacheableWebView extends MaterialWebView {
 
   private void enableCache() {
     WebSettings webSettings = getSettings();
-    webSettings.setAllowFileAccess(true);
+    webSettings.setAllowFileAccess(false);
     setCacheModeInternal();
   }
 
@@ -142,6 +147,29 @@ public class CacheableWebView extends MaterialWebView {
         + CACHE_PREFIX
         + name
         + CACHE_EXTENSION;
+  }
+
+  @Override
+  protected WebResourceResponse interceptRequest(WebResourceRequest request) {
+    Uri uri = request.getUrl();
+    if (uri != null && "file".equals(uri.getScheme())) {
+      String path = uri.getPath();
+      if (path != null) {
+        try {
+          File cacheDir = getContext().getApplicationContext().getCacheDir();
+          File file = new File(path);
+          String canonicalCache = cacheDir.getCanonicalPath();
+          String canonicalFile = file.getCanonicalPath();
+          if (canonicalFile.startsWith(canonicalCache) && canonicalFile.endsWith(CACHE_EXTENSION)) {
+            String mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension("mht");
+            return new WebResourceResponse(mimeType != null ? mimeType : "message/rfc822", "UTF-8", new FileInputStream(file));
+          }
+        } catch (IOException e) {
+          // ignore
+        }
+      }
+    }
+    return null;
   }
 
   public static class ArchiveClient extends WebChromeClient {

--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/MaterialWebView.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/MaterialWebView.java
@@ -68,6 +68,10 @@ public class MaterialWebView extends android.webkit.WebView {
     reloadUrl(FILE);
   }
 
+  protected WebResourceResponse interceptRequest(WebResourceRequest request) {
+    return null;
+  }
+
   static class HistoryWebViewClient extends WebViewClient {
     private WebViewClient mClient;
 
@@ -109,6 +113,12 @@ public class MaterialWebView extends android.webkit.WebView {
     @Override
     public WebResourceResponse shouldInterceptRequest(
         android.webkit.WebView view, WebResourceRequest request) {
+      if (view instanceof MaterialWebView) {
+        WebResourceResponse response = ((MaterialWebView) view).interceptRequest(request);
+        if (response != null) {
+          return response;
+        }
+      }
       return mClient != null
           ? mClient.shouldInterceptRequest(view, request)
           : super.shouldInterceptRequest(view, request);


### PR DESCRIPTION
🎯 **What:** Fixed a Local File Inclusion (LFI) vulnerability in `CacheableWebView` where `setAllowFileAccess(true)` was enabled.
⚠️ **Risk:** Enabling `setAllowFileAccess(true)` on modern Android versions poses a critical security risk by allowing malicious web pages or intercepted requests to read sensitive local files, which can lead to data exfiltration or app compromise.
🛡️ **Solution:** Disabled `setAllowFileAccess` by setting it to `false`. Re-implemented the ability to securely load valid cached `.mht` offline files via `shouldInterceptRequest` inside `MaterialWebView`'s `HistoryWebViewClient` by reading only from the safe cache directory path and properly checking canonical paths to prevent path traversal attacks. The fix falls back to returning `null` rather than a blank response to preserve native Android handling for legitimate local assets (`android_asset`, `android_res`).

---
*PR created automatically by Jules for task [18006873004128363003](https://jules.google.com/task/18006873004128363003) started by @sheepdestroyer*

## Summary by Sourcery

Mitigate a Local File Inclusion vulnerability in CacheableWebView by disabling generic file access and introducing a controlled offline cache loading path for .mht files.

Bug Fixes:
- Prevent malicious web content from reading arbitrary local files by turning off WebView file access and restricting cached file loading to the app cache directory with path validation.

Enhancements:
- Add a MaterialWebView hook for request interception and delegate HistoryWebViewClient to use it for secure offline cache responses.