### PR TITLE
🧹 [code health improvement] Compensate shift on drag in NavFloatingActionButton

### DIFF
--- a/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/NavFloatingActionButton.java
+++ b/app/src/main/java/io/github/sheepdestroyer/materialisheep/widget/NavFloatingActionButton.java
@@ -167,7 +167,7 @@ public class NavFloatingActionButton extends FloatingActionButton
                 if (mNavigable == null) {
                   return;
                 }
-                startDrag(e.getX(), e.getY());
+                startDrag(e.getRawX(), e.getRawY());
               }
             });
     // noinspection Convert2Lambda
@@ -182,7 +182,9 @@ public class NavFloatingActionButton extends FloatingActionButton
   }
 
   @Synthetic
-  void startDrag(float startX, float startY) {
+  void startDrag(float startRawX, float startRawY) {
+    float startViewX = getX();
+    float startViewY = getY();
     if (mVibrationEnabled) {
       mVibrator.vibrate(
           VibrationEffect.createOneShot(
@@ -197,8 +199,8 @@ public class NavFloatingActionButton extends FloatingActionButton
             switch (motionEvent.getAction()) {
               case MotionEvent.ACTION_MOVE:
                 mMoved = true;
-                view.setX(motionEvent.getRawX() - startX); // TODO compensate shift
-                view.setY(motionEvent.getRawY() - startY);
+                view.setX(startViewX + motionEvent.getRawX() - startRawX);
+                view.setY(startViewY + motionEvent.getRawY() - startRawY);
                 break;
               case MotionEvent.ACTION_CANCEL:
               case MotionEvent.ACTION_UP:


### PR DESCRIPTION
🎯 **What:** Modified `NavFloatingActionButton.java` to compensate for the sudden shift when starting to drag the view.
💡 **Why:** By capturing the raw initial touch and view coordinates on long press and applying relative raw deltas rather than using localized coordinates on every move, the view no longer jumps away from the initial touch point. This fixes a long-standing `TODO compensate shift` comment and massively improves the button's maintainability by adhering to standard absolute vs relative coordinate calculations.
✅ **Verification:** Validated that compiling and all local unit tests (like `./gradlew testDebugUnitTest`) pass successfully with no side effects.
✨ **Result:** The draggable `NavFloatingActionButton` is now smoothly manipulated from wherever the user initiated the long-press.

---
*PR created automatically by Jules for task [2448009618983556530](https://jules.google.com/task/2448009618983556530) started by @sheepdestroyer*

## Summary by Sourcery

Bug Fixes:
- Fix NavFloatingActionButton jumping away from the initial touch point when starting a drag.